### PR TITLE
Update links to new docs repo

### DIFF
--- a/client/android/transports/daily.mdx
+++ b/client/android/transports/daily.mdx
@@ -51,7 +51,7 @@ Your server endpoint should return Daily-specific configuration:
         horizontal
         title="Demo"
         icon="play"
-        href="https://github.com/pipecat-ai/pipecat/tree/main/examples/simple-chatbot/client/android"
+        href="https://github.com/pipecat-ai/pipecat-examples/tree/main/simple-chatbot/client/android"
     >
         Simple Chatbot Demo
     </Card>
@@ -64,12 +64,13 @@ Your server endpoint should return Daily-specific configuration:
     >
         Client Transports
     </Card>
+
 </CardGroup>
 
 <Card
-    title="Daily Transport Reference"
-    icon="book-open"
-    href="https://docs-android.rtvi.ai/"
+  title="Daily Transport Reference"
+  icon="book-open"
+  href="https://docs-android.rtvi.ai/"
 >
   Complete API documentation for the Daily transport implementation
 </Card>

--- a/client/android/transports/small-webrtc.mdx
+++ b/client/android/transports/small-webrtc.mdx
@@ -40,7 +40,7 @@ client.start().withCallback {
     horizontal
     title="Demo"
     icon="play"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/p2p-webrtc/video-transform/client/android"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/p2p-webrtc/video-transform/client/android"
   >
     Demo App
   </Card>

--- a/client/introduction.mdx
+++ b/client/introduction.mdx
@@ -4,7 +4,15 @@ description: "Client libraries for building real-time AI applications with Pipec
 ---
 
 <Warning>
-  The Client SDKs are currently in transition to a new, simpler API design. The js and react libraries have already been deployed with these changes. Their corresponding documentation along with this top-level documentation has been updated to reflect the latest changes. For transitioning to the new API, please refer to the [migration guide](/client/migration-guide). Note that React Native, iOS, and Android SDKs are still in the process of being updated and their documentation will be updated once the new versions are released. If you have any questions or need assistance, please reach out to us on [Discord](https://discord.gg/pipecat).
+  The Client SDKs are currently in transition to a new, simpler API design. The
+  js and react libraries have already been deployed with these changes. Their
+  corresponding documentation along with this top-level documentation has been
+  updated to reflect the latest changes. For transitioning to the new API,
+  please refer to the [migration guide](/client/migration-guide). Note that
+  React Native, iOS, and Android SDKs are still in the process of being updated
+  and their documentation will be updated once the new versions are released. If
+  you have any questions or need assistance, please reach out to us on
+  [Discord](https://discord.gg/pipecat).
 </Warning>
 
 Pipecat provides client SDKs for multiple platforms, all implementing the RTVI (Real-Time Voice and Video Inference) standard. These SDKs make it easy to build real-time AI applications that can handle voice, video, and text interactions.
@@ -75,12 +83,15 @@ All Pipecat client SDKs provide:
 ## Core Types
 
 ### PipecatClient
+
 The main class for interacting with Pipecat bots. It is the primary type you will interact with.
 
 ### Transport
+
 The `PipecatClient` wraps a Transport, which defines and provides the underlying connection mechanism (e.g., WebSocket, WebRTC). Your Pipecat pipeline will contain a corresponding transport.
 
 ### RTVIMessage
+
 Represents a message sent to or received from a Pipecat bot.
 
 ## Simple Usage Examples
@@ -201,63 +212,72 @@ Represents a message sent to or received from a Pipecat bot.
 
   <CodeGroup>
 
-  ```javascript javascript
-  import { PipecatClient } from "@pipecat-ai/client-js";
+```javascript javascript
+import { PipecatClient } from "@pipecat-ai/client-js";
 
-  const pcClient = new PipecatClient({
-    transport: new DailyTransport(),
-    callbacks: {
-      onBotConnected: () => {
-        pcClient.sendClientRequest('get-language')
-          .then((response) => {
-            console.log("[CALLBACK] Bot using language:", response);
-            if (response !== preferredLanguage) {
-              pcClient.sendClientMessage('set-language', {language: preferredLanguage});
-            }
-          })
-          .catch((error) => {
-            console.error("[CALLBACK] Error getting language:", error);
-          });
-      },
-      onServerMessage: (message) => {
-        console.log("[CALLBACK] Received message from server:", message);
-      },
+const pcClient = new PipecatClient({
+  transport: new DailyTransport(),
+  callbacks: {
+    onBotConnected: () => {
+      pcClient
+        .sendClientRequest("get-language")
+        .then((response) => {
+          console.log("[CALLBACK] Bot using language:", response);
+          if (response !== preferredLanguage) {
+            pcClient.sendClientMessage("set-language", {
+              language: preferredLanguage,
+            });
+          }
+        })
+        .catch((error) => {
+          console.error("[CALLBACK] Error getting language:", error);
+        });
     },
-  });
-  await pcClient.connect({url: "https://your-daily-room-url", token: "your-daily-token"});
-  ```
+    onServerMessage: (message) => {
+      console.log("[CALLBACK] Received message from server:", message);
+    },
+  },
+});
+await pcClient.connect({
+  url: "https://your-daily-room-url",
+  token: "your-daily-token",
+});
+```
 
-  ```jsx react
-  // Example: Messaging in a React application
-  import { useCallback } from "react";
-  import { RTVIEvent, TransportState } from "@pipecat-ai/client-js";
-  import { usePipecatClient, useRTVIClientEvent } from "@pipecat-ai/client-react";
+```jsx react
+// Example: Messaging in a React application
+import { useCallback } from "react";
+import { RTVIEvent, TransportState } from "@pipecat-ai/client-js";
+import { usePipecatClient, useRTVIClientEvent } from "@pipecat-ai/client-react";
 
-  function EventListener() {
-    const pcClient = usePipecatClient();
-    useRTVIClientEvent(
-      RTVIEvent.BotConnected,
-      useCallback(() => {
-        pcClient.sendClientRequest('get-language')
-          .then((response) => {
-            console.log("[CALLBACK] Bot using language:", response);
-            if (response !== preferredLanguage) {
-              pcClient.sendClientMessage('set-language', {language: preferredLanguage});
-            }
-          })
-          .catch((error) => {
-            console.error("[CALLBACK] Error getting language:", error);
-          });
-      }, [])
-    );
-    useRTVIClientEvent(
-      RTVIEvent.ServerMessage,
-      useCallback((data) => {
-        console.log("[CALLBACK] Received message from server:", data);
-      }, [])
-    );
-  }
-  ```
+function EventListener() {
+  const pcClient = usePipecatClient();
+  useRTVIClientEvent(
+    RTVIEvent.BotConnected,
+    useCallback(() => {
+      pcClient
+        .sendClientRequest("get-language")
+        .then((response) => {
+          console.log("[CALLBACK] Bot using language:", response);
+          if (response !== preferredLanguage) {
+            pcClient.sendClientMessage("set-language", {
+              language: preferredLanguage,
+            });
+          }
+        })
+        .catch((error) => {
+          console.error("[CALLBACK] Error getting language:", error);
+        });
+    }, [])
+  );
+  useRTVIClientEvent(
+    RTVIEvent.ServerMessage,
+    useCallback((data) => {
+      console.log("[CALLBACK] Received message from server:", data);
+    }, [])
+  );
+}
+```
 
   </CodeGroup>
 
@@ -280,7 +300,7 @@ Get started by trying out examples:
   <Card
     title="Simple Chatbot Example"
     icon="robot"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/simple-chatbot"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/simple-chatbot"
   >
     Complete client-server example with both bot backend (Python) and frontend
     implementation (JS, React, React Native, iOS, and Android).
@@ -288,7 +308,7 @@ Get started by trying out examples:
   <Card
     title="More Examples"
     icon="code"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples"
+    href="https://github.com/pipecat-ai/pipecat-examples
   >
     Explore our full collection of example applications and implementations
     across different platforms and use cases.

--- a/client/ios/introduction.mdx
+++ b/client/ios/introduction.mdx
@@ -79,11 +79,7 @@ try await client.start()
 ## Documentation
 
 <CardGroup cols={2}>
-  <Card
-    title="API Reference"
-    icon="book"
-    href="https://docs-ios.pipecat.ai/"
-  >
+  <Card title="API Reference" icon="book" href="https://docs-ios.pipecat.ai/">
     Complete SDK API documentation
   </Card>
   <Card
@@ -100,15 +96,11 @@ try await client.start()
     horizontal
     title="Demo"
     icon="play"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/simple-chatbot/client/ios"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/simple-chatbot/client/ios"
   >
     Simple Chatbot Demo
   </Card>
-  <Card
-    title="Daily Transport"
-    icon="network-wired"
-    href="./transports/daily"
-  >
+  <Card title="Daily Transport" icon="network-wired" href="./transports/daily">
     WebRTC implementation using Daily
   </Card>
 </CardGroup>

--- a/client/ios/transports/daily.mdx
+++ b/client/ios/transports/daily.mdx
@@ -60,7 +60,7 @@ Your server endpoint should return Daily-specific configuration:
     horizontal
     title="Demo"
     icon="play"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/simple-chatbot/client/ios"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/simple-chatbot/client/ios"
   >
     Simple Chatbot Demo
   </Card>

--- a/client/js/transports/daily.mdx
+++ b/client/js/transports/daily.mdx
@@ -15,21 +15,21 @@ import { PipecatClient } from "@pipecat-ai/client-js";
 import { DailyTransport } from "@pipecat-ai/daily-transport";
 
 const pcClient = new PipecatClient({
-    transport: new DailyTransport ({
-      // DailyTransport constructor options
-      bufferLocalAudioUntilBotReady: true, // Optional, defaults to false
-      inputSettings: { video: { processor: {type: 'background-blur'}  } },
-    }),
-    enableCam: false,  // Default camera off
-    enableMic: true,   // Default microphone on
-    callbacks: {
-      // Event handlers
-    },
-    // ...
+  transport: new DailyTransport({
+    // DailyTransport constructor options
+    bufferLocalAudioUntilBotReady: true, // Optional, defaults to false
+    inputSettings: { video: { processor: { type: "background-blur" } } },
+  }),
+  enableCam: false, // Default camera off
+  enableMic: true, // Default microphone on
+  callbacks: {
+    // Event handlers
+  },
+  // ...
 });
 
 await pcClient.connect({
-    endpoint: 'https://your-server/connect',
+  endpoint: "https://your-server/connect",
 });
 ```
 
@@ -45,15 +45,18 @@ interface DailyTransportConstructorOptions extends DailyFactoryOptions {
 
 <ParamField path="bufferLocalAudioUntilBotReady" type="boolean" default="false" required="false">
 
-  If set to `true`, the transport will buffer local audio until the bot is ready. This is useful for ensuring that bot gets any audio from the user that started before the bot is ready to process it.
+If set to `true`, the transport will buffer local audio until the bot is ready. This is useful for ensuring that bot gets any audio from the user that started before the bot is ready to process it.
+
 </ParamField>
 
 <ParamField path="DailyFactoryOptions">
 
-  The `DailyTransportConstructorOptions` extends the `DailyFactoryOptions` type that is accepted by the underlying Daily instance. These options are passed directly through to the Daily constructor. See the [Daily API Reference](https://docs.daily.co/reference/daily-js/daily-call-client/properties) for a complete list of options.
+The `DailyTransportConstructorOptions` extends the `DailyFactoryOptions` type that is accepted by the underlying Daily instance. These options are passed directly through to the Daily constructor. See the [Daily API Reference](https://docs.daily.co/reference/daily-js/daily-call-client/properties) for a complete list of options.
 
 <Note>
-While you can provide the room url and optional token as part of your constructor options, the typical pattern is to provide them via a connection endpoint or directly as part of `connect()`. See below.
+  While you can provide the room url and optional token as part of your
+  constructor options, the typical pattern is to provide them via a connection
+  endpoint or directly as part of `connect()`. See below.
 </Note>
 
 </ParamField>
@@ -93,6 +96,7 @@ async def rtvi_connect(request: Request) -> Dict[Any, Any]:
     # Return the Daily call options in format expected by DailyTransport/Daily Call Object
     return {"url": room_url, "token": token}
 ```
+
 </CodeGroup>
 
 ### Methods
@@ -105,8 +109,8 @@ For most operations, you will not interact with the transport directly. Most met
 
   ```typescript
   pcClient.transport.preAuth({
-    url: 'https://your.daily.co/room',
-    token: 'your_token'
+    url: "https://your.daily.co/room",
+    token: "your_token",
   });
   const roomInfo = pcClient.transport.dailyCallClient.room();
   ```
@@ -130,7 +134,10 @@ const dailyCall = pcClient.transport.dailyCallClient;
 ```
 
 <Note>
-The Daily call client returned is safe-guarded to not allow you to call functions which affect the call's lifecycle and will redirect you to use either a Transport method or the `PipecatClient` to perform the equivalent action.
+  The Daily call client returned is safe-guarded to not allow you to call
+  functions which affect the call's lifecycle and will redirect you to use
+  either a Transport method or the `PipecatClient` to perform the equivalent
+  action.
 </Note>
 
 ## More Information
@@ -140,7 +147,7 @@ The Daily call client returned is safe-guarded to not allow you to call function
     horizontal
     title="Demo"
     icon="play"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/simple-chatbot"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/simple-chatbot"
   >
     Simple Chatbot Demo
   </Card>

--- a/client/js/transports/small-webrtc.mdx
+++ b/client/js/transports/small-webrtc.mdx
@@ -106,7 +106,7 @@ pcClient.connect({
 
 ```python server
 # See
-# https://github.com/pipecat-ai/pipecat/blob/main/examples/p2p-webrtc/video-transform/server/server.py
+# https://github.com/pipecat-ai/pipecat-examples/blob/main/p2p-webrtc/video-transform/server/server.py
 # for a complete example of how to implement the server-side endpoint.
 @app.post("/api/offer")
 async def offer(request: dict, background_tasks: BackgroundTasks):
@@ -177,7 +177,7 @@ The transport includes automatic reconnection logic:
     horizontal
     title="Video Transform Demo"
     icon="video"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/p2p-webrtc/video-transform"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/p2p-webrtc/video-transform"
   >
     Real-time video transformation example
   </Card>

--- a/client/js/transports/websocket.mdx
+++ b/client/js/transports/websocket.mdx
@@ -11,6 +11,7 @@ This transport is intended for lightweight implementations, particularly for loc
 The `WebSocketTransport` is best suited for server-server applications and prototyping client/server apps.
 
 For client/server production applications, we strongly recommend using a WebRTC-based transport for robust network and media handling. For more on WebRTC vs. Websocket communication, check out [this article](https://voiceaiandvoiceagents.com/#websockets-webrtc).
+
 </Warning>
 
 ## Usage
@@ -25,7 +26,7 @@ import {
 } from "@pipecat-ai/websocket-transport";
 
 const pcClient = new PipecatClient({
-  transport: new WebSocketTransport ({
+  transport: new WebSocketTransport({
     serializer: new ProtobufFrameSerializer(),
     recorderSampleRate: 8000,
     playerSampleRate: 8000,
@@ -38,7 +39,7 @@ const pcClient = new PipecatClient({
 });
 
 await pcClient.connect({
-    endpoint: 'https://your-server/connect',
+  endpoint: "https://your-server/connect",
 });
 ```
 
@@ -58,13 +59,21 @@ type WebSocketTransportOptions = {
 #### Properties
 
 <ParamField name="ws_url" type="string">
-  URL of the WebSocket server. This is the endpoint your client will connect to for WebSocket communication.
+  URL of the WebSocket server. This is the endpoint your client will connect to
+  for WebSocket communication.
 </ParamField>
 
-<ParamField name="serializer" type="WebSocketSerializer" default="ProtobufFrameSerializer">
-  The serializer to use for encoding/decoding messages sent over the WebSocket connection. The websocket-transport package provides two serializer options:
-  - `ProtobufFrameSerializer`: Uses Protocol Buffers for serialization.
-  - `TwilioSerializer`: Uses Twilio's serialization format. The main purpose of the TwilioSerializer is to allow testing the bots built to work with Twilio without having to make phone calls.
+<ParamField
+  name="serializer"
+  type="WebSocketSerializer"
+  default="ProtobufFrameSerializer"
+>
+  The serializer to use for encoding/decoding messages sent over the WebSocket
+  connection. The websocket-transport package provides two serializer options: -
+  `ProtobufFrameSerializer`: Uses Protocol Buffers for serialization. -
+  `TwilioSerializer`: Uses Twilio's serialization format. The main purpose of
+  the TwilioSerializer is to allow testing the bots built to work with Twilio
+  without having to make phone calls.
 </ParamField>
 
 <ParamField name="recorderSampleRate" type="number">
@@ -72,7 +81,8 @@ type WebSocketTransportOptions = {
 </ParamField>
 
 <ParamField name="playerSampleRate" type="number">
-  Sample rate for which to decode the incoming audio for output. Default is `24000`.
+  Sample rate for which to decode the incoming audio for output. Default is
+  `24000`.
 </ParamField>
 
 ### TransportConnectionParams
@@ -92,7 +102,7 @@ pcClient.connect({
 
 ```python server
 # See
-# https://github.com/pipecat-ai/pipecat/blob/main/examples/websocket/server/server.py
+# https://github.com/pipecat-ai/pipecat-examples/blob/main/websocket/server/server.py
 # for a complete example of how to implement the server-side endpoint.
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
@@ -112,7 +122,7 @@ async def bot_connect(request: Request) -> Dict[Any, Any]:
 
 ```python bot
 # See
-# https://github.com/pipecat-ai/pipecat/blob/main/examples/websocket/server/bot_websocket_server.py
+# https://github.com/pipecat-ai/pipecat-examples/blob/main/websocket/server/bot_websocket_server.py
 # for a complete example of a bot script using the WebSocketTransport.
 from pipecat.serializers.protobuf import ProtobufFrameSerializer
 from pipecat.transports.network.websocket_server import (
@@ -156,6 +166,7 @@ async def run_bot(websocket_client):
     )
     ...
 ```
+
 </CodeGroup>
 
 ### Methods
@@ -163,10 +174,14 @@ async def run_bot(websocket_client):
 For most operations, you will not interact with the transport directly. Most methods have an equivalent in the `PipecatClient` and should be called from the `PipecatClient`. However, there is one transport-specific methods that you may need to call directly. When doing so, be sure to access your transport via the `transport` property of the `PipecatClient` instance.
 
 <ResponseField name="handleUserAudioStream" type="method">
-  If implementing your own serializer, you will need to pass the user audio stream to the transport via this method, which takes an `ArrayBuffer` of audio data.
+  If implementing your own serializer, you will need to pass the user audio
+  stream to the transport via this method, which takes an `ArrayBuffer` of audio
+  data.
+
 ```javascript
 transport.handleUserAudioStream(chunk.data);
 ```
+
 </ResponseField>
 ## Events
 
@@ -183,7 +198,7 @@ The WebSocketTransport does provide reconnection handling. If the WebSocket conn
     horizontal
     title="WebSocket Demo"
     icon="video"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/websocket"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/websocket"
   >
     Basic Agent example using a WebSocket transport
   </Card>
@@ -191,7 +206,7 @@ The WebSocketTransport does provide reconnection handling. If the WebSocket conn
     horizontal
     title="Twilio Demo"
     icon="video"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/twilio-chatbot"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/twilio-chatbot"
   >
     Example using a WebSocket transport to simulate a Twilio connection to a bot
   </Card>

--- a/getting-started/next-steps.mdx
+++ b/getting-started/next-steps.mdx
@@ -12,7 +12,7 @@ After completing the quickstart, you're ready to explore more advanced Pipecat f
     title="Learn the Fundamentals"
     icon="school"
     iconType="duotone"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/foundational"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/foundational"
   >
     Master Pipecat's core concepts through progressive examples
   </Card>
@@ -20,7 +20,7 @@ After completing the quickstart, you're ready to explore more advanced Pipecat f
     title="Build Web Applications"
     icon="browser"
     iconType="duotone"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/simple-chatbot"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/simple-chatbot"
   >
     Create client/server voice applications with web interfaces
   </Card>
@@ -66,7 +66,7 @@ If you're new to Pipecat, we recommend exploring our foundational examples that 
   title="Foundational Examples Repository"
   icon="github"
   iconType="duotone"
-  href="https://github.com/pipecat-ai/pipecat/tree/main/examples/foundational"
+  href="https://github.com/pipecat-ai/pipecat-examples/tree/main/foundational"
 >
   A series of step-by-step examples that build upon each other to teach Pipecat
   fundamentals.
@@ -80,7 +80,7 @@ For building web-based conversational applications with separate client and serv
   title="Simple Chatbot Example"
   icon="comment-dots"
   iconType="duotone"
-  href="https://github.com/pipecat-ai/pipecat/tree/main/examples/simple-chatbot"
+  href="https://github.com/pipecat-ai/pipecat-examples/tree/main/simple-chatbot"
 >
   A complete client/server example demonstrating how to connect your Pipecat bot
   to JS, React, iOS, and Android clients.
@@ -95,7 +95,7 @@ To make your bots accessible via regular phone calls:
     title="Twilio Chatbot"
     icon="phone-office"
     iconType="duotone"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/twilio-chatbot"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/twilio-chatbot"
   >
     Build phone-accessible bots using Twilio's telephony platform
   </Card>
@@ -103,7 +103,7 @@ To make your bots accessible via regular phone calls:
     title="Telnyx Chatbot"
     icon="phone-volume"
     iconType="duotone"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/telnyx-chatbot"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/telnyx-chatbot"
   >
     Create voice bots using Telnyx's communication API
   </Card>
@@ -134,7 +134,7 @@ Get inspired by applications others have built with Pipecat:
     title="Storytelling Bot"
     icon="book-open"
     iconType="duotone"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/storytelling-chatbot"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/storytelling-chatbot"
   >
     AI-powered storyteller that creates and narrates interactive stories
   </Card>
@@ -142,7 +142,7 @@ Get inspired by applications others have built with Pipecat:
     title="Patient Intake System"
     icon="hospital-user"
     iconType="duotone"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/patient-intake"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/patient-intake"
   >
     Automated form-filling system for healthcare applications
   </Card>
@@ -150,7 +150,7 @@ Get inspired by applications others have built with Pipecat:
     title="StudyPal"
     icon="graduation-cap"
     iconType="duotone"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/studypal"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/studypal"
   >
     Interactive study assistant that helps with learning
   </Card>
@@ -158,7 +158,7 @@ Get inspired by applications others have built with Pipecat:
     title="Vision-enabled Bot"
     icon="image"
     iconType="duotone"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/moondream-chatbot"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/moondream-chatbot"
   >
     Multimodal assistant that can see and discuss images
   </Card>

--- a/getting-started/overview.mdx
+++ b/getting-started/overview.mdx
@@ -11,7 +11,7 @@ Pipecat is an open source Python framework that handles the complex orchestratio
   <Card
     title="Voice Assistants"
     icon="microphone"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/simple-chatbot">
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/simple-chatbot">
     Natural, real-time conversations with AI using speech recognition and
     synthesis
   </Card>
@@ -19,7 +19,7 @@ Pipecat is an open source Python framework that handles the complex orchestratio
 <Card
   title="Interactive Agents"
   icon="robot"
-  href="https://github.com/pipecat-ai/pipecat/tree/main/examples/studypal"
+  href="https://github.com/pipecat-ai/pipecat-examples/tree/main/studypal"
 >
   Personal coaches and meeting assistants that can understand context and
   provide guidance
@@ -28,7 +28,7 @@ Pipecat is an open source Python framework that handles the complex orchestratio
 <Card
   title="Multimodal Apps"
   icon="layer-group"
-  href="https://github.com/pipecat-ai/pipecat/tree/main/examples/moondream-chatbot"
+  href="https://github.com/pipecat-ai/pipecat-examples/tree/main/moondream-chatbot"
 >
   Applications that combine voice, video, images, and text for rich interactions
 </Card>
@@ -36,7 +36,7 @@ Pipecat is an open source Python framework that handles the complex orchestratio
 <Card
   title="Creative Tools"
   icon="wand-magic-sparkles"
-  href="https://github.com/pipecat-ai/pipecat/tree/main/examples/storytelling-chatbot"
+  href="https://github.com/pipecat-ai/pipecat-examples/tree/main/storytelling-chatbot"
 >
   Storytelling experiences and social companions that engage users
 </Card>
@@ -44,7 +44,7 @@ Pipecat is an open source Python framework that handles the complex orchestratio
 <Card
   title="Business Solutions"
   icon="building"
-  href="https://github.com/pipecat-ai/pipecat/tree/main/examples/patient-intake"
+  href="https://github.com/pipecat-ai/pipecat-examples/tree/main/patient-intake"
 >
   Customer intake flows and support bots for automated business processes
 </Card>

--- a/getting-started/quickstart.mdx
+++ b/getting-started/quickstart.mdx
@@ -61,9 +61,9 @@ curl.exe -O https://raw.githubusercontent.com/pipecat-ai/pipecat/main/examples/f
   <Tab title="Manual Download">
   Download these files and save them to your project directory:
 
-  - [01-say-one-thing.py](https://github.com/pipecat-ai/pipecat/blob/main/examples/foundational/01-say-one-thing.py)
-  - [requirements.txt](https://github.com/pipecat-ai/pipecat/blob/main/examples/foundational/requirements.txt)
-  </Tab>
+- [01-say-one-thing.py](https://github.com/pipecat-ai/pipecat/blob/main/examples/foundational/01-say-one-thing.py)
+- [requirements.txt](https://github.com/pipecat-ai/pipecat/blob/main/examples/foundational/requirements.txt)
+    </Tab>
 </Tabs>
 
 ### Install dependencies
@@ -94,9 +94,10 @@ echo CARTESIA_API_KEY=your_cartesia_api_key > .env
   <Tab title="Manual Method">
   Create a file named `.env` in your project directory and add:
 
-  ```env
-  CARTESIA_API_KEY=your_cartesia_api_key
-  ```
+```env
+CARTESIA_API_KEY=your_cartesia_api_key
+```
+
   </Tab>
 </Tabs>
 
@@ -202,7 +203,7 @@ Try these simple modifications to enhance your bot:
     title="Try more examples"
     icon="code"
     iconType="duotone"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples"
+    href="https://github.com/pipecat-ai/pipecat-examples
   >
     Explore our GitHub repository with more sophisticated examples
   </Card>

--- a/guides/deployment/fly.mdx
+++ b/guides/deployment/fly.mdx
@@ -21,7 +21,7 @@ You can find instructions for creating and setting up your fly account [here](ht
 
 <Note>
   We have created a template project
-  [here](https://github.com/pipecat-ai/pipecat/tree/main/examples/deployment/flyio-example)
+  [here](https://github.com/pipecat-ai/pipecat-examples/tree/main/deployment/flyio-example)
   which you can clone. Since we're targeting production use-cases, this example
   uses Daily (WebRTC) as a transport, but you can configure your bot however you
   like.

--- a/guides/deployment/modal.mdx
+++ b/guides/deployment/modal.mdx
@@ -10,7 +10,7 @@ This guide walks through the Modal example included in the Pipecat repository, w
 <Card
   title="Modal example"
   icon="github"
-  href="https://github.com/pipecat-ai/pipecat/tree/main/examples/deployment/modal-example"
+  href="https://github.com/pipecat-ai/pipecat-examples/tree/main/deployment/modal-example"
 >
   View the complete Modal deployment example in our GitHub repository
 </Card>
@@ -105,7 +105,7 @@ Simply click on the URL displayed after running the server or deploy step to lau
 
 ### Option 2: Connect via an RTVI Client
 
-Follow the instructions provided in the [client folder's README](https://github.com/pipecat-ai/pipecat/blob/main/examples/deployment/modal-example/client/javascript/README.md) for building and running a custom client that connects to your Modal endpoint. The provided client includes a dropdown for choosing which bot pipeline to run.
+Follow the instructions provided in the [client folder's README](https://github.com/pipecat-ai/pipecat-examples/tree/main/deployment/modal-example/client/javascript) for building and running a custom client that connects to your Modal endpoint. The provided client includes a dropdown for choosing which bot pipeline to run.
 
 ## Navigating your LLM, server, and Pipecat logs
 

--- a/guides/deployment/overview.mdx
+++ b/guides/deployment/overview.mdx
@@ -10,7 +10,7 @@ You've created your Pipecat bot, had a good chat with it locally, and are eager 
 <Note>
   We're continually adding further deployment example projects to the Pipecat
   repo, which you can find
-  [here](https://github.com/pipecat-ai/pipecat/tree/main/examples/deployment).
+  [here](https://github.com/pipecat-ai/pipecat-examples/tree/main/deployment).
 </Note>
 
 ### Deployment options

--- a/guides/features/gemini-multimodal-live.mdx
+++ b/guides/features/gemini-multimodal-live.mdx
@@ -17,7 +17,7 @@ This guide will walk you through building a real-time AI chatbot using Gemini Mu
   <Card
     title="Example Code"
     icon="code"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/simple-chatbot"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/simple-chatbot"
   >
     Find the complete client and server code in Github
   </Card>
@@ -449,7 +449,7 @@ function ChatApp() {
 
 <Note>
   Check out the [example
-  repository](https://github.com/pipecat-ai/pipecat/tree/main/examples/simple-chatbot)
+  repository](https://github.com/pipecat-ai/pipecat-examples/tree/main/simple-chatbot)
   for a complete client implementation with styling and error handling.
 </Note>
 
@@ -513,7 +513,7 @@ Now that you have a working chatbot, consider these enhancements:
   <Card
     title="Simple Chatbot"
     icon="robot"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/simple-chatbot"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/simple-chatbot"
   >
     A complete client/server implementation showing how to build a Pipecat JS or React client that connects to a Gemini Live Pipecat bot
   </Card>

--- a/guides/telephony/daily-webrtc.mdx
+++ b/guides/telephony/daily-webrtc.mdx
@@ -11,7 +11,7 @@ description: "Call your Pipecat bot using Daily WebRTC"
 <Card
   title="Prefer to look at code? See the example project!"
   icon="code"
-  href="https://github.com/pipecat-ai/pipecat/tree/main/examples/phone-chatbot"
+  href="https://github.com/pipecat-ai/pipecat-examples/tree/main/phone-chatbot"
 >
   We have a complete dialin-ready project using Daily as both a transport and
   PSTN/SIP provider in the Pipecat repo. This guide referencse the project and
@@ -74,7 +74,7 @@ except Exception:
 
 <Note>
   Full bot source code
-  [here](https://github.com/pipecat-ai/pipecat/blob/main/examples/phone-chatbot/bot_daily.py)
+  [here](https://github.com/pipecat-ai/pipecat-examples/tree/main/phone-chatbot/daily-pstn-dial-in)
 </Note>
 
 ### Orchestrating incoming calls

--- a/guides/telephony/twilio-daily-webrtc.mdx
+++ b/guides/telephony/twilio-daily-webrtc.mdx
@@ -12,7 +12,7 @@ description: "Connect phone calls to your Pipecat bot using Twilio and Daily's S
 <Card
   title="Prefer to look at code? See the example project!"
   icon="code"
-  href="https://github.com/pipecat-ai/pipecat/tree/main/examples/phone-chatbot-daily-twilio-sip"
+  href="https://github.com/pipecat-ai/pipecat-examples/tree/main/phone-chatbot-daily-twilio-sip"
 >
   We have a complete example project using Daily as a transport with Twilio as a
   phone provider. This guide walks through the important components and best

--- a/guides/telephony/twilio-websockets.mdx
+++ b/guides/telephony/twilio-websockets.mdx
@@ -14,7 +14,7 @@ This guide walks through creating a voice AI agent that users can reach by diali
 <Card
   title="Complete example code on GitHub"
   icon="code"
-  href="https://github.com/pipecat-ai/pipecat/tree/main/examples/twilio-chatbot"
+  href="https://github.com/pipecat-ai/pipecat-examples/tree/main/twilio-chatbot"
 >
   The full source code for this example is available in the Pipecat repository.
 </Card>
@@ -330,7 +330,7 @@ proc = subprocess.Popen(
   <Card
     title="Try the complete example"
     icon="code"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/twilio-chatbot"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/twilio-chatbot"
   >
     Clone the full working Twilio chatbot example from GitHub and run it
     yourself.

--- a/mint.json
+++ b/mint.json
@@ -66,7 +66,7 @@
     {
       "name": "Examples",
       "icon": "code",
-      "url": "https://github.com/pipecat-ai/pipecat/tree/main/examples"
+      "url": "https://github.com/pipecat-ai/pipecat-examples"
     },
     {
       "name": "Changelog",

--- a/server/frameworks/rtvi/google-rtvi-observer.mdx
+++ b/server/frameworks/rtvi/google-rtvi-observer.mdx
@@ -25,7 +25,7 @@ The `GoogleRTVIObserver` extends the [base `RTVIObserver` type](./rtvi-observer)
   <Card
     title="Example Code"
     icon="play"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/news-chatbot"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/news-chatbot"
   >
     Working example using Google's search grounding to ask about current events
   </Card>

--- a/server/services/s2s/gemini.mdx
+++ b/server/services/s2s/gemini.mdx
@@ -441,7 +441,7 @@ llm = GeminiMultimodalLiveLLMService(
 - [Foundational Example](https://github.com/pipecat-ai/pipecat/blob/main/examples/foundational/26a-gemini-multimodal-live-transcription.py)
   Basic implementation showing core features and transcription
 
-- [Simple Chatbot](https://github.com/pipecat-ai/pipecat/tree/main/examples/simple-chatbot)
+- [Simple Chatbot](https://github.com/pipecat-ai/pipecat-examples/tree/main/simple-chatbot)
   A client/server example showing how to build a Pipecat JS or React client that connects to a Gemini Live Pipecat bot.
 
 ### Learn More

--- a/server/services/serializers/plivo.mdx
+++ b/server/services/serializers/plivo.mdx
@@ -171,6 +171,6 @@ To enable audio streaming with Plivo, you'll need to configure your Plivo applic
 
 <Note>
   See the [Plivo Chatbot
-  example](https://github.com/pipecat-ai/pipecat/tree/main/examples/plivo-chatbot)
+  example](https://github.com/pipecat-ai/pipecat-examples/tree/main/plivo-chatbot)
   for a complete implementation.
 </Note>

--- a/server/services/serializers/telnyx.mdx
+++ b/server/services/serializers/telnyx.mdx
@@ -160,6 +160,6 @@ async def websocket_endpoint(websocket: WebSocket):
 
 <Note>
   See the [Telnyx Chatbot
-  example](https://github.com/pipecat-ai/pipecat/tree/main/examples/telnyx-chatbot)
+  example](https://github.com/pipecat-ai/pipecat-examples/tree/main/telnyx-chatbot)
   for a complete implementation.
 </Note>

--- a/server/services/serializers/twilio.mdx
+++ b/server/services/serializers/twilio.mdx
@@ -143,6 +143,6 @@ async def websocket_endpoint(websocket: WebSocket):
 
 <Note>
   See the [Twilio Chatbot
-  example](https://github.com/pipecat-ai/pipecat/tree/main/examples/twilio-chatbot)
+  example](https://github.com/pipecat-ai/pipecat-examples/tree/main/twilio-chatbot)
   for a complete implementation.
 </Note>

--- a/server/services/transport/fastapi-websocket.mdx
+++ b/server/services/transport/fastapi-websocket.mdx
@@ -137,7 +137,7 @@ async def websocket_endpoint(websocket: WebSocket):
 
 <Tip>
   Check out the [Twilio Chatbot
-  example](https://github.com/pipecat-ai/pipecat/tree/main/examples/twilio-chatbot)
+  example](https://github.com/pipecat-ai/pipecat-examples/tree/main/twilio-chatbot)
   to see how to use the FastAPI transport in a phone application.
 </Tip>
 

--- a/server/services/transport/small-webrtc.mdx
+++ b/server/services/transport/small-webrtc.mdx
@@ -472,14 +472,14 @@ To see a complete implementation, check out the following examples:
   <Card
     title="Video Transform"
     icon="camera"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/p2p-webrtc/video-transform"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/p2p-webrtc/video-transform"
   >
     Demonstrates real-time video processing using WebRTC transport
   </Card>
   <Card
     title="Voice Agent"
     icon="microphone"
-    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/p2p-webrtc/voice-agent"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/p2p-webrtc/voice-agent"
   >
     Implements a voice assistant using WebRTC for audio communication
   </Card>

--- a/server/services/transport/websocket-server.mdx
+++ b/server/services/transport/websocket-server.mdx
@@ -128,7 +128,7 @@ pipeline = Pipeline([
 
 <Tip>
   Check out the [Websocket Server
-  example](https://github.com/pipecat-ai/pipecat/tree/main/examples/websocket-server)
+  example](https://github.com/pipecat-ai/pipecat-examples/tree/main/websocket-server)
   to see how to use this transport in a pipeline.
 </Tip>
 

--- a/server/utilities/opentelemetry.mdx
+++ b/server/utilities/opentelemetry.mdx
@@ -78,8 +78,8 @@ task = PipelineTask(
 <Info>
 For complete working examples, see our sample implementations:
 
-- [Jaeger Tracing Example](https://github.com/pipecat-ai/pipecat/tree/main/examples/open-telemetry/jaeger) - Uses gRPC exporter with Jaeger
-- [Langfuse Tracing Example](https://github.com/pipecat-ai/pipecat/tree/main/examples/open-telemetry/langfuse) - Uses HTTP exporter with Langfuse for LLM-focused observability
+- [Jaeger Tracing Example](https://github.com/pipecat-ai/pipecat-examples/tree/main/open-telemetry/jaeger) - Uses gRPC exporter with Jaeger
+- [Langfuse Tracing Example](https://github.com/pipecat-ai/pipecat-examples/tree/main/open-telemetry/langfuse) - Uses HTTP exporter with Langfuse for LLM-focused observability
 
 </Info>
 
@@ -149,7 +149,7 @@ exporter = OTLPSpanExporter(
 )
 ```
 
-See our [Langfuse example](https://github.com/pipecat-ai/pipecat/tree/main/examples/open-telemetry/langfuse) for details on configuring this exporter.
+See our [Langfuse example](https://github.com/pipecat-ai/pipecat-examples/tree/main/open-telemetry/langfuse) for details on configuring this exporter.
 
 ### Console Exporter (for debugging)
 
@@ -310,7 +310,11 @@ The total time spent processing in each service is captured in the span duration
   Custom ID for the conversation. If not provided, a UUID will be generated
 </ParamField>
 
-<ParamField path="additional_span_attributes" type="Optional[dict]" default="None">
+<ParamField
+  path="additional_span_attributes"
+  type="Optional[dict]"
+  default="None"
+>
   Any additional attributes to add to top-level OpenTelemetry conversation span.
 </ParamField>
 

--- a/server/utilities/serializers/plivo.mdx
+++ b/server/utilities/serializers/plivo.mdx
@@ -171,6 +171,6 @@ To enable audio streaming with Plivo, you'll need to configure your Plivo applic
 
 <Note>
   See the [Plivo Chatbot
-  example](https://github.com/pipecat-ai/pipecat/tree/main/examples/plivo-chatbot)
+  example](https://github.com/pipecat-ai/pipecat-examples/tree/main/plivo-chatbot)
   for a complete implementation.
 </Note>

--- a/server/utilities/serializers/telnyx.mdx
+++ b/server/utilities/serializers/telnyx.mdx
@@ -160,6 +160,6 @@ async def websocket_endpoint(websocket: WebSocket):
 
 <Note>
   See the [Telnyx Chatbot
-  example](https://github.com/pipecat-ai/pipecat/tree/main/examples/telnyx-chatbot)
+  example](https://github.com/pipecat-ai/pipecat-examples/tree/main/telnyx-chatbot)
   for a complete implementation.
 </Note>

--- a/server/utilities/serializers/twilio.mdx
+++ b/server/utilities/serializers/twilio.mdx
@@ -143,6 +143,6 @@ async def websocket_endpoint(websocket: WebSocket):
 
 <Note>
   See the [Twilio Chatbot
-  example](https://github.com/pipecat-ai/pipecat/tree/main/examples/twilio-chatbot)
+  example](https://github.com/pipecat-ai/pipecat-examples/tree/main/twilio-chatbot)
   for a complete implementation.
 </Note>


### PR DESCRIPTION
Updating examples due to the new pipecat-examples repo.

Also: https://github.com/pipecat-ai/pipecat/pull/2290 removes examples, so this is required.