### PR TITLE
Fixing the Krisp recommended model for Linux (x86_64)

### DIFF
--- a/guides/features/krisp.mdx
+++ b/guides/features/krisp.mdx
@@ -22,10 +22,10 @@ To use Krisp's noise cancellation, you'll need to obtain their SDK and models th
    - Windows (x64): `Desktop SDK v7.0.2: Windows`
 3. Download the corresponding models. We recommend trying the `Background Voice Cancellation` model. Recommended model for each platform:
    - Linux (ARM): `hs.c6.f.s.de56df.kw`
-   - Mac (ARM): `outbound-bvc-models-fp16/hs.c6.f.s.de56df.bucharest.kef`
+   - Mac (ARM): `hs.c6.f.s.de56df.kw`
    - Linux (x86_64): `hs.c6.f.s.de56df.kw`
-   - Mac (x86_64): `outbound-bvc-models-fp32/hs.c6.f.s.de56df.bucharest.kef`
-   - Windows (x86_64): `outbound-bvc-models-fp32/hs.c6.f.s.de56df.bucharest.kef`
+   - Mac (x86_64): `hs.c6.f.s.de56df.kw`
+   - Windows (x86_64): `hs.c6.f.s.de56df.kw`
 
 <Frame>![Krisp SDK Portal](/images/krisp-portal.png)</Frame>
 

--- a/guides/features/krisp.mdx
+++ b/guides/features/krisp.mdx
@@ -23,7 +23,7 @@ To use Krisp's noise cancellation, you'll need to obtain their SDK and models th
 3. Download the corresponding models. We recommend trying the `Background Voice Cancellation` model. Recommended model for each platform:
    - Linux (ARM): `hs.c6.f.s.de56df.kw`
    - Mac (ARM): `outbound-bvc-models-fp16/hs.c6.f.s.de56df.bucharest.kef`
-   - Linux (x86_64): `outbound-bvc-models-fp32/hs.c6.f.s.de56df.bucharest.kef`
+   - Linux (x86_64): `hs.c6.f.s.de56df.kw`
    - Mac (x86_64): `outbound-bvc-models-fp32/hs.c6.f.s.de56df.bucharest.kef`
    - Windows (x86_64): `outbound-bvc-models-fp32/hs.c6.f.s.de56df.bucharest.kef`
 


### PR DESCRIPTION
This matches the model name that we downloaded from the Krisp portal for Linux (x86_64).

