### PR TITLE
Updated docs for Speechmatics

### DIFF
--- a/server/services/stt/speechmatics.mdx
+++ b/server/services/stt/speechmatics.mdx
@@ -65,7 +65,6 @@ You'll also need to set up your Speechmatics API key as an environment variable:
 
 - `InterimTranscriptionFrame` - Real-time transcription updates
 - `TranscriptionFrame` - Final transcription results
-- `ErrorFrame` - Connection or processing errors
 
 ## Endpoints
 

--- a/server/services/stt/speechmatics.mdx
+++ b/server/services/stt/speechmatics.mdx
@@ -58,8 +58,6 @@ You'll also need to set up your Speechmatics API key as an environment variable:
 ### Input
 
 - `InputAudioRawFrame` - Raw PCM audio data (16-bit, 16kHz, mono)
-- `STTUpdateSettingsFrame` - Runtime transcription configuration updates
-- `STTMuteFrame` - Mute audio input for transcription
 
 ### Output
 

--- a/server/services/stt/speechmatics.mdx
+++ b/server/services/stt/speechmatics.mdx
@@ -155,48 +155,6 @@ Setting a language can be done using the `language` parameter when creating the 
 | `Language.VI`  | Vietnamese         | -                         | -              |
 | `Language.CY`  | Welsh              | -                         | -              |
 
-### Translation Support
-
-Speechmatics supports the translation of transcribed output into the following languages:
-
-| Language Code  | Description |
-| -------------- | ----------- |
-| `Language.BG`  | Bulgarian   |
-| `Language.CA`  | Catalan     |
-| `Language.CMN` | Mandarin    |
-| `Language.CS`  | Czech       |
-| `Language.DA`  | Danish      |
-| `Language.DE`  | German      |
-| `Language.EL`  | Greek       |
-| `Language.EN`  | English     |
-| `Language.ES`  | Spanish     |
-| `Language.ET`  | Estonian    |
-| `Language.FI`  | Finnish     |
-| `Language.FR`  | French      |
-| `Language.GL`  | Galician    |
-| `Language.HI`  | Hindi       |
-| `Language.HR`  | Croatian    |
-| `Language.HU`  | Hungarian   |
-| `Language.ID`  | Indonesian  |
-| `Language.IT`  | Italian     |
-| `Language.JA`  | Japanese    |
-| `Language.KO`  | Korean      |
-| `Language.LT`  | Lithuanian  |
-| `Language.LV`  | Latvian     |
-| `Language.MS`  | Malay       |
-| `Language.NL`  | Dutch       |
-| `Language.NO`  | Norwegian   |
-| `Language.PL`  | Polish      |
-| `Language.PT`  | Portuguese  |
-| `Language.RO`  | Romanian    |
-| `Language.RU`  | Russian     |
-| `Language.SK`  | Slovakian   |
-| `Language.SL`  | Slovenian   |
-| `Language.SV`  | Swedish     |
-| `Language.TR`  | Turkish     |
-| `Language.UK`  | Ukrainian   |
-| `Language.VI`  | Vietnamese  |
-
 ## Speaker Diarization
 
 Speechmatics STT supports speaker diarization, which separates out different speakers in the audio. The identity of each speaker is returned in the TranscriptionFrame objects in the `user_id` attribute.


### PR DESCRIPTION
Adjustment to the documentation:
- Removal of translation information, as this is not support in the plugin
- Updated references to supported input frames