### PR TITLE
Fix: new download location for run.py

### DIFF
--- a/getting-started/quickstart.mdx
+++ b/getting-started/quickstart.mdx
@@ -46,7 +46,7 @@ source env/Scripts/activate # If using Git Bash
 
 ```bash
 curl -O https://raw.githubusercontent.com/pipecat-ai/pipecat/main/examples/foundational/01-say-one-thing.py
-curl -O https://raw.githubusercontent.com/pipecat-ai/pipecat/main/examples/foundational/run.py
+curl -O https://raw.githubusercontent.com/pipecat-ai/pipecat/main/src/pipecat/examples/run.py
 curl -O https://raw.githubusercontent.com/pipecat-ai/pipecat/main/examples/foundational/requirements.txt
 ```
 
@@ -55,7 +55,7 @@ curl -O https://raw.githubusercontent.com/pipecat-ai/pipecat/main/examples/found
 
 ```powershell
 curl.exe -O https://raw.githubusercontent.com/pipecat-ai/pipecat/main/examples/foundational/01-say-one-thing.py
-curl.exe -O https://raw.githubusercontent.com/pipecat-ai/pipecat/main/examples/foundational/run.py
+curl.exe -O https://raw.githubusercontent.com/pipecat-ai/pipecat/main/src/pipecat/examples/run.py
 curl.exe -O https://raw.githubusercontent.com/pipecat-ai/pipecat/main/examples/foundational/requirements.txt
 ```
 
@@ -64,7 +64,7 @@ curl.exe -O https://raw.githubusercontent.com/pipecat-ai/pipecat/main/examples/f
   Download these files and save them to your project directory:
   
   - [01-say-one-thing.py](https://github.com/pipecat-ai/pipecat/blob/main/examples/foundational/01-say-one-thing.py)
-  - [run.py](https://github.com/pipecat-ai/pipecat/blob/main/examples/foundational/run.py)
+  - [run.py](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/examples/run.py)
   - [requirements.txt](https://github.com/pipecat-ai/pipecat/blob/main/examples/foundational/requirements.txt)
   </Tab>
 </Tabs>


### PR DESCRIPTION
Docs counterpart to: https://github.com/pipecat-ai/pipecat/pull/1936