### PR TITLE
fix link tpyo

### DIFF
--- a/guides/deployment/fly.mdx
+++ b/guides/deployment/fly.mdx
@@ -7,7 +7,7 @@ description: "Deploy Pipecat bots to Fly.io machines"
 
 Let's explore how we can use [fly.io](www.fly.io) to make our app scalable for production by spawning our Pipecat bots on virtual machines with their own resources.
 
-We mentioned [before](http://localhost:3000/deployment/pattern) that you would ideally containerize the `bot_runner.py` web service and the `bot.py` separately. To keep this example simple, we'll use the same container image for both services.
+We mentioned [before](/guides/deployment/pattern) that you would ideally containerize the `bot_runner.py` web service and the `bot.py` separately. To keep this example simple, we'll use the same container image for both services.
 
 <Frame>
   ![Fly.io Pipecat deployment](/deployment/images/deployment-fly.png)

--- a/guides/deployment/overview.mdx
+++ b/guides/deployment/overview.mdx
@@ -25,7 +25,7 @@ The best choice depends on your specific requirements, scale, and expertise.
 
 ### Things you'll need
 
-- **Transport service** - Pipecat has existing services for various different [media transport](http://localhost:3000/docs/category/transports) modes, such as WebRTC or WebSockets. If you're not using a third-party service for handling media transport, you'll want to make sure that infrastructure is hosted and ready to receive connections.
+- **Transport service** - Pipecat has existing services for various different [media transport](/docs/category/transports) modes, such as WebRTC or WebSockets. If you're not using a third-party service for handling media transport, you'll want to make sure that infrastructure is hosted and ready to receive connections.
 
 - **Deployment target** - You can deploy and run Pipecat bots anywhere that can run Python code - Google Cloud Run, AWS, Fly.io etc. We recommend providers that offer APIs, so you can programmatically spawn new bot agents on-demand.
 

--- a/guides/deployment/overview.mdx
+++ b/guides/deployment/overview.mdx
@@ -25,7 +25,7 @@ The best choice depends on your specific requirements, scale, and expertise.
 
 ### Things you'll need
 
-- **Transport service** - Pipecat has existing services for various different [media transport](/docs/category/transports) modes, such as WebRTC or WebSockets. If you're not using a third-party service for handling media transport, you'll want to make sure that infrastructure is hosted and ready to receive connections.
+- **Transport service** - Pipecat has existing services for various different [media transport](/server/services/supported-services#transports) modes, such as WebRTC or WebSockets. If you're not using a third-party service for handling media transport, you'll want to make sure that infrastructure is hosted and ready to receive connections.
 
 - **Deployment target** - You can deploy and run Pipecat bots anywhere that can run Python code - Google Cloud Run, AWS, Fly.io etc. We recommend providers that offer APIs, so you can programmatically spawn new bot agents on-demand.
 


### PR DESCRIPTION
link should be `/docs/category/transports` ala [here](https://github.com/pipecat-ai/docs/blob/8be67e58228baf83fc0ff768b266ccc2f791b67f/guides/deployment/pattern.mdx?plain=1#L103)