### PR TITLE
Docs update for TransportParams: audio_out_10ms_chunks

### DIFF
--- a/server/base-classes/transport.mdx
+++ b/server/base-classes/transport.mdx
@@ -117,6 +117,11 @@ def add_event_handler(self, event_name: str, handler)
   Audio output bitrate in bits/second
 </ParamField>
 
+<ParamField path="audio_out_10ms_chunks" type="int" default="4">
+  Audio output chunk size in 10ms intervals. Default is 4, resulting in 40ms
+  chunks.
+</ParamField>
+
 <ParamField
   path="audio_out_mixer"
   type="Optional[BaseAudioMixer]"


### PR DESCRIPTION
Docs for: https://github.com/pipecat-ai/pipecat/pull/1504