### PR TITLE
SmallWebRTCTransport docs update

### DIFF
--- a/client/js/transports/small-webrtc.mdx
+++ b/client/js/transports/small-webrtc.mdx
@@ -7,10 +7,6 @@ description: "A lightweight WebRTC transport for peer-to-peer connections with P
 
 This transport is intended for lightweight implementations, particularly for local development and testing. It expects your Pipecat server to include the corresponding [`SmallWebRTCTransport` server-side](/server/services/transport/small-webrtc) implementation.
 
-<Warning>
-  `SmallWebRTCTransport` is best used for testing and development. For production deployments with scale, consider using the [DailyTransport](/client/js/transports/daily), as it has global, low-latency infrastructure.
-</Warning>
-
 ## Usage
 
 ### Basic Setup
@@ -20,7 +16,7 @@ import { PipecatClient } from "@pipecat-ai/client-js";
 import { SmallWebRTCTransport } from "@pipecat-ai/small-webrtc-transport";
 
 const pcClient = new PipecatClient({
-  transport: new SmallWebRTCTransport ({
+  transport: new SmallWebRTCTransport({
     // Optional configuration for the transport
     iceServers: ["stun:stun.l.google.com:19302"],
   }),
@@ -32,7 +28,7 @@ const pcClient = new PipecatClient({
 });
 
 await pcClient.connect({
-    endpoint: 'https://your-server/connect',
+  endpoint: "https://your-server/connect",
 });
 ```
 
@@ -62,22 +58,29 @@ transport.iceServers = [
   "stun:stun1.l.google.com:19302",
 ];
 ```
+
 </ParamField>
 
 <ParamField name="waitForICEGathering" type="boolean" default="false">
-  If `true`, the transport will wait for ICE gathering to complete before being considered `'connected'`.
+  If `true`, the transport will wait for ICE gathering to complete before being
+  considered `'connected'`.
 </ParamField>
 
 <ParamField name="connectionUrl" type="string">
-  URL of the WebRTC signaling server's offer endpoint. This endpoint may also be provided as part of the `connect()` either directly or as the response from a server-side endpoint you control. It should return an `answer` from your corresponding Pipecat server's `SmallWebRTCConnection`.
+  URL of the WebRTC signaling server's offer endpoint. This endpoint may also be
+  provided as part of the `connect()` either directly or as the response from a
+  server-side endpoint you control. It should return an `answer` from your
+  corresponding Pipecat server's `SmallWebRTCConnection`.
 </ParamField>
 
 <ParamField name="audioCodec" type="string">
-  Preferred audio codec to use. If not specified, your browser default will be used.
+  Preferred audio codec to use. If not specified, your browser default will be
+  used.
 </ParamField>
 
 <ParamField name="videoCodec" type="string">
-  Preferred video codec to use. If not specified, your browser default will be used.
+  Preferred video codec to use. If not specified, your browser default will be
+  used.
 </ParamField>
 
 ### TransportConnectionParams
@@ -121,6 +124,7 @@ async def offer(request: dict, background_tasks: BackgroundTasks):
 
     return answer
 ```
+
 </CodeGroup>
 
 ### Methods

--- a/server/services/transport/small-webrtc.mdx
+++ b/server/services/transport/small-webrtc.mdx
@@ -5,16 +5,15 @@ description: "A lightweight WebRTC transport for peer-to-peer audio and video co
 
 ## Overview
 
-`SmallWebRTCTransport` enables peer-to-peer WebRTC connections between clients and your Pipecat application. It implements bidirectional audio and video streaming using WebRTC for real-time communication.
+SmallWebRTCTransport enables peer-to-peer ("serverless") WebRTC connections between clients and your Pipecat application. It implements bidirectional audio, video and data channels using WebRTC for real-time communication. This transport is open source and self-contained, with no dependencies on any other infrastructure.
 
-This transport is intended for lightweight implementations, particularly for local development and testing. It expects your clients to include a corresponding `SmallWebRTCTransport` implementation. [See here](/client/js/transports/small-webrtc) for the JavaScript implementation.
+SmallWebRTCTransport is the default transport for the Pipecat examples and starter kits. It is heavily tested and can be used in production.
 
-<Warning>
-  `SmallWebRTCTransport` is best used for testing and development. For
-  production deployments with scale, consider using the
-  [DailyTransport](/server/services/transport/daily), as it has global,
-  low-latency infrastructure.
-</Warning>
+<Tip>
+  For detailed notes on how to decide between using the SmallWebRTCTransport or
+  other WebRTC transports like the DailyTransport, see [this
+  post](https://www.daily.co/blog/you-dont-need-a-webrtc-server-for-your-voice-agents/).
+</Tip>
 
 ## Installation
 


### PR DESCRIPTION
Removing warnings + new copy for the Pipecat transport.

@kwindla I call out the article as a <Tip> which makes it visually easier to find.