### PR TITLE
Add Soniox STT service docs

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -165,6 +165,7 @@
             "server/services/stt/groq",
             "server/services/stt/riva",
             "server/services/stt/openai",
+            "server/services/stt/soniox",
             "server/services/stt/ultravox",
             "server/services/stt/whisper"
           ]

--- a/server/services/stt/soniox.mdx
+++ b/server/services/stt/soniox.mdx
@@ -1,0 +1,207 @@
+---
+title: "Soniox"
+description: "Speech-to-text service implementation using Soniox’s WebSocket API"
+---
+
+## Overview
+
+`SonioxSTTService` is a speech-to-text (STT) service that integrates with Soniox’s WebSocket API to provide real-time transcription capabilities. It processes audio input and produces transcription frames and interim transcription frames in real time, supporting over 60 languages. Supports custom context, multiple languages in same conversation and more.
+
+## Installation
+
+To use `SonioxSTTService`, you need to install the Soniox dependencies:
+
+```bash
+pip install "pipecat-ai[soniox]"
+```
+
+You'll also need to set up your Soniox API key as an environment variable: `SONIOX_API_KEY`. You can obtain a Soniox API key by signing up at [Soniox console](https://console.soniox.com/).
+
+## Configuration
+
+### Service Parameters
+
+<ParamField path="api_key" type="string" required>
+  Your Soniox API key for authentication
+</ParamField>
+
+<ParamField path="url" type="string" default="wss://stt-rt.soniox.com/transcribe-websocket">
+  Soniox WebSocket API endpoint URL
+</ParamField>
+
+<ParamField path="sample_rate" type="integer" default="None">
+  Audio sample rate in Hz
+</ParamField>
+
+<ParamField
+  path="params"
+  type="SonioxInputParams"
+  default="SonioxInputParams()"
+>
+  Additional configuration parameters for the service, see below.
+</ParamField>
+
+<ParamField path="enable_vad" type="bool" default="true">
+  Enable voice activity detection (VAD) to call finalization when the user stops speaking.
+</ParamField>
+
+<ParamField path="auto_finalize_delay_ms" type="int" default="3000">
+  If there are no new tokens received for this duration, the service will call finalization automatically. This is useful when user stops speaking and endpoint is not detected by Soniox.
+</ParamField>
+
+### SonioxInputParams
+
+Params are directly passed to the Soniox WebSocket API. For more information, refer to [WebSocket API documentation](https://soniox.com/docs/speech-to-text/api-reference/websocket-api).
+
+<ParamField path="model" type="string" default="stt-rt-preview">
+  Model to use for transcription. To see available models and their supported languages, refer to [Models REST API endpoint](https://soniox.com/docs/speech-to-text/api-reference/models/get_models). Note that the model used will have to be a real-time model.
+</ParamField>
+
+<ParamField path="audio_format" type="string" default="pcm_s16le">
+  Audio format. See list of supported audio formats [here](https://soniox.com/docs/speech-to-text/core-concepts/audio-formats#raw-audio-formats-manual-configuration-required).
+</ParamField>
+
+<ParamField path="num_channels" type="integer" default="1">
+  Number of audio channels.
+</ParamField>
+
+<ParamField path="sample_rate" type="integer" default="16000">
+  Audio sample rate in Hz.
+</ParamField>
+
+<ParamField path="language_hints" type="List[Language]" optional>
+  Hint model language(s) for transcription.
+</ParamField>
+
+<ParamField path="context" type="string" optional>
+  Add context to guide the model to improve transcription of uncommon names or phrases.
+</ParamField>
+
+<ParamField
+  path="enable_non_final_tokens"
+  type="boolean"
+  default="true"
+  optional
+>
+  Enable non-final tokens. If enabled, `SonioxSTTService` will produce interim transcription frames. See [Final-vs-non-final tokens](https://soniox.com/docs/speech-to-text/core-concepts/final-vs-non-final-tokens) for more information.
+</ParamField>
+
+<ParamField path="max_non_final_tokens_duration_ms" type="integer" optional>
+  Maximum delay (in milliseconds) between a spoken word and its finalization.
+</ParamField>
+
+<ParamField path="enable_endpoint_detection" type="bool" default="true">
+  Enable endpoint detection to send messages on user speaking endpoints.
+</ParamField>
+
+<ParamField path="client_reference_id" type="string" optional>
+  Optional tracking identifier string. Does not need to be unique.
+</ParamField>
+
+## Input
+
+By default the service processes raw audio data with the following requirements:
+
+- PCM audio format
+- 16-bit depth
+- 16kHz sample rate
+- Single channel
+
+Soniox supports a wide range of audio formats, custom sample rates and number of channels. Refer to [Audio formats](https://soniox.com/docs/speech-to-text/core-concepts/audio-formats) for more information.
+
+## Output
+
+The service produces two types of frames during transcription:
+
+### TranscriptionFrame
+
+Generated for final transcriptions tokens, containing:
+
+<ParamField path="text" type="string">
+  Transcribed text
+</ParamField>
+
+<ParamField path="timestamp" type="string">
+  ISO 8601 formatted timestamp
+</ParamField>
+
+Internally, `SonioxSTTService` buffers the transcription frames until `<end>` or `<fin>` tokens are received.
+
+- When the user stops speaking, the service will call finalization and receive `<fin>` token after the finalization is complete. You can disable this behavior by setting `enable_vad` to `false`.
+- Soniox automatically detects the user's speech endpoint (e.g. a pause in speech) and sends `<end>` token when the endpoint is detected. You can disable this behavior by setting `enable_endpoint_detection` in the `SonioxInputParams` to `false`.
+
+
+### InterimTranscriptionFrame
+
+Generated during ongoing speech, containing the same fields as TranscriptionFrame but with preliminary results.
+
+### ErrorFrame
+
+Generated when transcription errors occur, containing error details.
+
+## Advanced Features
+
+### Language Hints
+
+There is no need to pre-select a language — the model automatically detects and transcribes any supported language. It also handles multilingual audio seamlessly, even when multiple languages are mixed within a single sentence or conversation.
+
+However, when you have prior knowledge of the languages likely to be spoken in your audio, you can use language hints to guide the model toward those languages for even greater recognition accuracy.
+
+```python
+from pipecat.services.soniox.config import SonioxInputParams
+from pipecat.transcriptions.language import Language
+
+SonioxInputParams(
+  language_hints=[Language.EN, Language.ES, Language.JA, Language.ZH],
+)
+```
+
+Language variants are ignored, for example `Language.EN_GB` will be treated same as `Language.EN`. See [Supported Languages](https://soniox.com/docs/speech-to-text/core-concepts/supported-languages) for a list of supported languages.
+
+You can learn more about language hints in the [Soniox documentation](https://soniox.com/docs/speech-to-text/core-concepts/language-hints).
+
+### Customization with Context
+
+By providing context, you help the AI model better understand and anticipate the language in your audio - even if some terms do not appear clearly or completely. 
+
+```python
+from pipecat.services.soniox.config import SonioxInputParams
+
+SonioxInputParams(
+  context="Celebrex, Zyrtec, Xanax, Prilosec, Amoxicillin Clavulanate Potassium",
+),
+```
+
+### Endpoint Detection, VAD and Auto-Finalization
+
+Soniox Speech-to-Text API provides a stream of tokens. There are multiple ways to decide when to finalize a transcription and send it to the next step in the pipeline (for example, send the transcription to the LLM). There are two main approaches:
+
+- [**Endpoint Detection**](https://soniox.com/docs/speech-to-text/core-concepts/endpoint-detection): Soniox automatically when the user stops speaking. This is useful when you want to send the transcription to the LLM immediately after the user finishes speaking. You can toggle this setting in the `SonioxInputParams`.
+- **Voice Activity Detection (VAD)**: Pipecat voice bots often use VAD to decide whose turn it is to speak. Soniox STT service will call finalization when the `UserStoppedSpeaking` event is received. You can toggle this setting by setting `enable_vad` to `False`.
+
+In addition to that, you can set `auto_finalize_delay_ms` to automatically call finalization when there are no new tokens received for a certain duration. This is useful when user stops speaking and endpoint is not detected by Soniox or VAD.
+
+## Usage Example
+
+```python
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.services.soniox.stt import SonioxSTTService
+from pipecat.services.soniox.config import SonioxInputParams
+from pipecat.transcriptions.language import Language
+
+# Configure the service
+stt = SonioxSTTService(
+    api_key=os.getenv("SONIOX_API_KEY"),
+    params=SonioxInputParams(
+      language_hints=[Language.EN, Language.ES, Language.JA, Language.ZH],
+    ),
+)
+
+# Use in pipeline
+pipeline = Pipeline([
+    transport.input(),
+    stt,
+    llm,
+    ...
+])
+```

--- a/server/services/supported-services.mdx
+++ b/server/services/supported-services.mdx
@@ -26,6 +26,7 @@ description: "AI services integrated with Pipecat and their setup requirements"
 | [Groq (Whisper)](/server/services/stt/groq)     | `pip install "pipecat-ai[groq]"`       |
 | [NVIDIA Riva](/server/services/stt/riva)        | `pip install "pipecat-ai[riva]"`       |
 | [OpenAI (Whisper)](/server/services/stt/openai) | `pip install "pipecat-ai[openai]"`     |
+| [Soniox](/server/services/stt/soniox)           | `pip install "pipecat-ai[soniox]"`     |
 | [Ultravox](/server/services/stt/ultravox)       | `pip install "pipecat-ai[ultravox]"`   |
 | [Whisper](/server/services/stt/whisper)         | `pip install "pipecat-ai[whisper]"`    |
 


### PR DESCRIPTION
This PR adds documentation for new STT provider `SonioxSTTService` added in https://github.com/pipecat-ai/pipecat/pull/1910.