### PR TITLE
Fix: Update pip install command for zsh compatibility

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -27,7 +27,7 @@ source env/bin/activate
 The `pipecat` Python module has a lot of optional dependencies, including some pretty big AI libraries. The module uses a lot of optional dependencies to allow you to only install what you need. For example, to install `pipecat` along with support for the services above, run this command (or add it to your `requirements.txt`):
 
 ```bash
-pip install pipecat-ai[daily,openai]
+pip install "pipecat-ai[daily,openai]"
 ```
 
 In order to use local audio on MacOS, you'll need to do one more thing:


### PR DESCRIPTION
Original `pip install` command was giving errors on zsh `zsh: no matches found: pipecat-ai[daily,openai]`

Adding quotes help prevent that and make the installation smooth 👌