### PR TITLE
Update pipecat flows pre and post action signatures

### DIFF
--- a/server/utilities/flows/pipecat-flows.mdx
+++ b/server/utilities/flows/pipecat-flows.mdx
@@ -759,9 +759,9 @@ Common actions shipped with Flows for managing conversation flow. To use them, j
 
 You can define custom `pre_actions` and `post_actions`. They are registered automatically when included in the `NodeConfig`.
 
-Custom actions are composed of:
+Custom actions are composed of at least:
 
-<ResponseField name="action_type" type="str" required>
+<ResponseField name="type" type="str" required>
   String identifier for the action
 </ResponseField>
 <ResponseField name="handler" type="Callable" required>
@@ -783,7 +783,8 @@ async def custom_notification(action: dict):
 "pre_actions": [
     {
         "type": "notify",
-        "handler": send_notification
+        "handler": send_notification,
+        "message": "Attention!",
     }
 ]
 ```

--- a/server/utilities/flows/pipecat-flows.mdx
+++ b/server/utilities/flows/pipecat-flows.mdx
@@ -774,7 +774,7 @@ Example:
 
 ```python
 # Define custom action handler
-async def custom_notification(action: dict):
+async def custom_notification(action: dict, flow_manager: FlowManager):
     """Custom action handler."""
     message = action.get("message", "")
     await notify_user(message)


### PR DESCRIPTION
This change is needed after [this change](https://github.com/pipecat-ai/pipecat-flows/pull/93) lands in `pipecat-flows` and is published.