### PR TITLE
Remove audio_out_is_live from TransportParams as it was no longer used

### DIFF
--- a/server/base-classes/transport.mdx
+++ b/server/base-classes/transport.mdx
@@ -105,10 +105,6 @@ def add_event_handler(self, event_name: str, handler)
   Enable audio output
 </ParamField>
 
-<ParamField path="audio_out_is_live" type="bool" default="False">
-  Whether audio output is live streaming
-</ParamField>
-
 <ParamField path="audio_out_sample_rate" type="int" default="None">
   Audio output sample rate in Hz
 </ParamField>


### PR DESCRIPTION
Docs for: https://github.com/pipecat-ai/pipecat/pull/1265