### PR TITLE
Remove speed and emotion from Cartesia docs

### DIFF
--- a/server/services/tts/cartesia.mdx
+++ b/server/services/tts/cartesia.mdx
@@ -64,31 +64,6 @@ Both services use the same input parameters structure:
   section for available options.
 </ParamField>
 
-<ParamField path="speed" type="Union[str, float]" default="">
-Controls the speech rate.
-
-Can be specified as either:
-
-- String options: `"slowest"`, `"slow"`, `"normal"`, `"fast"`, `"fastest"`
-- Float value: Between `-1.0` (slowest) and `1.0` (fastest), where `0.0` is normal speed
-
-</ParamField>
-
-<ParamField path="emotion" type="List[str]" default="[]">
-List of emotion controls to apply.
-
-Each emotion can be specified as:
-
-- Simple emotion: `"anger"`, `"positivity"`, `"surprise"`, `"sadness"`, `"curiosity"`
-- Emotion with level: "emotion:level" where level can be `"lowest"`, `"low"`, `"high"`,
-  `"highest"`
-
-Example: `["positivity:high", "curiosity"]`
-
-Note: Emotion controls are additive and their effects may vary by voice and content.
-
-</ParamField>
-
 ## CartesiaTTSService (WebSocket)
 
 WebSocket-based implementation supporting real-time streaming and word timestamps.
@@ -233,11 +208,6 @@ tts = CartesiaTTSService(
     model="sonic",
     params=CartesiaTTSService.InputParams(
         language=Language.EN,
-        speed="normal",
-        emotion=[
-          "positivity:high",
-          "curiosity"
-        ]
     )
 )
 
@@ -260,7 +230,6 @@ http_service = CartesiaHttpTTSService(
     model="sonic",
     params=CartesiaHttpTTSService.InputParams(
         language=Language.EN,
-        speed=1.0
     )
 )
 ```


### PR DESCRIPTION
No longer work in newer model snapshots, so removing to match.