### PR TITLE
feat: Make Quickstart example dynamic support many TTS providers

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -26,9 +26,17 @@ source env/bin/activate
 
 The `pipecat` Python module has a lot of optional dependencies, including some pretty big AI libraries. The module uses a lot of optional dependencies to allow you to only install what you need. For example, to install `pipecat` along with support for the services above, run this command (or add it to your `requirements.txt`):
 
-```bash
-pip install pipecat-ai[daily,openai]
-```
+<Tabs>
+  <Tab title="ElevenLabs">
+    ```bash pip install "pipecat-ai[daily,elevenlabs]" ```
+  </Tab>
+  <Tab title="Cartesia">
+    ```bash pip install "pipecat-ai[daily,cartesia]" ```
+  </Tab>
+  <Tab title="Deepgram">
+    ```bash pip install "pipecat-ai[daily,deepgram]" ```
+  </Tab>
+</Tabs>
 
 In order to use local audio on MacOS, you'll need to do one more thing:
 
@@ -48,18 +56,83 @@ Start by heading over to [dashboard.daily.co/rooms](https://dashboard.daily.co/r
 
 While you're there, stop by [dashboard.daily.co/developers](https://dashboard.daily.co/developers) and copy your API key.
 
-Next, head over to [Eleven Labs](https://elevenlabs.io/app/voice-lab) and find a voice you want to use. Make note of the Voice ID, and get your API key from your user avatar on the bottom left.
+<AccordionGroup>
+    <Accordion title="Using ElevenLabs">
+        Next, head over to [Eleven Labs](https://elevenlabs.io/app/voice-lab) and find a voice you want to use. Make note of the Voice ID, and get your API key from your user avatar on the bottom left.
+    </Accordion>
+    <Accordion title="Using Cartesia">
+        Find in [Cartesia Voice library](https://play.cartesia.ai/library) a voice
+        that you like. Then click the three dots at the end and select `Copy Id`.
+
+        Then, head over to [Cartesia API keys](https://play.cartesia.ai/keys) and create your API key.
+    </Accordion>
+
+    <Accordion title="Using Deepgram">
+        Check all the voices available in [Deepgram](https://developers.deepgram.com/docs/tts-models), find your favourite and note the model name. For example `aura-arcas-en`.
+        Then, head over to your [Deepgram project](https://console.deepgram.com/) and create an API key.
+    </Accordion>
+
+</AccordionGroup>
 
 ## Running your first example
 
-Download the ["Say One Thing"](https://github.com/pipecat-ai/pipecat/raw/main/examples/foundational/01-say-one-thing.py) example file from the [`pipecat` repo](https://github.com/pipecat-ai/pipecat/blob/main/examples/foundational/01-say-one-thing.py), and save it to a new folder somewhere. In that same folder, create a file named `.env`, and add values for the following environment variables:
+Download the ["Say One Thing"](https://github.com/pipecat-ai/pipecat/raw/main/examples/foundational/01-say-one-thing.py) example file from the [`pipecat` repo](https://github.com/pipecat-ai/pipecat/blob/main/examples/foundational/01-say-one-thing.py), and save it to a new folder somewhere.
+In that same folder, create a file named `.env`, and add values for the following environment variables:
 
 ```
 DAILY_SAMPLE_ROOM_URL=https://YOURDOMAIN.daily.co/YOURROOM # with the real domain and room name, of course
 DAILY_API_KEY=7df3...
-ELEVENLABS_API_KEY=aeb1...
-ELEVENLABS_VOICE_ID=ErXw...
-```
+``` 
+
+<AccordionGroup>
+    <Accordion title="ElevenLabs">
+        In the same `.env` file, add the following lines:
+        ```
+        ELEVENLABS_API_KEY=aeb1...
+        ELEVENLABS_VOICE_ID=ErXw...
+        ```
+
+        In the `01-say-one-thing.py` file, make sure to import the ElevenLabs module:
+        ```python
+        from pipecat.services.elevenlabs import ElevenLabsTTSService
+        ``` 
+
+        And change the `tts` variable to use the ElevenLabs service:
+        ```python
+        tts = ElevenLabsTTSService(
+            api_key=os.getenv("ELEVENLABS_API_KEY"),
+            voice_id=os.getenv("ELEVENLABS_VOICE_ID"),
+        )
+        ``` 
+    </Accordion>
+    <Accordion title="Cartesia">
+        In the same `.env` file, add the following lines:
+        ```
+        CARTESIA_API_KEY=efb1...
+        CARTESKA_VOICE_ID=5c3c89e5-...
+        ```
+
+        In the `01-say-one-thing.py` file, make sure to import the ElevenLabs module:
+        ```python
+        from pipecat.services.elevenlabs import ElevenLabsTTSService
+        ``` 
+
+        And change the `tts` variable to use the ElevenLabs service:
+        ```python
+        tts = ElevenLabsTTSService(
+            api_key=os.getenv("ELEVENLABS_API_KEY"),
+            voice_id=os.getenv("ELEVENLABS_VOICE_ID"),
+        )
+        ``` 
+    </Accordion>
+    <Accordion title="Deepgram">
+        In the same `.env` file, add the following lines:
+            ```
+            DEEPGRAM_API_KEY=7df3...
+            DEEPGRAM_MODEL_NAME=aura-arcas-en
+            ```
+    </Accordion>
+</AccordionGroup>
 
 Open your Daily room URL in a browser tab. Once you've joined the room, run the example:
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -10,8 +10,7 @@ Let's start by getting Pipecat installed and running your first example app.
 While you can use Pipecat without them, there are a few third-party services you'll probably want to use with Pipecat. We recommend these to start, since they're easy to sign up and get started for free or low cost:
 
 - [Daily.co](https://dashboard.daily.co/u/signup) for your transport layer. Daily uses WebRTC to exchange real-time audio and video between the bot and the user.
-- [OpenAI](https://platform.openai.com/signup) gets you ChatGPT for an LLM, and DALL-E for image generation.
-- [Eleven Labs](https://elevenlabs.io/sign-up) or [Deepgram](https://console.deepgram.com/signup) for text-to-speech.
+- [ElevenLabs](https://elevenlabs.io/sign-up), [Cartesia] (https://play.cartesia.ai/) or [Deepgram](https://console.deepgram.com/signup) for text-to-speech.
 
 ## Installing the module
 
@@ -44,7 +43,7 @@ In order to use local audio on MacOS, you'll need to do one more thing:
 brew install portaudio
 ```
 
-Some services, like Eleven Labs and Deepgram, just use built-in Python functionality for REST requests, so they don't have anything extra to install.
+Some services, like ElevenLabs and Deepgram, just use built-in Python functionality for REST requests, so they don't have anything extra to install.
 
 You can always install other dependencies later. For the full list, look for the `[project.optional-dependencies]` section in [pyproject.toml](https://github.com/pipecat-ai/pipecat/blob/main/pyproject.toml).
 
@@ -58,7 +57,7 @@ While you're there, stop by [dashboard.daily.co/developers](https://dashboard.da
 
 <AccordionGroup>
     <Accordion title="Using ElevenLabs">
-        Next, head over to [Eleven Labs](https://elevenlabs.io/app/voice-lab) and find a voice you want to use. Make note of the Voice ID, and get your API key from your user avatar on the bottom left.
+        Next, head over to [ElevenLabs](https://elevenlabs.io/app/voice-lab) and find a voice you want to use. Make note of the Voice ID, and get your API key from your user avatar on the bottom left.
     </Accordion>
     <Accordion title="Using Cartesia">
         Find in [Cartesia Voice library](https://play.cartesia.ai/library) a voice
@@ -82,7 +81,9 @@ In that same folder, create a file named `.env`, and add values for the followin
 ```
 DAILY_SAMPLE_ROOM_URL=https://YOURDOMAIN.daily.co/YOURROOM # with the real domain and room name, of course
 DAILY_API_KEY=7df3...
-``` 
+```
+
+Follow the instructions for the service you're using:
 
 <AccordionGroup>
     <Accordion title="ElevenLabs">
@@ -95,7 +96,12 @@ DAILY_API_KEY=7df3...
         In the `01-say-one-thing.py` file, make sure to import the ElevenLabs module:
         ```python
         from pipecat.services.elevenlabs import ElevenLabsTTSService
-        ``` 
+        ```
+
+        Also add the following import:
+        ```python
+        from pipecat.frames.frames import LLMFullResponseEndFrame
+        ```
 
         And change the `tts` variable to use the ElevenLabs service:
         ```python
@@ -103,7 +109,16 @@ DAILY_API_KEY=7df3...
             api_key=os.getenv("ELEVENLABS_API_KEY"),
             voice_id=os.getenv("ELEVENLABS_VOICE_ID"),
         )
-        ``` 
+        ```
+
+        Finally ,find the line
+        ```python
+        await task.queue_frame(TextFrame(f"Hello there, {participant_name}!"))
+        ```
+        Add the following after it:
+        ```python
+        await task.queue_frame(LLMFullResponseEndFrame())
+        ```
     </Accordion>
     <Accordion title="Cartesia">
         In the same `.env` file, add the following lines:
@@ -112,27 +127,42 @@ DAILY_API_KEY=7df3...
         CARTESKA_VOICE_ID=5c3c89e5-...
         ```
 
-        In the `01-say-one-thing.py` file, make sure to import the ElevenLabs module:
+        In the `01-say-one-thing.py` file, make sure to import the Cartesia module:
         ```python
-        from pipecat.services.elevenlabs import ElevenLabsTTSService
-        ``` 
+        from pipecat.services.cartesia import CartesiaHttpTTSService
+        ```
 
         And change the `tts` variable to use the ElevenLabs service:
         ```python
-        tts = ElevenLabsTTSService(
-            api_key=os.getenv("ELEVENLABS_API_KEY"),
-            voice_id=os.getenv("ELEVENLABS_VOICE_ID"),
+        tts = CartesiaHttpTTSService(
+            api_key=os.getenv("CARTESIA_API_KEY"),
+            voice_id=os.getenv("CARTESKA_VOICE_ID"),
         )
-        ``` 
+        ```
     </Accordion>
     <Accordion title="Deepgram">
         In the same `.env` file, add the following lines:
-            ```
-            DEEPGRAM_API_KEY=7df3...
-            DEEPGRAM_MODEL_NAME=aura-arcas-en
-            ```
+        ```
+        DEEPGRAM_API_KEY=7df3...
+        DEEPGRAM_MODEL_NAME=aura-arcas-en
+        ```
+
+        In the `01-say-one-thing.py` file, make sure to import the Deepgram module:
+        ```python
+        from pipecat.services.deepgram import DeepgramTTSService
+        ```
+
+        And change the `tts` variable to use the ElevenLabs service:
+        ```python
+        tts = DeepgramTTSService(
+            api_key=os.getenv("DEEPGRAM_API_KEY"),
+            voice=os.getenv("DEEPGRAM_VOICE_MODEL"),
+        )
+        ```
     </Accordion>
 </AccordionGroup>
+
+Now you're ready to run the example!
 
 Open your Daily room URL in a browser tab. Once you've joined the room, run the example:
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -10,7 +10,7 @@ Let's start by getting Pipecat installed and running your first example app.
 While you can use Pipecat without them, there are a few third-party services you'll probably want to use with Pipecat. We recommend these to start, since they're easy to sign up and get started for free or low cost:
 
 - [Daily.co](https://dashboard.daily.co/u/signup) for your transport layer. Daily uses WebRTC to exchange real-time audio and video between the bot and the user.
-- [ElevenLabs](https://elevenlabs.io/sign-up), [Cartesia] (https://play.cartesia.ai/) or [Deepgram](https://console.deepgram.com/signup) for text-to-speech.
+- [ElevenLabs](https://elevenlabs.io/sign-up), [Cartesia](https://play.cartesia.ai/) or [Deepgram](https://console.deepgram.com/signup) for text-to-speech.
 
 ## Installing the module
 


### PR DESCRIPTION
Hey Pipecat team

When I went through the quickstart for the first time I got a bit lost because I was not familiar with the tools mentioned. 

In the spirit of making quickstart experience better and easier for people with different background, I added a flow for easier TTS provider `ElevenLabs`, `Cartesia` and `Deepgram`.

Making it easier to copy/paste code sample and run the first test.

Also fixed ElevenLabs branding according to their [recommendation](https://elevenlabs.io/brand).
👎 `Eleven Labs`
👍  `ElevenLabs`

Hope you find this helpful.