### PR TITLE
Add `host` param for Mem0 memory

### DIFF
--- a/server/services/memory/mem0.mdx
+++ b/server/services/memory/mem0.mdx
@@ -29,6 +29,10 @@ You'll also need to set up your Mem0 API key as an environment variable: `MEM0_A
   Mem0 API key for accessing the service
 </ParamField>
 
+<ParamField path="host" type="str" required>
+  Mem0 host for accessing the service
+</ParamField>
+
 <ParamField path="user_id" type="str" optional>
   Unique identifier for the end user to associate with memories
 </ParamField>


### PR DESCRIPTION
Show support for `host` param while initializing Mem0 memory. 

Code changes: https://github.com/pipecat-ai/pipecat/pull/2199