### PR TITLE
Update docs to use FunctionSchema and ToolsSchema

### DIFF
--- a/guides/deployment/cerebrium.mdx
+++ b/guides/deployment/cerebrium.mdx
@@ -132,7 +132,7 @@ async def main(room_url: str, token: str):
 
         task = PipelineTask(
             pipeline,
-            PipelineParams(
+            params=PipelineParams(
                 allow_interruptions=True,
                 enable_metrics=True,
                 enable_usage_metrics=True,

--- a/guides/deployment/pattern.mdx
+++ b/guides/deployment/pattern.mdx
@@ -201,7 +201,7 @@ async def main(room_url: str, token: str):
             tma_out,
         ])
 
-        task = PipelineTask(pipeline, PipelineParams(allow_interruptions=True))
+        task = PipelineTask(pipeline, params=PipelineParams(allow_interruptions=True))
 
         @transport.event_handler("on_first_participant_joined")
         async def on_first_participant_joined(transport, participant):

--- a/guides/features/function-calling.mdx
+++ b/guides/features/function-calling.mdx
@@ -27,11 +27,54 @@ Here's how it works:
 
 ### 1. Define Functions
 
-Functions are defined differently depending on your LLM provider. Here are examples of a weather function for supported providers:
+Pipecat provides a standardized `FunctionSchema` that works across all supported LLM providers. This makes it easy to define functions once and use them with any provider.
+
+#### Using the Standard Schema (Recommended)
+
+```python
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
+
+# Define a function using the standard schema
+weather_function = FunctionSchema(
+    name="get_current_weather",
+    description="Get the current weather in a location",
+    properties={
+        "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA",
+        },
+        "format": {
+            "type": "string",
+            "enum": ["celsius", "fahrenheit"],
+            "description": "The temperature unit to use.",
+        },
+    },
+    required=["location", "format"]
+)
+
+# Create a tools schema with your functions
+tools = ToolsSchema(standard_tools=[weather_function])
+
+# Pass this to your LLM context
+context = OpenAILLMContext(
+    messages=[{"role": "system", "content": "You are a helpful assistant."}],
+    tools=tools
+)
+```
+
+The `ToolsSchema` will be automatically converted to the correct format for your LLM provider through adapters.
+
+#### Using Provider-Specific Formats (Alternative)
+
+You can also define functions in the provider-specific format if needed:
 
 <CodeGroup>
 
 ```python OpenAI
+from openai.types.chat import ChatCompletionToolParam
+
+# OpenAI native format
 tools = [
     ChatCompletionToolParam(
         type="function",
@@ -59,6 +102,7 @@ tools = [
 ```
 
 ```python Anthropic
+# Anthropic native format
 tools = [
     {
         "name": "get_weather",
@@ -83,6 +127,7 @@ tools = [
 ```
 
 ```python Gemini
+# Gemini native format
 tools = [
     {
         "function_declarations": [
@@ -112,16 +157,48 @@ tools = [
 
 </CodeGroup>
 
+#### Provider-Specific Custom Tools
+
+Some providers support unique tools that don't fit the standard function schema. For these cases, you can add custom tools:
+
+```python
+from pipecat.adapters.schemas.tools_schema import AdapterType, ToolsSchema
+
+# Standard functions
+weather_function = FunctionSchema(
+    name="get_current_weather",
+    description="Get the current weather",
+    properties={"location": {"type": "string"}},
+    required=["location"]
+)
+
+# Custom Gemini search tool
+gemini_search_tool = {
+    "web_search": {
+        "description": "Search the web for information"
+    }
+}
+
+# Create a tools schema with both standard and custom tools
+tools = ToolsSchema(
+    standard_tools=[weather_function],
+    custom_tools={
+        AdapterType.GEMINI: [gemini_search_tool]
+    }
+)
+```
+
+<Tip>
+  See the provider-specific documentation for details on custom tools and their
+  formats.
+</Tip>
+
 ### 2. Register Function Handlers
 
-Register handlers for your functions using the LLM service's [`register_function` method](/api-reference/services/base-service-classes#methods-2):
+Register handlers for your functions using the LLM service's [`register_function` method](/server/base-classes/llm#methods):
 
 ```python
 llm = OpenAILLMService(api_key="your-api-key", model="gpt-4")
-
-# Optional start callback - called when function execution begins
-async def start_fetch_weather(function_name, llm, context):
-    logger.debug(f"Starting weather fetch: {function_name}")
 
 # Main function handler - called to execute the function
 async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context, result_callback):
@@ -133,7 +210,6 @@ async def fetch_weather_from_api(function_name, tool_call_id, args, llm, context
 llm.register_function(
     "get_current_weather",
     fetch_weather_from_api,
-    start_callback=start_fetch_weather
 )
 ```
 
@@ -142,26 +218,24 @@ llm.register_function(
 Include your LLM service in your pipeline with the registered functions:
 
 ```python
-# Initiliaze the LLM context, including messges and tool calls
-context = OpenAILLMContext(messages, tools)
+# Initialize the LLM context with your function schemas
+context = OpenAILLMContext(
+    messages=[{"role": "system", "content": "You are a helpful assistant."}],
+    tools=tools
+)
 
-# Create the context aggregator, to collec the user and assistnat context
+# Create the context aggregator to collect the user and assistant context
 context_aggregator = llm.create_context_aggregator(context)
 
 # Create the pipeline
-# 1. Input from the transport
-# 2. User context aggregation
-# 3. LLM processing
-# 4. TTS processing
-# 5. Output to the transport
-# 6. Assistant context aggregation
 pipeline = Pipeline([
-    transport.input(),
-    context_aggregator.user(),
-    llm,
-    tts,
-    transport.output(),
-    context_aggregator.assistant(),
+    transport.input(),               # Input from the transport
+    stt,                             # STT processing
+    context_aggregator.user(),       # User context aggregation
+    llm,                             # LLM processing
+    tts,                             # TTS processing
+    transport.output(),              # Output to the transport
+    context_aggregator.assistant(),  # Assistant context aggregation
 ])
 ```
 
@@ -182,9 +256,15 @@ pipeline = Pipeline([
 - Return `None` to ignore the function call
 - Errors should be handled within your function
 
-## Controlling Function Call Behavior
+## Controlling Function Call Behavior (Advanced)
 
 When returning results from a function handler, you can control how the LLM processes those results using a `FunctionCallResultProperties` frame.
+
+<Tip>
+  It can be handy to skip a completion when you have back-to-back function
+  calls. Note, if you skip a completion, then you must manually trigger one from
+  the context.
+</Tip>
 
 ### Properties
 
@@ -192,7 +272,8 @@ When returning results from a function handler, you can control how the LLM proc
 Controls whether the LLM should generate a response after the function call:
 
 - `True`: Run LLM after function call (default if no other function calls in progress)
-- `False`: Don't run LLM after function call - `None`: Use default behavior
+- `False`: Don't run LLM after function call
+- `None`: Use default behavior
 
 </ParamField>
 

--- a/guides/features/krisp.mdx
+++ b/guides/features/krisp.mdx
@@ -126,8 +126,8 @@ Export the path to your Krisp SDK and model files:
   model file, not just the directory. The path should look something like this:
   <Tabs>
     <Tab title="ARM Linux">
-      ```bash export
-      KRISP_MODEL_PATH=./krisp/hs.c6.f.s.de56df.kw
+      ```bash
+      export KRISP_MODEL_PATH=./krisp/hs.c6.f.s.de56df.kw
       ```
     </Tab>
     <Tab title="Mac ARM">
@@ -140,13 +140,14 @@ Export the path to your Krisp SDK and model files:
       $env:KRISP_MODEL_PATH="C:\krisp\outbound-bvc-models-fp32\hs.c6.f.s.de56df.bucharest.kef"
       ```
     </Tab>
+
   </Tabs>
 </Tip>
 
 Next, install the `pipecat-ai[krisp]` module, which will automatically build the `pipecat-ai-krisp` python wrapper module:
 
 ```bash
-pip install pipecat-ai[krisp]
+pip install "pipecat-ai[krisp]"
 ```
 
 ### Test the integration
@@ -205,7 +206,7 @@ Common issues and solutions:
 Error: Missing module: pipecat_ai_krisp
 ```
 
-Solution: Ensure you've installed with the krisp extra: `pip install pipecat-ai[krisp]`
+Solution: Ensure you've installed with the krisp extra: `pip install "pipecat-ai[krisp]"`
 
 2. **Model Path Not Found**
 

--- a/guides/features/metrics.mdx
+++ b/guides/features/metrics.mdx
@@ -16,7 +16,7 @@ Set `enable_metrics=True` in `PipelineParams` when creating a task:
 ```python Example config
 task = PipelineTask(
             pipeline,
-            PipelineParams(
+            params=PipelineParams(
                 ...
                 enable_metrics=True,
                 ...
@@ -46,7 +46,7 @@ optionally pass `report_only_initial_ttfb=True` in `PipelineParams`:
 ```python Example config
 task = PipelineTask(
             pipeline,
-            PipelineParams(
+            params=PipelineParams(
                 ...
                 enable_metrics=True,
                 report_only_initial_ttfb=True,
@@ -65,7 +65,7 @@ Set `enable_usage_metrics=True` in PipelineParams when creating a task:
 ```python Example config
 task = PipelineTask(
             pipeline,
-            PipelineParams(
+            params=PipelineParams(
                 ...
                 enable_usage_metrics=True,
                 ...

--- a/server/base-classes/llm.mdx
+++ b/server/base-classes/llm.mdx
@@ -20,7 +20,6 @@ def register_function(
   self,
   function_name: str | None,
   callback,
-  start_callback=None
 )
 ```
 

--- a/server/services/analytics/canonical.mdx
+++ b/server/services/analytics/canonical.mdx
@@ -12,7 +12,7 @@ description: "Analytics service for processing and analyzing conversation record
 To use `CanonicalMetricsService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[canonical]
+pip install "pipecat-ai[canonical]"
 ```
 
 You'll also need to set up your Canonical API key as an environment variable: `CANONICAL_API_KEY`

--- a/server/services/analytics/sentry.mdx
+++ b/server/services/analytics/sentry.mdx
@@ -12,7 +12,7 @@ description: "Performance monitoring integration with Sentry for Pipecat frame p
 To use Sentry metrics, install the Sentry SDK:
 
 ```bash
-pip install pipecat-ai[sentry]
+pip install "pipecat-ai[sentry]"
 ```
 
 ## Configuration

--- a/server/services/image-generation/fal.mdx
+++ b/server/services/image-generation/fal.mdx
@@ -12,7 +12,7 @@ description: "Image generation service implementation using fal’s fast SDXL mo
 To use `FalImageGenService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[fal]
+pip install "pipecat-ai[fal]"
 ```
 
 You'll also need to set up your Fal API key as an environment variable: `FAL_KEY`

--- a/server/services/image-generation/google-imagen.mdx
+++ b/server/services/image-generation/google-imagen.mdx
@@ -12,7 +12,7 @@ description: "Image generation service implementation using Google’s Imagen mo
 To use `GoogleImageGenService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[google]
+pip install "pipecat-ai[google]"
 ```
 
 You'll also need to set up your Google API key as an environment variable: `GOOGLE_API_KEY`

--- a/server/services/llm/anthropic.mdx
+++ b/server/services/llm/anthropic.mdx
@@ -12,7 +12,7 @@ description: "Large Language Model service implementation using Anthropic’s Cl
 To use `AnthropicLLMService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[anthropic]
+pip install "pipecat-ai[anthropic]"
 ```
 
 You'll also need to set up your Anthropic API key as an environment variable: `ANTHROPIC_API_KEY`

--- a/server/services/llm/anthropic.mdx
+++ b/server/services/llm/anthropic.mdx
@@ -183,13 +183,15 @@ This service supports function calling (also known as tool calling) which allows
 - Access external APIs
 - Perform custom actions
 
-See the [Function Calling guide](/guides/features/function-calling) for:
-
-- Detailed implementation instructions
-- Provider-specific function definitions
-- Handler registration examples
-- Control over function call behavior
-- Complete usage examples
+<Card
+  title="Function Calling Guide"
+  icon="function"
+  href="/guides/features/function-calling"
+>
+  Learn how to implement function calling with standardized schemas, register
+  handlers, manage context properly, and control execution flow in your
+  conversational AI applications.
+</Card>
 
 ## Usage Examples
 
@@ -220,31 +222,41 @@ pipeline = Pipeline([
 ### With Function Calling
 
 ```python
-# Configure function calling
-context = AnthropicLLMContext(
-    system="You are a helpful assistant",
-    tools=[{
-        "type": "function",
-        "function": {
-            "name": "get_weather",
-            "description": "Get weather information",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {"type": "string"}
-                }
-            }
-        }
-    }]
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
+from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
+
+messages = [{"role": "user", "content": "Say 'hello' to start the conversation."}]
+
+# Define the weather function using standardized schema
+weather_function = FunctionSchema(
+    name="get_weather",
+    description="Get weather information",
+    properties={
+        "location": {"type": "string"}
+    },
+    required=["location"]  # Specify required parameters
 )
 
-# Use in pipeline
-pipeline = Pipeline([
-    context_aggregator,
-    llm,
-    function_handler
-])
+# Create a tools schema
+tools = ToolsSchema(standard_tools=[weather_function])
+
+# Configure function calling
+context = OpenAILLMContext(
+    messages=messages,
+    tools=tools
+)
 ```
+
+# Use in pipeline
+
+pipeline = Pipeline([
+context_aggregator,
+llm,
+function_handler
+])
+
+````
 
 ## Frame Flow
 
@@ -257,7 +269,7 @@ graph TD
     B --> F[LLMFullResponseEndFrame]
     E --> G[Function Results]
     G --> B
-```
+````
 
 ## Metrics Support
 

--- a/server/services/llm/azure.mdx
+++ b/server/services/llm/azure.mdx
@@ -12,7 +12,7 @@ description: "Large Language Model service implementation using Azure OpenAI API
 To use `AzureLLMService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[azure]
+pip install "pipecat-ai[azure]"
 ```
 
 You'll need to set up:

--- a/server/services/llm/azure.mdx
+++ b/server/services/llm/azure.mdx
@@ -117,50 +117,30 @@ See the [LLM base class methods](/server/base-classes/llm#methods) for additiona
 
 ## Function Calling
 
-Supports OpenAI-compatible function calling:
+This service supports function calling (also known as tool calling) which allows the LLM to request information from external services and APIs. For example, you can enable your bot to:
 
-```python
-# Define tools
-tools = [{
-    "type": "function",
-    "function": {
-        "name": "get_weather",
-        "description": "Get weather information",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "location": {"type": "string"}
-            }
-        }
-    }
-}]
+- Check current weather conditions
+- Query databases
+- Access external APIs
+- Perform custom actions
 
-# Configure context with tools
-context = OpenAILLMContext(
-    messages=[],
-    tools=tools
-)
-
-# Register function handler
-@service.function("get_weather")
-async def handle_weather(location: str):
-    return {"temperature": 72, "condition": "sunny"}
-```
-
-See the [Function Calling guide](/guides/features/function-calling) for:
-
-- Detailed implementation instructions
-- Provider-specific function definitions
-- Handler registration examples
-- Control over function call behavior
-- Complete usage examples
+<Card
+  title="Function Calling Guide"
+  icon="function"
+  href="/guides/features/function-calling"
+>
+  Learn how to implement function calling with standardized schemas, register
+  handlers, manage context properly, and control execution flow in your
+  conversational AI applications.
+</Card>
 
 ## Usage Example
 
 ```python
 from pipecat.services.azure import AzureLLMService
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
-from openai.types.chat import ChatCompletionToolParam
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 
@@ -171,31 +151,26 @@ llm = AzureLLMService(
     model="your-deployment-name"  # e.g., "gpt-4o"
 )
 
-# Define tools for function calling
-tools = [
-    ChatCompletionToolParam(
-        type="function",
-        function={
-            "name": "get_current_weather",
-            "description": "Get the current weather",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "The city and state, e.g. San Francisco, CA"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["celsius", "fahrenheit"],
-                        "description": "The temperature unit to use"
-                    }
-                },
-                "required": ["location", "format"]
-            }
+# Define weather function using standardized schema
+weather_function = FunctionSchema(
+    name="get_current_weather",
+    description="Get the current weather",
+    properties={
+        "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA"
+        },
+        "format": {
+            "type": "string",
+            "enum": ["celsius", "fahrenheit"],
+            "description": "The temperature unit to use"
         }
-    )
-]
+    },
+    required=["location", "format"]
+)
+
+# Create tools schema
+tools = ToolsSchema(standard_tools=[weather_function])
 
 # Create context with system message and tools
 context = OpenAILLMContext(
@@ -212,7 +187,7 @@ context = OpenAILLMContext(
 async def fetch_weather(function_name, tool_call_id, args, llm, context, result_callback):
     await result_callback({"conditions": "nice", "temperature": "75"})
 
-llm.register_function(None, fetch_weather)
+llm.register_function("get_current_weather", fetch_weather)
 
 # Create context aggregator for message handling
 context_aggregator = llm.create_context_aggregator(context)
@@ -230,7 +205,7 @@ pipeline = Pipeline([
 # Create and configure task
 task = PipelineTask(
     pipeline,
-    PipelineParams(
+    params=params=PipelineParams(
         allow_interruptions=True,
         enable_metrics=True,
         enable_usage_metrics=True,

--- a/server/services/llm/cerebras.mdx
+++ b/server/services/llm/cerebras.mdx
@@ -58,7 +58,8 @@ Inherits OpenAI-compatible parameters:
 ```python
 from pipecat.services.cerebras import CerebrasLLMService
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
-from openai.types.chat import ChatCompletionToolParam
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 
@@ -68,46 +69,41 @@ llm = CerebrasLLMService(
     model="llama-3.3-70b"
 )
 
-# Define tools for function calling
-tools = [
-    ChatCompletionToolParam(
-        type="function",
-        function={
-            "name": "get_current_weather",
-            "description": "Get the current weather",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "The city and state, e.g. San Francisco, CA"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["celsius", "fahrenheit"],
-                        "description": "The temperature unit to use"
-                    }
-                },
-                "required": ["location", "format"]
-            }
+# Define weather function using standardized schema
+weather_function = FunctionSchema(
+    name="get_current_weather",
+    description="Get the current weather",
+    properties={
+        "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA"
+        },
+        "format": {
+            "type": "string",
+            "enum": ["celsius", "fahrenheit"],
+            "description": "The temperature unit to use"
         }
-    )
-]
+    },
+    required=["location", "format"]
+)
+
+# Create tools schema
+tools = ToolsSchema(standard_tools=[weather_function])
 
 # Create context with system message and tools
 context = OpenAILLMContext(
-    messages = [
+    messages=[
         {
             "role": "system",
             "content": """You are a helpful LLM in a WebRTC call. Your goal is to demonstrate your capabilities in a succinct way.
 
-You have one functions available:
+You have one function available:
 
 1. get_current_weather is used to get current weather information.
 
-Infer whether to use Fahrenheit or Celsius automatically based on the location, unless the user specifies a preference. Start by asking me for my location. Then, use 'get_weather_current' to give me a forecast. Respond to what the user said in a creative and helpful way.""",
+Infer whether to use Fahrenheit or Celsius automatically based on the location, unless the user specifies a preference. Start by asking me for my location. Then, use 'get_current_weather' to give me a forecast. Respond to what the user said in a creative and helpful way.""",
         },
-    ]
+    ],
     tools=tools
 )
 
@@ -115,7 +111,7 @@ Infer whether to use Fahrenheit or Celsius automatically based on the location, 
 async def fetch_weather(function_name, tool_call_id, args, llm, context, result_callback):
     await result_callback({"conditions": "nice", "temperature": "75"})
 
-llm.register_function(None, fetch_weather)
+llm.register_function("get_current_weather", fetch_weather)
 
 # Create context aggregator for message handling
 context_aggregator = llm.create_context_aggregator(context)
@@ -133,7 +129,7 @@ pipeline = Pipeline([
 # Create and configure task
 task = PipelineTask(
     pipeline,
-    PipelineParams(
+    params=PipelineParams(
         allow_interruptions=True,
         enable_metrics=True,
         enable_usage_metrics=True,
@@ -147,15 +143,22 @@ See the [LLM base class methods](/server/base-classes/llm#methods) for additiona
 
 ## Function Calling
 
-Supports OpenAI-compatible function calling. For optimal function calling performance, provide clear instructions in the system message about when and how to use functions.
+This service supports function calling (also known as tool calling) which allows the LLM to request information from external services and APIs. For example, you can enable your bot to:
 
-See the [Function Calling guide](/guides/features/function-calling) for:
+- Check current weather conditions
+- Query databases
+- Access external APIs
+- Perform custom actions
 
-- Detailed implementation instructions
-- Provider-specific function definitions
-- Handler registration examples
-- Control over function call behavior
-- Complete usage examples
+<Card
+  title="Function Calling Guide"
+  icon="function"
+  href="/guides/features/function-calling"
+>
+  Learn how to implement function calling with standardized schemas, register
+  handlers, manage context properly, and control execution flow in your
+  conversational AI applications.
+</Card>
 
 ## Available Models
 

--- a/server/services/llm/deepseek.mdx
+++ b/server/services/llm/deepseek.mdx
@@ -12,7 +12,7 @@ description: "LLM service implementation using DeepSeek’s API with OpenAI-comp
 To use `DeepSeekLLMService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[deepseek]
+pip install "pipecat-ai[deepseek]"
 ```
 
 You'll also need to set up your DeepSeek API key as an environment variable: `DEEPSEEK_API_KEY`

--- a/server/services/llm/deepseek.mdx
+++ b/server/services/llm/deepseek.mdx
@@ -100,7 +100,8 @@ Inherits all input parameters from OpenAILLMService:
 ```python
 from pipecat.services.deepseek import DeepSeekLLMService
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
-from openai.types.chat import ChatCompletionToolParam
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 
@@ -110,31 +111,26 @@ llm = DeepSeekLLMService(
     model="deepseek-chat"
 )
 
-# Define tools for function calling
-tools = [
-    ChatCompletionToolParam(
-        type="function",
-        function={
-            "name": "get_current_weather",
-            "description": "Get the current weather",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "The city and state, e.g. San Francisco, CA"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["celsius", "fahrenheit"],
-                        "description": "The temperature unit to use"
-                    }
-                },
-                "required": ["location", "format"]
-            }
+# Define weather function using standardized schema
+weather_function = FunctionSchema(
+    name="get_current_weather",
+    description="Get the current weather",
+    properties={
+        "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA"
+        },
+        "format": {
+            "type": "string",
+            "enum": ["celsius", "fahrenheit"],
+            "description": "The temperature unit to use"
         }
-    )
-]
+    },
+    required=["location", "format"]
+)
+
+# Create tools schema
+tools = ToolsSchema(standard_tools=[weather_function])
 
 # Create context with system message and tools
 context = OpenAILLMContext(
@@ -151,7 +147,7 @@ context = OpenAILLMContext(
 async def fetch_weather(function_name, tool_call_id, args, llm, context, result_callback):
     await result_callback({"conditions": "nice", "temperature": "75"})
 
-llm.register_function(None, fetch_weather)
+llm.register_function("get_current_weather", fetch_weather)
 
 # Create context aggregator for message handling
 context_aggregator = llm.create_context_aggregator(context)
@@ -169,7 +165,7 @@ pipeline = Pipeline([
 # Create and configure task
 task = PipelineTask(
     pipeline,
-    PipelineParams(
+    params=PipelineParams(
         allow_interruptions=True,
         enable_metrics=True,
         enable_usage_metrics=True,
@@ -183,43 +179,22 @@ See the [LLM base class methods](/server/base-classes/llm#methods) for additiona
 
 ## Function Calling
 
-Supports OpenAI-compatible function calling:
+This service supports function calling (also known as tool calling) which allows the LLM to request information from external services and APIs. For example, you can enable your bot to:
 
-```python
-# Define tools
-tools = [{
-    "type": "function",
-    "function": {
-        "name": "get_weather",
-        "description": "Get weather information",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "location": {"type": "string"}
-            }
-        }
-    }
-}]
+- Check current weather conditions
+- Query databases
+- Access external APIs
+- Perform custom actions
 
-# Configure context with tools
-context = OpenAILLMContext(
-    messages=[],
-    tools=tools
-)
-
-# Register function handler
-@service.function("get_weather")
-async def handle_weather(location: str):
-    return {"temperature": 72, "condition": "sunny"}
-```
-
-See the [Function Calling guide](/guides/features/function-calling) for:
-
-- Detailed implementation instructions
-- Provider-specific function definitions
-- Handler registration examples
-- Control over function call behavior
-- Complete usage examples
+<Card
+  title="Function Calling Guide"
+  icon="function"
+  href="/guides/features/function-calling"
+>
+  Learn how to implement function calling with standardized schemas, register
+  handlers, manage context properly, and control execution flow in your
+  conversational AI applications.
+</Card>
 
 ## Available Models
 

--- a/server/services/llm/fireworks.mdx
+++ b/server/services/llm/fireworks.mdx
@@ -146,43 +146,22 @@ pipeline = Pipeline(
 
 ## Function Calling
 
-Supports OpenAI-compatible function calling with the `firefunction-v2` model:
+This service supports function calling (also known as tool calling) which allows the LLM to request information from external services and APIs. For example, you can enable your bot to:
 
-```python
-# Define tools
-tools = [{
-    "type": "function",
-    "function": {
-        "name": "get_weather",
-        "description": "Get weather information",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "location": {"type": "string"}
-            }
-        }
-    }
-}]
+- Check current weather conditions
+- Query databases
+- Access external APIs
+- Perform custom actions
 
-# Configure context with tools
-context = OpenAILLMContext(
-    messages=[],
-    tools=tools
-)
-
-# Register function handler
-@service.function("get_weather")
-async def handle_weather(location: str):
-    return {"temperature": 72, "condition": "sunny"}
-```
-
-See the [Function Calling guide](/guides/features/function-calling) for:
-
-- Detailed implementation instructions
-- Provider-specific function definitions
-- Handler registration examples
-- Control over function call behavior
-- Complete usage examples
+<Card
+  title="Function Calling Guide"
+  icon="function"
+  href="/guides/features/function-calling"
+>
+  Learn how to implement function calling with standardized schemas, register
+  handlers, manage context properly, and control execution flow in your
+  conversational AI applications.
+</Card>
 
 ## Available Models
 

--- a/server/services/llm/fireworks.mdx
+++ b/server/services/llm/fireworks.mdx
@@ -12,7 +12,7 @@ description: "LLM service implementation using Fireworks AI’s API with OpenAI-
 To use `FireworksLLMService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[fireworks]
+pip install "pipecat-ai[fireworks]"
 ```
 
 You'll also need to set up your Fireworks API key as an environment variable: `FIREWORKS_API_KEY`

--- a/server/services/llm/gemini.mdx
+++ b/server/services/llm/gemini.mdx
@@ -197,13 +197,15 @@ This service supports function calling (also known as tool calling) which allows
 - Access external APIs
 - Perform custom actions
 
-See the [Function Calling guide](/guides/features/function-calling) for:
-
-- Detailed implementation instructions
-- Provider-specific function definitions
-- Handler registration examples
-- Control over function call behavior
-- Complete usage examples
+<Card
+  title="Function Calling Guide"
+  icon="function"
+  href="/guides/features/function-calling"
+>
+  Learn how to implement function calling with standardized schemas, register
+  handlers, manage context properly, and control execution flow in your
+  conversational AI applications.
+</Card>
 
 ## Search Grounding
 

--- a/server/services/llm/gemini.mdx
+++ b/server/services/llm/gemini.mdx
@@ -12,7 +12,7 @@ description: "Large Language Model service implementation using Google’s Gemin
 To use `GoogleLLMService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[google]
+pip install "pipecat-ai[google]"
 ```
 
 You'll also need to set up your Google API key as an environment variable: `GOOGLE_API_KEY`

--- a/server/services/llm/grok.mdx
+++ b/server/services/llm/grok.mdx
@@ -64,7 +64,8 @@ Inherits OpenAI-compatible parameters:
 ```python
 from pipecat.services.grok import GrokLLMService
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
-from openai.types.chat import ChatCompletionToolParam
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 
@@ -74,31 +75,26 @@ llm = GrokLLMService(
     model="grok-2"
 )
 
-# Define tools for function calling
-tools = [
-    ChatCompletionToolParam(
-        type="function",
-        function={
-            "name": "get_current_weather",
-            "description": "Get the current weather",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "The city and state, e.g. San Francisco, CA"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["celsius", "fahrenheit"],
-                        "description": "The temperature unit to use"
-                    }
-                },
-                "required": ["location", "format"]
-            }
+# Define weather function using standardized schema
+weather_function = FunctionSchema(
+    name="get_current_weather",
+    description="Get the current weather",
+    properties={
+        "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA"
+        },
+        "format": {
+            "type": "string",
+            "enum": ["celsius", "fahrenheit"],
+            "description": "The temperature unit to use"
         }
-    )
-]
+    },
+    required=["location", "format"]
+)
+
+# Create tools schema
+tools = ToolsSchema(standard_tools=[weather_function])
 
 # Create context with system message and tools
 context = OpenAILLMContext(
@@ -115,7 +111,7 @@ context = OpenAILLMContext(
 async def fetch_weather(function_name, tool_call_id, args, llm, context, result_callback):
     await result_callback({"conditions": "nice", "temperature": "75"})
 
-llm.register_function(None, fetch_weather)
+llm.register_function("get_current_weather", fetch_weather)
 
 # Create context aggregator for message handling
 context_aggregator = llm.create_context_aggregator(context)
@@ -133,7 +129,7 @@ pipeline = Pipeline([
 # Create and configure task
 task = PipelineTask(
     pipeline,
-    PipelineParams(
+    params=PipelineParams(
         allow_interruptions=True,
         enable_metrics=True,
         enable_usage_metrics=True,
@@ -147,43 +143,22 @@ See the [LLM base class methods](/server/base-classes/llm#methods) for additiona
 
 ## Function Calling
 
-Supports OpenAI-compatible function calling:
+This service supports function calling (also known as tool calling) which allows the LLM to request information from external services and APIs. For example, you can enable your bot to:
 
-```python
-# Define tools
-tools = [{
-    "type": "function",
-    "function": {
-        "name": "get_weather",
-        "description": "Get weather information",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "location": {"type": "string"}
-            }
-        }
-    }
-}]
+- Check current weather conditions
+- Query databases
+- Access external APIs
+- Perform custom actions
 
-# Configure context with tools
-context = OpenAILLMContext(
-    messages=[],
-    tools=tools
-)
-
-# Register function handler
-@service.function("get_weather")
-async def handle_weather(location: str):
-    return {"temperature": 72, "condition": "sunny"}
-```
-
-See the [Function Calling guide](/guides/features/function-calling) for:
-
-- Detailed implementation instructions
-- Provider-specific function definitions
-- Handler registration examples
-- Control over function call behavior
-- Complete usage examples
+<Card
+  title="Function Calling Guide"
+  icon="function"
+  href="/guides/features/function-calling"
+>
+  Learn how to implement function calling with standardized schemas, register
+  handlers, manage context properly, and control execution flow in your
+  conversational AI applications.
+</Card>
 
 ## Available Models
 

--- a/server/services/llm/groq.mdx
+++ b/server/services/llm/groq.mdx
@@ -74,31 +74,26 @@ llm = GroqLLMService(
     model="llama-3.3-70b-versatile"
 )
 
-# Define tools for function calling
-tools = [
-    ChatCompletionToolParam(
-        type="function",
-        function={
-            "name": "get_current_weather",
-            "description": "Get the current weather",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "The city and state, e.g. San Francisco, CA"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["celsius", "fahrenheit"],
-                        "description": "The temperature unit to use"
-                    }
-                },
-                "required": ["location", "format"]
-            }
+# Define weather function using standardized schema
+weather_function = FunctionSchema(
+    name="get_current_weather",
+    description="Get the current weather",
+    properties={
+        "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA"
+        },
+        "format": {
+            "type": "string",
+            "enum": ["celsius", "fahrenheit"],
+            "description": "The temperature unit to use"
         }
-    )
-]
+    },
+    required=["location", "format"]
+)
+
+# Create tools schema
+tools = ToolsSchema(standard_tools=[weather_function])
 
 # Create context with system message and tools
 context = OpenAILLMContext(
@@ -115,7 +110,7 @@ context = OpenAILLMContext(
 async def fetch_weather(function_name, tool_call_id, args, llm, context, result_callback):
     await result_callback({"conditions": "nice", "temperature": "75"})
 
-llm.register_function(None, fetch_weather)
+llm.register_function("get_current_weather", fetch_weather)
 
 # Create context aggregator for message handling
 context_aggregator = llm.create_context_aggregator(context)
@@ -133,7 +128,7 @@ pipeline = Pipeline([
 # Create and configure task
 task = PipelineTask(
     pipeline,
-    PipelineParams(
+    params=PipelineParams(
         allow_interruptions=True,
         enable_metrics=True,
         enable_usage_metrics=True,
@@ -147,43 +142,22 @@ See the [LLM base class methods](/server/base-classes/llm#methods) for additiona
 
 ## Function Calling
 
-Supports OpenAI-compatible function calling:
+This service supports function calling (also known as tool calling) which allows the LLM to request information from external services and APIs. For example, you can enable your bot to:
 
-```python
-# Define tools
-tools = [{
-    "type": "function",
-    "function": {
-        "name": "get_weather",
-        "description": "Get weather information",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "location": {"type": "string"}
-            }
-        }
-    }
-}]
+- Check current weather conditions
+- Query databases
+- Access external APIs
+- Perform custom actions
 
-# Configure context with tools
-context = OpenAILLMContext(
-    messages=[],
-    tools=tools
-)
-
-# Register function handler
-@service.function("get_weather")
-async def handle_weather(location: str):
-    return {"temperature": 72, "condition": "sunny"}
-```
-
-See the [Function Calling guide](/guides/features/function-calling) for:
-
-- Detailed implementation instructions
-- Provider-specific function definitions
-- Handler registration examples
-- Control over function call behavior
-- Complete usage examples
+<Card
+  title="Function Calling Guide"
+  icon="function"
+  href="/guides/features/function-calling"
+>
+  Learn how to implement function calling with standardized schemas, register
+  handlers, manage context properly, and control execution flow in your
+  conversational AI applications.
+</Card>
 
 ## Available Models
 

--- a/server/services/llm/nim.mdx
+++ b/server/services/llm/nim.mdx
@@ -72,7 +72,8 @@ Inherits OpenAI-compatible parameters:
 ```python
 from pipecat.services.nim import NimLLMService
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
-from openai.types.chat import ChatCompletionToolParam
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 
@@ -82,31 +83,26 @@ llm = NimLLMService(
     model="nvidia/llama-3.1-nemotron-70b-instruct"
 )
 
-# Define tools for function calling
-tools = [
-    ChatCompletionToolParam(
-        type="function",
-        function={
-            "name": "get_current_weather",
-            "description": "Get the current weather",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "The city and state, e.g. San Francisco, CA"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["celsius", "fahrenheit"],
-                        "description": "The temperature unit to use"
-                    }
-                },
-                "required": ["location", "format"]
-            }
+# Define weather function using standardized schema
+weather_function = FunctionSchema(
+    name="get_current_weather",
+    description="Get the current weather",
+    properties={
+        "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA"
+        },
+        "format": {
+            "type": "string",
+            "enum": ["celsius", "fahrenheit"],
+            "description": "The temperature unit to use"
         }
-    )
-]
+    },
+    required=["location", "format"]
+)
+
+# Create tools schema
+tools = ToolsSchema(standard_tools=[weather_function])
 
 # Create context with system message and tools
 context = OpenAILLMContext(
@@ -123,7 +119,7 @@ context = OpenAILLMContext(
 async def fetch_weather(function_name, tool_call_id, args, llm, context, result_callback):
     await result_callback({"conditions": "nice", "temperature": "75"})
 
-llm.register_function(None, fetch_weather)
+llm.register_function("get_current_weather", fetch_weather)
 
 # Create context aggregator for message handling
 context_aggregator = llm.create_context_aggregator(context)
@@ -141,7 +137,7 @@ pipeline = Pipeline([
 # Create and configure task
 task = PipelineTask(
     pipeline,
-    PipelineParams(
+    params=PipelineParams(
         allow_interruptions=True,
         enable_metrics=True,
         enable_usage_metrics=True,
@@ -155,43 +151,22 @@ See the [LLM base class methods](/server/base-classes/llm#methods) for additiona
 
 ## Function Calling
 
-Supports OpenAI-compatible function calling:
+This service supports function calling (also known as tool calling) which allows the LLM to request information from external services and APIs. For example, you can enable your bot to:
 
-```python
-# Define tools
-tools = [{
-    "type": "function",
-    "function": {
-        "name": "get_weather",
-        "description": "Get weather information",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "location": {"type": "string"}
-            }
-        }
-    }
-}]
+- Check current weather conditions
+- Query databases
+- Access external APIs
+- Perform custom actions
 
-# Configure context with tools
-context = OpenAILLMContext(
-    messages=[],
-    tools=tools
-)
-
-# Register function handler
-@service.function("get_weather")
-async def handle_weather(location: str):
-    return {"temperature": 72, "condition": "sunny"}
-```
-
-See the [Function Calling guide](/guides/features/function-calling) for:
-
-- Detailed implementation instructions
-- Provider-specific function definitions
-- Handler registration examples
-- Control over function call behavior
-- Complete usage examples
+<Card
+  title="Function Calling Guide"
+  icon="function"
+  href="/guides/features/function-calling"
+>
+  Learn how to implement function calling with standardized schemas, register
+  handlers, manage context properly, and control execution flow in your
+  conversational AI applications.
+</Card>
 
 ## Available Models
 

--- a/server/services/llm/ollama.mdx
+++ b/server/services/llm/ollama.mdx
@@ -184,13 +184,15 @@ This service supports function calling (also known as tool calling) which allows
 - Access external APIs
 - Perform custom actions
 
-See the [Function Calling guide](/guides/features/function-calling) for:
-
-- Detailed implementation instructions
-- Provider-specific function definitions
-- Handler registration examples
-- Control over function call behavior
-- Complete usage examples
+<Card
+  title="Function Calling Guide"
+  icon="function"
+  href="/guides/features/function-calling"
+>
+  Learn how to implement function calling with standardized schemas, register
+  handlers, manage context properly, and control execution flow in your
+  conversational AI applications.
+</Card>
 
 ## Usage Example
 

--- a/server/services/llm/ollama.mdx
+++ b/server/services/llm/ollama.mdx
@@ -15,7 +15,7 @@ To use `OLLamaLLMService`, you need:
 2. Install Pipecat dependencies:
 
 ```bash
-pip install pipecat-ai[ollama]
+pip install "pipecat-ai[ollama]"
 ```
 
 ## Configuration

--- a/server/services/llm/openai.mdx
+++ b/server/services/llm/openai.mdx
@@ -12,7 +12,7 @@ description: "Large Language Model services using OpenAI’s chat completion API
 To use OpenAI services, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[openai]
+pip install "pipecat-ai[openai]"
 ```
 
 You'll also need to set up your OpenAI API key as an environment variable: `OPENAI_API_KEY`

--- a/server/services/llm/openai.mdx
+++ b/server/services/llm/openai.mdx
@@ -212,30 +212,30 @@ Defaults to NOT_GIVEN (`auto`).
 The simplest way to create a context is:
 
 ```python
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 
-# Basic context with system prompt
-context = OpenAILLMContext(
-    messages=[{"role": "system", "content": "You are a helpful assistant."}]
+# Define weather function using standardized schema
+weather_function = FunctionSchema(
+    name="get_weather",
+    description="Get current weather information",
+    properties={
+        "location": {
+            "type": "string",
+            "description": "The city name"
+        }
+    },
+    required=["location"]
 )
+
+# Create tools schema
+tools = ToolsSchema(standard_tools=[weather_function])
 
 # Context with function calling enabled
 context = OpenAILLMContext(
     messages=[{"role": "system", "content": "You are a helpful assistant."}],
-    tools=[{
-        "type": "function",
-        "function": {
-            "name": "get_weather",
-            "description": "Get current weather information",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {"type": "string", "description": "The city name"}
-                },
-                "required": ["location"]
-            }
-        }
-    }]
+    tools=tools
 )
 ```
 
@@ -300,13 +300,15 @@ This service supports function calling (also known as tool calling) which allows
 - Access external APIs
 - Perform custom actions
 
-See the [Function Calling guide](/guides/features/function-calling) for:
-
-- Detailed implementation instructions
-- Provider-specific function definitions
-- Handler registration examples
-- Control over function call behavior
-- Complete usage examples
+<Card
+  title="Function Calling Guide"
+  icon="function"
+  href="/guides/features/function-calling"
+>
+  Learn how to implement function calling with standardized schemas, register
+  handlers, manage context properly, and control execution flow in your
+  conversational AI applications.
+</Card>
 
 ## Usage Examples
 
@@ -349,40 +351,48 @@ pipeline = Pipeline([
 ```python
 from pipecat.services.openai import OpenAILLMService
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.task import PipelineParams, PipelineTask
 
 # Configure the service
 llm = OpenAILLMService(model="gpt-4o")
 
-# Create context with tools
-context = OpenAILLMContext(
-    messages=[{"role": "system", "content": "You are a helpful assistant."}],
-    tools=[{
-        "type": "function",
-        "function": {
-            "name": "get_weather",
-            "description": "Get current weather information",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {"type": "string"}
-                },
-                "required": ["location"]
-            }
-        }
-    }]
+# Define the weather function using standardized schema
+weather_function = FunctionSchema(
+    name="get_weather",
+    description="Get weather information",
+    properties={
+        "location": {"type": "string"}
+    },
+    required=["location"]  # Specify required parameters
 )
 
-# Register function handler
-@llm.register_function("get_weather")
-async def handle_weather(function_name, tool_call_id, arguments, llm, context, callback):
-    location = arguments.get("location", "")
-    weather_data = {"temperature": 72, "condition": "sunny", "location": location}
-    await callback(weather_data)
+# Create a tools schema
+tools = ToolsSchema(standard_tools=[weather_function])
 
-# Create context aggregator
+# Create context with system message and tools
+context = OpenAILLMContext(
+    messages=[
+        {
+            "role": "system",
+            "content": "You are a helpful assistant in a voice conversation. Keep responses concise."
+        }
+    ],
+    tools=tools
+)
+
+# Register function handlers
+async def fetch_weather(function_name, tool_call_id, args, llm, context, result_callback):
+    await result_callback({"conditions": "nice", "temperature": "75"})
+
+llm.register_function("get_current_weather", fetch_weather)
+
+# Create context aggregator for message handling
 context_aggregator = llm.create_context_aggregator(context)
 
-# Create pipeline
+# Set up pipeline
 pipeline = Pipeline([
     transport.input(),
     stt,
@@ -392,6 +402,16 @@ pipeline = Pipeline([
     transport.output(),
     context_aggregator.assistant()
 ])
+
+# Create and configure task
+task = PipelineTask(
+    pipeline,
+    params=PipelineParams(
+        allow_interruptions=True,
+        enable_metrics=True,
+        enable_usage_metrics=True,
+    ),
+)
 ```
 
 ## Frame Flow

--- a/server/services/llm/openpipe.mdx
+++ b/server/services/llm/openpipe.mdx
@@ -12,7 +12,7 @@ description: "LLM service implementation using OpenPipe for LLM request logging 
 To use `OpenPipeLLMService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[openpipe]
+pip install "pipecat-ai[openpipe]"
 ```
 
 You'll need to set up the following environment variables:

--- a/server/services/llm/openrouter.mdx
+++ b/server/services/llm/openrouter.mdx
@@ -104,7 +104,8 @@ Inherits all input parameters from OpenAILLMService:
 ```python
 from pipecat.services.openrouter import OpenRouterLLMService
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
-from openai.types.chat import ChatCompletionToolParam
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 
@@ -114,31 +115,26 @@ llm = OpenRouterLLMService(
     model="openai/gpt-4o-2024-11-20"
 )
 
-# Define tools for function calling
-tools = [
-    ChatCompletionToolParam(
-        type="function",
-        function={
-            "name": "get_current_weather",
-            "description": "Get the current weather",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "The city and state, e.g. San Francisco, CA"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["celsius", "fahrenheit"],
-                        "description": "The temperature unit to use"
-                    }
-                },
-                "required": ["location", "format"]
-            }
+# Define weather function using standardized schema
+weather_function = FunctionSchema(
+    name="get_current_weather",
+    description="Get the current weather",
+    properties={
+        "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA"
+        },
+        "format": {
+            "type": "string",
+            "enum": ["celsius", "fahrenheit"],
+            "description": "The temperature unit to use"
         }
-    )
-]
+    },
+    required=["location", "format"]
+)
+
+# Create tools schema
+tools = ToolsSchema(standard_tools=[weather_function])
 
 # Create context with system message and tools
 context = OpenAILLMContext(
@@ -155,7 +151,7 @@ context = OpenAILLMContext(
 async def fetch_weather(function_name, tool_call_id, args, llm, context, result_callback):
     await result_callback({"conditions": "nice", "temperature": "75"})
 
-llm.register_function(None, fetch_weather)
+llm.register_function(get_current_weather, fetch_weather)
 
 # Create context aggregator for message handling
 context_aggregator = llm.create_context_aggregator(context)
@@ -173,7 +169,7 @@ pipeline = Pipeline([
 # Create and configure task
 task = PipelineTask(
     pipeline,
-    PipelineParams(
+    params=PipelineParams(
         allow_interruptions=True,
         enable_metrics=True,
         enable_usage_metrics=True,
@@ -187,43 +183,22 @@ See the [LLM base class methods](/server/base-classes/llm#methods) for additiona
 
 ## Function Calling
 
-Supports OpenAI-compatible function calling:
+This service supports function calling (also known as tool calling) which allows the LLM to request information from external services and APIs. For example, you can enable your bot to:
 
-```python
-# Define tools
-tools = [{
-    "type": "function",
-    "function": {
-        "name": "get_weather",
-        "description": "Get weather information",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "location": {"type": "string"}
-            }
-        }
-    }
-}]
+- Check current weather conditions
+- Query databases
+- Access external APIs
+- Perform custom actions
 
-# Configure context with tools
-context = OpenAILLMContext(
-    messages=[],
-    tools=tools
-)
-
-# Register function handler
-@service.function("get_weather")
-async def handle_weather(location: str):
-    return {"temperature": 72, "condition": "sunny"}
-```
-
-See the [Function Calling guide](/guides/features/function-calling) for:
-
-- Detailed implementation instructions
-- Provider-specific function definitions
-- Handler registration examples
-- Control over function call behavior
-- Complete usage examples
+<Card
+  title="Function Calling Guide"
+  icon="function"
+  href="/guides/features/function-calling"
+>
+  Learn how to implement function calling with standardized schemas, register
+  handlers, manage context properly, and control execution flow in your
+  conversational AI applications.
+</Card>
 
 ## Available Models
 

--- a/server/services/llm/openrouter.mdx
+++ b/server/services/llm/openrouter.mdx
@@ -12,7 +12,7 @@ description: "LLM service implementation using OpenRouter’s API with OpenAI-co
 To use `OpenRouterLLMService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[openrouter]
+pip install "pipecat-ai[openrouter]"
 ```
 
 You'll also need to set up your OpenRouter API key as an environment variable: `OPENROUTER_API_KEY`

--- a/server/services/llm/perplexity.mdx
+++ b/server/services/llm/perplexity.mdx
@@ -105,7 +105,7 @@ pipeline = Pipeline([
 # Create and configure task
 task = PipelineTask(
     pipeline,
-    PipelineParams(
+    params=PipelineParams(
         allow_interruptions=True,
         enable_metrics=True,
         enable_usage_metrics=True,

--- a/server/services/llm/together.mdx
+++ b/server/services/llm/together.mdx
@@ -12,7 +12,7 @@ description: "LLM service implementation using Together AI’s API with OpenAI-c
 To use `TogetherLLMService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[together]
+pip install "pipecat-ai[together]"
 ```
 
 You'll also need to set up your Together API key as an environment variable: `TOGETHER_API_KEY`

--- a/server/services/llm/together.mdx
+++ b/server/services/llm/together.mdx
@@ -112,7 +112,8 @@ Inherits all input parameters from OpenAILLMService:
 ```python
 from pipecat.services.together import TogetherLLMService
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
-from openai.types.chat import ChatCompletionToolParam
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 
@@ -122,31 +123,26 @@ llm = TogetherLLMService(
     model="meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"
 )
 
-# Define tools for function calling
-tools = [
-    ChatCompletionToolParam(
-        type="function",
-        function={
-            "name": "get_current_weather",
-            "description": "Get the current weather",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "The city and state, e.g. San Francisco, CA"
-                    },
-                    "format": {
-                        "type": "string",
-                        "enum": ["celsius", "fahrenheit"],
-                        "description": "The temperature unit to use"
-                    }
-                },
-                "required": ["location", "format"]
-            }
+# Define weather function using standardized schema
+weather_function = FunctionSchema(
+    name="get_current_weather",
+    description="Get the current weather",
+    properties={
+        "location": {
+            "type": "string",
+            "description": "The city and state, e.g. San Francisco, CA"
+        },
+        "format": {
+            "type": "string",
+            "enum": ["celsius", "fahrenheit"],
+            "description": "The temperature unit to use"
         }
-    )
-]
+    },
+    required=["location", "format"]
+)
+
+# Create tools schema
+tools = ToolsSchema(standard_tools=[weather_function])
 
 # Create context with system message and tools
 context = OpenAILLMContext(
@@ -163,7 +159,7 @@ context = OpenAILLMContext(
 async def fetch_weather(function_name, tool_call_id, args, llm, context, result_callback):
     await result_callback({"conditions": "nice", "temperature": "75"})
 
-llm.register_function(None, fetch_weather)
+llm.register_function("get_current_weather", fetch_weather)
 
 # Create context aggregator for message handling
 context_aggregator = llm.create_context_aggregator(context)
@@ -181,7 +177,7 @@ pipeline = Pipeline([
 # Create and configure task
 task = PipelineTask(
     pipeline,
-    PipelineParams(
+    params=PipelineParams(
         allow_interruptions=True,
         enable_metrics=True,
         enable_usage_metrics=True,
@@ -195,43 +191,22 @@ See the [LLM base class methods](/server/base-classes/llm#methods) for additiona
 
 ## Function Calling
 
-Supports OpenAI-compatible function calling:
+This service supports function calling (also known as tool calling) which allows the LLM to request information from external services and APIs. For example, you can enable your bot to:
 
-```python
-# Define tools
-tools = [{
-    "type": "function",
-    "function": {
-        "name": "get_weather",
-        "description": "Get weather information",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "location": {"type": "string"}
-            }
-        }
-    }
-}]
+- Check current weather conditions
+- Query databases
+- Access external APIs
+- Perform custom actions
 
-# Configure context with tools
-context = OpenAILLMContext(
-    messages=[],
-    tools=tools
-)
-
-# Register function handler
-@service.function("get_weather")
-async def handle_weather(location: str):
-    return {"temperature": 72, "condition": "sunny"}
-```
-
-See the [Function Calling guide](/guides/features/function-calling) for:
-
-- Detailed implementation instructions
-- Provider-specific function definitions
-- Handler registration examples
-- Control over function call behavior
-- Complete usage examples
+<Card
+  title="Function Calling Guide"
+  icon="function"
+  href="/guides/features/function-calling"
+>
+  Learn how to implement function calling with standardized schemas, register
+  handlers, manage context properly, and control execution flow in your
+  conversational AI applications.
+</Card>
 
 ## Available Models
 

--- a/server/services/s2s/gemini.mdx
+++ b/server/services/s2s/gemini.mdx
@@ -34,7 +34,7 @@ The `GeminiMultimodalLiveLLMService` enables natural, real-time conversations wi
 To use `GeminiMultimodalLiveLLMService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[google]
+pip install "pipecat-ai[google]"
 ```
 
 You’ll need to set up your Google API key as an environment variable: `GOOGLE_API_KEY`.

--- a/server/services/s2s/openai.mdx
+++ b/server/services/s2s/openai.mdx
@@ -163,23 +163,25 @@ pipeline = Pipeline([
 The service supports function calling with automatic response handling:
 
 ```python
-# Define tools
-tools = [{
-    "type": "function",
-    "function": {
-        "name": "get_weather",
-        "description": "Get weather information",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "location": {"type": "string"}
-            }
-        }
-    }
-}]
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
+from pipecat.services.openai_realtime_beta import SessionProperties
+
+# Define weather function using standardized schema
+weather_function = FunctionSchema(
+    name="get_weather",
+    description="Get weather information",
+    properties={
+        "location": {"type": "string"}
+    },
+    required=["location"]
+)
+
+# Create tools schema
+tools = ToolsSchema(standard_tools=[weather_function])
 
 # Configure service with tools
-service = OpenAIRealtimeBetaLLMService(
+llm = OpenAIRealtimeBetaLLMService(
     api_key="your-api-key",
     session_properties=SessionProperties(
         tools=tools,
@@ -187,11 +189,7 @@ service = OpenAIRealtimeBetaLLMService(
     )
 )
 
-# Register function handler
-@service.function("get_weather")
-async def handle_weather(location: str):
-    # Implementation
-    return {"temperature": 72, "condition": "sunny"}
+llm.register_function("get_weather", fetch_weather_from_api)
 ```
 
 See the [Function Calling guide](/guides/features/function-calling) for:

--- a/server/services/s2s/openai.mdx
+++ b/server/services/s2s/openai.mdx
@@ -12,7 +12,7 @@ description: "Real-time speech-to-speech service implementation using OpenAI’s
 To use `OpenAIRealtimeBetaLLMService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[openai]
+pip install "pipecat-ai[openai]"
 ```
 
 You'll also need to set up your OpenAI API key as an environment variable: `OPENAI_API_KEY`.

--- a/server/services/stt/assemblyai.mdx
+++ b/server/services/stt/assemblyai.mdx
@@ -12,7 +12,7 @@ description: "Speech-to-text service implementation using AssemblyAI’s real-ti
 To use `AssemblyAISTTService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[assemblyai]
+pip install "pipecat-ai[assemblyai]"
 ```
 
 You'll also need to set up your AssemblyAI API key as an environment variable: `ASSEMBLYAI_API_KEY`.

--- a/server/services/stt/azure.mdx
+++ b/server/services/stt/azure.mdx
@@ -12,7 +12,7 @@ description: "Speech-to-text service using Azure Cognitive Services Speech SDK"
 To use `AzureSTTService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[azure]
+pip install "pipecat-ai[azure]"
 ```
 
 You'll also need to set up the following environment variables:

--- a/server/services/stt/deepgram.mdx
+++ b/server/services/stt/deepgram.mdx
@@ -12,7 +12,7 @@ description: "Speech-to-text service implementation using Deepgram’s real-time
 To use `DeepgramSTTService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[deepgram]
+pip install "pipecat-ai[deepgram]"
 ```
 
 You'll also need to set up your Deepgram API key as an environment variable: `DEEPGRAM_API_KEY`.

--- a/server/services/stt/fal.mdx
+++ b/server/services/stt/fal.mdx
@@ -12,7 +12,7 @@ description: "Speech-to-text service implementation using Fal’s Wizper API"
 To use `FalSTTService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[fal]
+pip install "pipecat-ai[fal]"
 ```
 
 You'll need to set up your Fal API key as an environment variable: `FAL_KEY`.

--- a/server/services/stt/gladia.mdx
+++ b/server/services/stt/gladia.mdx
@@ -12,7 +12,7 @@ description: "Speech-to-text service implementation using Gladia’s API"
 To use `GladiaSTTService`, you need to install the Gladia dependencies:
 
 ```bash
-pip install pipecat-ai[gladia]
+pip install "pipecat-ai[gladia]"
 ```
 
 You'll also need to set up your Gladia API key as an environment variable: `GLADIA_API_KEY`

--- a/server/services/stt/google.mdx
+++ b/server/services/stt/google.mdx
@@ -12,7 +12,7 @@ description: "Speech-to-text service implementation using Google Cloud’s Speec
 To use `GoogleSTTService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[google]
+pip install "pipecat-ai[google]"
 ```
 
 You'll need Google Cloud credentials either as a JSON string or file.

--- a/server/services/stt/groq.mdx
+++ b/server/services/stt/groq.mdx
@@ -12,7 +12,7 @@ description: "Speech-to-text service implementation using Groq’s Whisper API"
 To use `GroqSTTService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[groq]
+pip install "pipecat-ai[groq]"
 ```
 
 You'll need to set up your Groq API key as an environment variable: `GROQ_API_KEY`.

--- a/server/services/stt/openai.mdx
+++ b/server/services/stt/openai.mdx
@@ -12,7 +12,7 @@ description: "Speech-to-text service implementation using OpenAI’s Whisper API
 To use `OpenAISTTService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[openai]
+pip install "pipecat-ai[openai]"
 ```
 
 You'll need to set up your OpenAI API key as an environment variable: `OPENAI_API_KEY`.

--- a/server/services/stt/parakeet.mdx
+++ b/server/services/stt/parakeet.mdx
@@ -12,7 +12,7 @@ description: "Speech-to-text service implementation using NVIDIA’s Parakeet sp
 To use `ParakeetSTTService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[riva]
+pip install "pipecat-ai[riva]"
 ```
 
 You'll also need to set up your NVIDIA API key as an environment variable: `NVIDIA_API_KEY`.

--- a/server/services/stt/ultravox.mdx
+++ b/server/services/stt/ultravox.mdx
@@ -12,7 +12,7 @@ description: "Speech-to-text service implementation using a locally-loaded Ultra
 To use `UltravoxSTTService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[ultravox]
+pip install "pipecat-ai[ultravox]"
 ```
 
 ## Configuration

--- a/server/services/stt/whisper.mdx
+++ b/server/services/stt/whisper.mdx
@@ -12,7 +12,7 @@ description: "Speech-to-text service implementation using locally-downloaded Whi
 To use `WhisperSTTService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[whisper]
+pip install "pipecat-ai[whisper]"
 ```
 
 ## Configuration

--- a/server/services/supported-services.mdx
+++ b/server/services/supported-services.mdx
@@ -5,99 +5,99 @@ description: "AI services integrated with Pipecat and their setup requirements"
 
 ## Transports
 
-| Service                                                           | Setup                               |
-| ----------------------------------------------------------------- | ----------------------------------- |
-| [Daily](/server/services/transport/daily)                         | `pip install pipecat-ai[daily]`     |
-| [FastAPI WebSocket](/server/services/transport/fastapi-websocket) | `pip install pipecat-ai[websocket]` |
-| [WebSocket Server](/server/services/transport/websocket-server)   | `pip install pipecat-ai[websocket]` |
+| Service                                                           | Setup                                |
+| ----------------------------------------------------------------- | ------------------------------------ |
+| [Daily](/server/services/transport/daily)                         | `pip install "pipecat-ai[daily]"`    |
+| [FastAPI WebSocket](/server/services/transport/fastapi-websocket) | `pip install "pipecat-ai[websocket]` |
+| [WebSocket Server](/server/services/transport/websocket-server)   | `pip install "pipecat-ai[websocket]` |
 
 ## Speech-to-Text
 
-| Service                                          | Setup                                |
-| ------------------------------------------------ | ------------------------------------ |
-| [AssemblyAI](/server/services/stt/assemblyai)    | `pip install pipecat-ai[assemblyai]` |
-| [Azure](/server/services/stt/azure)              | `pip install pipecat-ai[azure]`      |
-| [Deepgram](/server/services/stt/deepgram)        | `pip install pipecat-ai[deepgram]`   |
-| [Fal Wizper](/server/services/stt/fal)           | `pip install pipecat-ai[fal]`        |
-| [Gladia](/server/services/stt/gladia)            | `pip install pipecat-ai[gladia]`     |
-| [Google](/server/services/stt/google)            | `pip install pipecat-ai[google]`     |
-| [Groq (Whisper)](/server/services/stt/groq)      | `pip install pipecat-ai[groq]`       |
-| [NVIDIA Parakeet](/server/services/stt/parakeet) | `pip install pipecat-ai[riva]`       |
-| [OpenAI (Whisper)](/server/services/stt/openai)  | `pip install pipecat-ai[openai]`     |
-| [Ultravox](/server/services/stt/ultravox)        | `pip install pipecat-ai[ultravox]`   |
-| [Whisper](/server/services/stt/whisper)          | `pip install pipecat-ai[whisper]`    |
+| Service                                          | Setup                                 |
+| ------------------------------------------------ | ------------------------------------- |
+| [AssemblyAI](/server/services/stt/assemblyai)    | `pip install "pipecat-ai[assemblyai]` |
+| [Azure](/server/services/stt/azure)              | `pip install "pipecat-ai[azure]`      |
+| [Deepgram](/server/services/stt/deepgram)        | `pip install "pipecat-ai[deepgram]`   |
+| [Fal Wizper](/server/services/stt/fal)           | `pip install "pipecat-ai[fal]`        |
+| [Gladia](/server/services/stt/gladia)            | `pip install "pipecat-ai[gladia]`     |
+| [Google](/server/services/stt/google)            | `pip install "pipecat-ai[google]`     |
+| [Groq (Whisper)](/server/services/stt/groq)      | `pip install "pipecat-ai[groq]`       |
+| [NVIDIA Parakeet](/server/services/stt/parakeet) | `pip install "pipecat-ai[riva]`       |
+| [OpenAI (Whisper)](/server/services/stt/openai)  | `pip install "pipecat-ai[openai]`     |
+| [Ultravox](/server/services/stt/ultravox)        | `pip install "pipecat-ai[ultravox]`   |
+| [Whisper](/server/services/stt/whisper)          | `pip install "pipecat-ai[whisper]`    |
 
 ## Large Language Models
 
-| Service                                        | Setup                                |
-| ---------------------------------------------- | ------------------------------------ |
-| [Anthropic](/server/services/llm/anthropic)    | `pip install pipecat-ai[anthropic]`  |
-| [Azure](/server/services/llm/azure)            | `pip install pipecat-ai[azure]`      |
-| [Cerebras](/server/services/llm/cerebras)      | `pip install pipecat-ai[cerebras]`   |
-| [DeepSeek](/server/services/llm/deepseek)      | `pip install pipecat-ai[deepseek]`   |
-| [Fireworks AI](/server/services/llm/fireworks) | `pip install pipecat-ai[fireworks]`  |
-| [Google Gemini](/server/services/llm/gemini)   | `pip install pipecat-ai[google]`     |
-| [Grok](/server/services/llm/grok)              | `pip install pipecat-ai[grok]`       |
-| [Groq](/server/services/llm/groq)              | `pip install pipecat-ai[groq]`       |
-| [NVIDIA NIM](/server/services/llm/nim)         | `pip install pipecat-ai[nim]`        |
-| [Ollama](/server/services/llm/ollama)          | `pip install pipecat-ai[ollama]`     |
-| [OpenAI](/server/services/llm/openai)          | `pip install pipecat-ai[openai]`     |
-| [OpenPipe](/server/services/llm/openpipe)      | `pip install pipecat-ai[openpipe]`   |
-| [OpenRouter](/server/services/llm/openrouter)  | `pip install pipecat-ai[openrouter]` |
-| [Perplexity](/server/services/llm/perplexity)  | `pip install pipecat-ai[perplexity]` |
-| [Together AI](/server/services/llm/together)   | `pip install pipecat-ai[together]`   |
+| Service                                        | Setup                                 |
+| ---------------------------------------------- | ------------------------------------- |
+| [Anthropic](/server/services/llm/anthropic)    | `pip install "pipecat-ai[anthropic]`  |
+| [Azure](/server/services/llm/azure)            | `pip install "pipecat-ai[azure]`      |
+| [Cerebras](/server/services/llm/cerebras)      | `pip install "pipecat-ai[cerebras]`   |
+| [DeepSeek](/server/services/llm/deepseek)      | `pip install "pipecat-ai[deepseek]`   |
+| [Fireworks AI](/server/services/llm/fireworks) | `pip install "pipecat-ai[fireworks]`  |
+| [Google Gemini](/server/services/llm/gemini)   | `pip install "pipecat-ai[google]`     |
+| [Grok](/server/services/llm/grok)              | `pip install "pipecat-ai[grok]`       |
+| [Groq](/server/services/llm/groq)              | `pip install "pipecat-ai[groq]`       |
+| [NVIDIA NIM](/server/services/llm/nim)         | `pip install "pipecat-ai[nim]`        |
+| [Ollama](/server/services/llm/ollama)          | `pip install "pipecat-ai[ollama]`     |
+| [OpenAI](/server/services/llm/openai)          | `pip install "pipecat-ai[openai]`     |
+| [OpenPipe](/server/services/llm/openpipe)      | `pip install "pipecat-ai[openpipe]`   |
+| [OpenRouter](/server/services/llm/openrouter)  | `pip install "pipecat-ai[openrouter]` |
+| [Perplexity](/server/services/llm/perplexity)  | `pip install "pipecat-ai[perplexity]` |
+| [Together AI](/server/services/llm/together)   | `pip install "pipecat-ai[together]`   |
 
 ## Text-to-Speech
 
-| Service                                            | Setup                                |
-| -------------------------------------------------- | ------------------------------------ |
-| [Amazon Polly](/server/services/tts/aws)           | `pip install pipecat-ai[aws]`        |
-| [Azure](/server/services/tts/azure)                | `pip install pipecat-ai[azure]`      |
-| [Cartesia](/server/services/tts/cartesia)          | `pip install pipecat-ai[cartesia]`   |
-| [Deepgram](/server/services/tts/deepgram)          | `pip install pipecat-ai[deepgram]`   |
-| [ElevenLabs](/server/services/tts/elevenlabs)      | `pip install pipecat-ai[elevenlabs]` |
-| [Fish](/server/services/tts/fish)                  | `pip install pipecat-ai[fish]`       |
-| [Google](/server/services/tts/google)              | `pip install pipecat-ai[google]`     |
-| [LMNT](/server/services/tts/lmnt)                  | `pip install pipecat-ai[lmnt]`       |
-| [Neuphonic](/server/services/tts/neuphonic)        | `pip install pipecat-ai[neuphonic]`  |
-| [NVIDIA FastPitch](/server/services/tts/fastpitch) | `pip install pipecat-ai[riva]`       |
-| [OpenAI](/server/services/tts/openai)              | `pip install pipecat-ai[openai]`     |
-| [PlayHT](/server/services/tts/playht)              | `pip install pipecat-ai[playht]`     |
-| [Rime](/server/services/tts/rime)                  | `pip install pipecat-ai[rime]`       |
-| [XTTS](/server/services/tts/xtts)                  | `pip install pipecat-ai[xtts]`       |
+| Service                                            | Setup                                 |
+| -------------------------------------------------- | ------------------------------------- |
+| [Amazon Polly](/server/services/tts/aws)           | `pip install "pipecat-ai[aws]`        |
+| [Azure](/server/services/tts/azure)                | `pip install "pipecat-ai[azure]`      |
+| [Cartesia](/server/services/tts/cartesia)          | `pip install "pipecat-ai[cartesia]`   |
+| [Deepgram](/server/services/tts/deepgram)          | `pip install "pipecat-ai[deepgram]`   |
+| [ElevenLabs](/server/services/tts/elevenlabs)      | `pip install "pipecat-ai[elevenlabs]` |
+| [Fish](/server/services/tts/fish)                  | `pip install "pipecat-ai[fish]`       |
+| [Google](/server/services/tts/google)              | `pip install "pipecat-ai[google]`     |
+| [LMNT](/server/services/tts/lmnt)                  | `pip install "pipecat-ai[lmnt]`       |
+| [Neuphonic](/server/services/tts/neuphonic)        | `pip install "pipecat-ai[neuphonic]`  |
+| [NVIDIA FastPitch](/server/services/tts/fastpitch) | `pip install "pipecat-ai[riva]`       |
+| [OpenAI](/server/services/tts/openai)              | `pip install "pipecat-ai[openai]`     |
+| [PlayHT](/server/services/tts/playht)              | `pip install "pipecat-ai[playht]`     |
+| [Rime](/server/services/tts/rime)                  | `pip install "pipecat-ai[rime]`       |
+| [XTTS](/server/services/tts/xtts)                  | `pip install "pipecat-ai[xtts]`       |
 
 ## Speech-to-Speech
 
-| Service                                               | Setup                            |
-| ----------------------------------------------------- | -------------------------------- |
-| [Gemini Multimodal Live](/server/services/s2s/gemini) | `pip install pipecat-ai[google]` |
-| [OpenAI Realtime](/server/services/s2s/openai)        | `pip install pipecat-ai[openai]` |
+| Service                                               | Setup                             |
+| ----------------------------------------------------- | --------------------------------- |
+| [Gemini Multimodal Live](/server/services/s2s/gemini) | `pip install "pipecat-ai[google]` |
+| [OpenAI Realtime](/server/services/s2s/openai)        | `pip install "pipecat-ai[openai]` |
 
 ## Image Generation
 
-| Service                                                          | Setup                            |
-| ---------------------------------------------------------------- | -------------------------------- |
-| [fal](/server/services/image-generation/fal)                     | `pip install pipecat-ai[fal]`    |
-| [Google Imagen](/server/services/image-generation/google-imagen) | `pip install pipecat-ai[google]` |
+| Service                                                          | Setup                             |
+| ---------------------------------------------------------------- | --------------------------------- |
+| [fal](/server/services/image-generation/fal)                     | `pip install "pipecat-ai[fal]`    |
+| [Google Imagen](/server/services/image-generation/google-imagen) | `pip install "pipecat-ai[google]` |
 
 ## Video
 
-| Service                               | Setup                           |
-| ------------------------------------- | ------------------------------- |
-| [Simli](/server/services/video/simli) | `pip install pipecat-ai[simli]` |
-| [Tavus](/server/services/video/tavus) | `pip install pipecat-ai[tavus]` |
+| Service                               | Setup                            |
+| ------------------------------------- | -------------------------------- |
+| [Simli](/server/services/video/simli) | `pip install "pipecat-ai[simli]` |
+| [Tavus](/server/services/video/tavus) | `pip install "pipecat-ai[tavus]` |
 
 ## Vision
 
-| Service                                        | Setup                               |
-| ---------------------------------------------- | ----------------------------------- |
-| [Moondream](/server/services/vision/moondream) | `pip install pipecat-ai[moondream]` |
+| Service                                        | Setup                                |
+| ---------------------------------------------- | ------------------------------------ |
+| [Moondream](/server/services/vision/moondream) | `pip install "pipecat-ai[moondream]` |
 
 ## Analytics & Monitoring
 
-| Service                                              | Setup                               |
-| ---------------------------------------------------- | ----------------------------------- |
-| [Canonical AI](/server/services/analytics/canonical) | `pip install pipecat-ai[canonical]` |
-| [Sentry](/server/services/analytics/sentry)          | `pip install pipecat-ai[sentry]`    |
+| Service                                              | Setup                                |
+| ---------------------------------------------------- | ------------------------------------ |
+| [Canonical AI](/server/services/analytics/canonical) | `pip install "pipecat-ai[canonical]` |
+| [Sentry](/server/services/analytics/sentry)          | `pip install "pipecat-ai[sentry]`    |
 
 For detailed configuration and usage examples, see each service's individual documentation page.

--- a/server/services/transport/daily.mdx
+++ b/server/services/transport/daily.mdx
@@ -12,7 +12,7 @@ description: "WebRTC transport implementation using Daily for real-time audio/vi
 To use DailyTransport, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[daily]
+pip install "pipecat-ai[daily]"
 ```
 
 You'll also need to set up your Daily API key as an environment variable:

--- a/server/services/transport/fastapi-websocket.mdx
+++ b/server/services/transport/fastapi-websocket.mdx
@@ -20,7 +20,7 @@ for robust network and media handling.
 To use `FastAPIWebsocketTransport`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[websocket]
+pip install "pipecat-ai[websocket]"
 ```
 
 ## Configuration

--- a/server/services/transport/websocket-server.mdx
+++ b/server/services/transport/websocket-server.mdx
@@ -20,7 +20,7 @@ for robust network and media handling.
 To use `WebsocketServerTransport`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[websocket]
+pip install "pipecat-ai[websocket]"
 ```
 
 ## Configuration

--- a/server/services/tts/aws.mdx
+++ b/server/services/tts/aws.mdx
@@ -12,7 +12,7 @@ description: "Text-to-speech service implementation using Amazon Polly"
 To use `PollyTTSService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[aws]
+pip install "pipecat-ai[aws]"
 ```
 
 You'll also need to set up your AWS credentials as environment variables:

--- a/server/services/tts/azure.mdx
+++ b/server/services/tts/azure.mdx
@@ -12,7 +12,7 @@ description: "Text-to-speech service using Azure Cognitive Services Speech SDK"
 To use `AzureTTSService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[azure]
+pip install "pipecat-ai[azure]"
 ```
 
 You'll also need to set up the following environment variables:

--- a/server/services/tts/cartesia.mdx
+++ b/server/services/tts/cartesia.mdx
@@ -15,7 +15,7 @@ Cartesia provides two TTS service implementations:
 To use Cartesia services, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[cartesia]
+pip install "pipecat-ai[cartesia]"
 ```
 
 You'll also need to set up your Cartesia API key as an environment variable: `CARTESIA_API_KEY`.

--- a/server/services/tts/deepgram.mdx
+++ b/server/services/tts/deepgram.mdx
@@ -12,7 +12,7 @@ description: "Text-to-speech service implementation using Deepgram’s Aura API"
 To use `DeepgramTTSService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[deepgram]
+pip install "pipecat-ai[deepgram]"
 ```
 
 You'll also need to set up your Deepgram API key as an environment variable: `DEEPGRAM_API_KEY`

--- a/server/services/tts/elevenlabs.mdx
+++ b/server/services/tts/elevenlabs.mdx
@@ -15,7 +15,7 @@ ElevenLabs TTS provides high-quality text-to-speech synthesis through two servic
 To use `ElevenLabsTTSService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[elevenlabs]
+pip install "pipecat-ai[elevenlabs]"
 ```
 
 You'll also need to set up your ElevenLabs API key as an environment variable: `ELEVENLABS_API_KEY`.

--- a/server/services/tts/fastpitch.mdx
+++ b/server/services/tts/fastpitch.mdx
@@ -12,7 +12,7 @@ description: "Text-to-speech service implementation using NVIDIA’s FastPitch m
 To use `FastPitchTTSService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[riva]
+pip install "pipecat-ai[riva]"
 ```
 
 You'll also need to set up your NVIDIA API key as an environment variable: `NVIDIA_API_KEY`

--- a/server/services/tts/fish.mdx
+++ b/server/services/tts/fish.mdx
@@ -12,7 +12,7 @@ The `FishAudioTTSService` provides real-time text-to-speech synthesis using Fish
 To use Fish Audio, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[fish]
+pip install "pipecat-ai[fish]"
 ```
 
 You'll need to set up your Fish Audio API key as an environment variable: `FISH_API_KEY`.

--- a/server/services/tts/google.mdx
+++ b/server/services/tts/google.mdx
@@ -12,7 +12,7 @@ description: "Text-to-speech service using Google’s Cloud Text-to-Speech API"
 To use `GoogleTTSService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[google]
+pip install "pipecat-ai[google]"
 ```
 
 You'll also need to set up Google Cloud credentials through either:

--- a/server/services/tts/lmnt.mdx
+++ b/server/services/tts/lmnt.mdx
@@ -12,7 +12,7 @@ description: "Text-to-speech service implementation using LMNT’s streaming API
 To use `LmntTTSService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[lmnt]
+pip install "pipecat-ai[lmnt]"
 ```
 
 You'll also need to set up your LMNT API key as an environment variable: `LMNT_API_KEY`

--- a/server/services/tts/neuphonic.mdx
+++ b/server/services/tts/neuphonic.mdx
@@ -17,7 +17,7 @@ Both services support various voices, languages, and customization options.
 To use Neuphonic TTS services, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[neuphonic]
+pip install "pipecat-ai[neuphonic]"
 ```
 
 You'll also need to set up your Neuphonic API key as an environment variable: `NEUPHONIC_API_KEY`
@@ -157,8 +157,8 @@ Neuphonic TTS supports the following languages:
 | `Language.NL` | Dutch       | `nl`          |
 | `Language.AR` | Arabic      | `ar`          |
 | `Language.FR` | French      | `fr`          |
-| `Language.PT` | Portuguese   | `pt`          |
-| `Language.RU` | Russian    | `ru`          |
+| `Language.PT` | Portuguese  | `pt`          |
+| `Language.RU` | Russian     | `ru`          |
 | `Language.HI` | Hindi       | `hi`          |
 | `Language.ZH` | Chinese     | `zh`          |
 

--- a/server/services/tts/openai.mdx
+++ b/server/services/tts/openai.mdx
@@ -12,7 +12,7 @@ description: "Text-to-speech service using OpenAI’s TTS API"
 To use `OpenAITTSService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[openai]
+pip install "pipecat-ai[openai]"
 ```
 
 You'll also need to set up your OpenAI API key as an environment variable: `OPENAI_API_KEY`

--- a/server/services/tts/playht.mdx
+++ b/server/services/tts/playht.mdx
@@ -15,7 +15,7 @@ PlayHT provides two TTS service implementations:
 To use PlayHT services, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[playht]
+pip install "pipecat-ai[playht]"
 ```
 
 You'll also need to set up your PlayHT credentials as environment variables:

--- a/server/services/video/simli.mdx
+++ b/server/services/video/simli.mdx
@@ -12,7 +12,7 @@ description: "Video service for generating AI avatar responses using Simli's Web
 Install the required dependencies:
 
 ```bash
-pip install pipecat-ai[simli]
+pip install "pipecat-ai[simli]"
 ```
 
 ## Configuration

--- a/server/services/video/tavus.mdx
+++ b/server/services/video/tavus.mdx
@@ -12,7 +12,7 @@ description: "Video service implementation for generating AI avatar responses us
 To use `TavusVideoService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[tavus]
+pip install "pipecat-ai[tavus]"
 ```
 
 You'll need to set up the following environment variables:

--- a/server/services/vision/moondream.mdx
+++ b/server/services/vision/moondream.mdx
@@ -12,7 +12,7 @@ description: "Vision service implementation using Moondream for local image anal
 To use `MoondreamService`, install the required dependencies:
 
 ```bash
-pip install pipecat-ai[moondream]
+pip install "pipecat-ai[moondream]"
 ```
 
 <Tip>

--- a/server/utilities/audio/koala-filter.mdx
+++ b/server/utilities/audio/koala-filter.mdx
@@ -14,7 +14,7 @@ To use Koala, you need a Picovoice access key. Get started at [Picovoice Console
 The Koala filter requires additional dependencies:
 
 ```bash
-pip install pipecat-ai[koala]
+pip install "pipecat-ai[koala]"
 ```
 
 You'll also need to set up your Koala access key as an environment variable: `KOALA_ACCESS_KEY`

--- a/server/utilities/audio/krisp-filter.mdx
+++ b/server/utilities/audio/krisp-filter.mdx
@@ -19,7 +19,7 @@ To use Krisp, you need a Krisp SDK license. Get started at [Krisp.ai](https://kr
 The Krisp filter requires additional dependencies:
 
 ```bash
-pip install pipecat-ai[krisp]
+pip install "pipecat-ai[krisp]"
 ```
 
 ## Environment Variables

--- a/server/utilities/audio/noisereduce-filter.mdx
+++ b/server/utilities/audio/noisereduce-filter.mdx
@@ -12,7 +12,7 @@ description: "Audio noise reduction filter using the noisereduce library"
 The noisereduce filter requires additional dependencies:
 
 ```bash
-pip install pipecat-ai[noisereduce]
+pip install "pipecat-ai[noisereduce]"
 ```
 
 ## Constructor Parameters

--- a/server/utilities/audio/silero-vad-analyzer.mdx
+++ b/server/utilities/audio/silero-vad-analyzer.mdx
@@ -12,7 +12,7 @@ description: "Voice Activity Detection analyzer using the Silero VAD ONNX model"
 The Silero VAD analyzer requires additional dependencies:
 
 ```bash
-pip install pipecat-ai[silero]
+pip install "pipecat-ai[silero]"
 ```
 
 ## Constructor Parameters

--- a/server/utilities/audio/soundfile-mixer.mdx
+++ b/server/utilities/audio/soundfile-mixer.mdx
@@ -12,7 +12,7 @@ description: "Audio mixer for combining real-time audio with sound files"
 The soundfile mixer requires additional dependencies:
 
 ```bash
-pip install pipecat-ai[soundfile]
+pip install "pipecat-ai[soundfile]"
 ```
 
 ## Constructor Parameters

--- a/server/utilities/heartbeats.mdx
+++ b/server/utilities/heartbeats.mdx
@@ -15,7 +15,7 @@ Heartbeats can be enabled by setting `enable_heartbeats` to `True` in the `Pipel
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 
 pipeline = Pipeline([...])
-params = PipelineParams(enable_heartbeats=True)
+params = params=PipelineParams(enable_heartbeats=True)
 task = PipelineTask(pipeline, params)
 ```
 

--- a/server/utilities/observers/llm-observer.mdx
+++ b/server/utilities/observers/llm-observer.mdx
@@ -25,7 +25,7 @@ from pipecat.observers.loggers.llm_log_observer import LLMLogObserver
 
 task = PipelineTask(
     pipeline,
-    PipelineParams(
+    params=PipelineParams(
         observers=[LLMLogObserver()],
     ),
 )

--- a/server/utilities/observers/observer-pattern.mdx
+++ b/server/utilities/observers/observer-pattern.mdx
@@ -40,7 +40,7 @@ You can attach multiple observers to a pipeline task. Each observer will be noti
 ```python
 task = PipelineTask(
     pipeline,
-    PipelineParams(
+    params=PipelineParams(
         observers=[LLMLogObserver(), TranscriptionLogObserver(), CustomObserver()],
     ),
 )

--- a/server/utilities/observers/rtvi-observer.mdx
+++ b/server/utilities/observers/rtvi-observer.mdx
@@ -63,7 +63,7 @@ The `RTVIObserver` is created and attached through the RTVI processor:
 rtvi = RTVIProcessor(config=RTVIConfig(config=[]))
 task = PipelineTask(
     pipeline,
-    PipelineParams(
+    params=PipelineParams(
         observers=[rtvi.observer()],
     ),
 )

--- a/server/utilities/observers/transcription-observer.mdx
+++ b/server/utilities/observers/transcription-observer.mdx
@@ -20,7 +20,7 @@ from pipecat.observers.loggers.transcription_log_observer import TranscriptionLo
 
 task = PipelineTask(
     pipeline,
-    PipelineParams(
+    params=PipelineParams(
         observers=[TranscriptionLogObserver()],
     ),
 )


### PR DESCRIPTION
- Adds docs for `FunctionSchema` and `ToolsSchema` (in function calling guide)
- General clean up to the function calling guide
- Updates function calling examples in docs to use this (not Flows yet—waiting on a Flows PR for that..)
- Removes start_callback
- Adds `params=PipelineParams` arg
- Fix pip install guidance to include ""