### PR TITLE
Improve quickstart wording

### DIFF
--- a/getting-started/quickstart.mdx
+++ b/getting-started/quickstart.mdx
@@ -119,9 +119,11 @@ You should see output similar to this:
 
 ### 5. Connect and test
 
-Open your browser and navigate to **http://localhost:7860/client**. You'll see a `Connect` button in the upper righthand corner. Click `Connect` and allow microphone access when prompted by your browser.
+**Open http://localhost:7860/client in your browser**. You'll see the Voice UI Kit console interface with a connect button in the upper right corner.
 
-You're now connected to your Pipecat bot! The bot will greet you and you can start talking to it. When you're finished, click `Disconnect` or close the browser tab to end the session. You can also stop the bot by pressing `Ctrl+C` in your terminal.
+Click **Connect** and allow microphone access when prompted. The console will establish a connection to your bot server and you can start having a voice conversation!
+
+When you're finished, click **Disconnect** or close the browser tab to end the session. You can also stop the bot by pressing **Ctrl+C** in your terminal.
 
 ## Understanding the Quickstart Bot
 

--- a/getting-started/quickstart.mdx
+++ b/getting-started/quickstart.mdx
@@ -111,17 +111,17 @@ You should see output similar to this:
    Open this URL in your browser to connect!
 ```
 
+<Note>
+  **First run timing**: The initial startup may take around 15 seconds as
+  Pipecat downloads required models like the Silero VAD (Voice Activity
+  Detection) model. Subsequent runs will be much faster.
+</Note>
+
 ### 5. Connect and test
 
 Open your browser and navigate to **http://localhost:7860/client**. You'll see a `Connect` button in the upper righthand corner. Click `Connect` and allow microphone access when prompted by your browser.
 
 You're now connected to your Pipecat bot! The bot will greet you and you can start talking to it. When you're finished, click `Disconnect` or close the browser tab to end the session. You can also stop the bot by pressing `Ctrl+C` in your terminal.
-
-<Note>
-  **First run timing**: The initial startup may take 10-15 seconds as Pipecat
-  downloads required models like the Silero VAD (Voice Activity Detection)
-  model. Subsequent runs will be much faster.
-</Note>
 
 ## Understanding the Quickstart Bot
 


### PR DESCRIPTION
This was in the wrong place before.

Also, improving the wording in the "Connect and test" section. It was too wordy before.