### PR TITLE
Add documentation for device errors and update transport constructors…

### DIFF
--- a/client/js/api-reference/callbacks.mdx
+++ b/client/js/api-reference/callbacks.mdx
@@ -109,6 +109,10 @@ pcClient.on(RTVIEvent.BotReady, () => console.log("Bot ready via event"));
   User selected a new speaker as their selected/active device.
 </ParamField>
 
+<ParamField path="onDeviceError" type="error:DeviceError">
+  Error related to media devices, such as camera or microphone issues. This could be due to permissions, device unavailability, or other related problems. See the [DeviceError](errors#deviceerror) section for more details about the return type.
+</ParamField>
+
 <ParamField
   path="onTrackStarted"
   type="track: MediaStreamTrack, participant:Participant"
@@ -304,6 +308,8 @@ Here's the complete reference mapping events to their corresponding callbacks:
 | `AvailableCamsUpdated` | `onAvailableCamsUpdated` | `MediaDeviceInfo[]`             |
 | `MicUpdated`           | `onMicUpdated`           | `MediaDeviceInfo`               |
 | `CamUpdated`           | `onCamUpdated`           | `MediaDeviceInfo`               |
+| `SpeakerUpdated`       | `onSpeakerUpdated`       | `MediaDeviceInfo`               |
+| `DeviceError`          | `onDeviceError`          | `DeviceError`                   |
 
 ### Audio Activity Events
 

--- a/client/js/api-reference/errors.mdx
+++ b/client/js/api-reference/errors.mdx
@@ -44,6 +44,28 @@ Emitted when the Transport is not able to connect. You may need to check the con
 
 Emitted when the client attempts to perform an action or method that requires the bot to be in a ready state, but the bot is not ready. You must call `connect()` first and wait for the bot to be ready before performing such actions.
 
+### DeviceError
+
+Emitted when there is an issue with acquiring or using a media device, such as a camera or microphone. This could be due to permissions issues, device unavailability, or other related problems.
+
+<ParamField path="devices" type="array<'cam' | 'mic' | 'speaker'>" required="true">
+List of media devices, `'cam'`, `'mic'`, and/or `'speaker'`, that are unavailable or could not be accessed.
+</ParamField>
+
+<ParamField path="type" type="string" required="true">
+The `type` field will indicate what type of device error occurred. Options include:
+  - `"in-use"`: A device is currently in use by another application and cannot be accessed. *windows only*
+  - `"permissions"`: The user has not granted permission to access the media device.
+  - `"undefined-mediadevices"`: `getUserMedia()` is not an available API on the current platform or browser.
+  - `"not-found"`: The specified media device could not be found.
+  - `"constraints"`: The media device could not be configured with the specified constraints.
+  - `"unknown"`: An unknown error occurred while accessing the media device.
+</ParamField>
+
+<ParamField path="details" type="object" required="false">
+Additional details about the device error, if available.
+</ParamField>
+
 ### UnsupportedFeatureError
 
 Not all Transports are created equal, and some may not support certain features. This error is thrown when a feature is requested that the current Transport does not support.

--- a/client/js/transports/small-webrtc.mdx
+++ b/client/js/transports/small-webrtc.mdx
@@ -43,6 +43,7 @@ interface SmallWebRTCTransportConstructorOptions {
   connectionUrl?: string;
   audioCodec?: string;
   videoCodec?: string;
+  mediaManager?: MediaManager;
 }
 ```
 
@@ -81,6 +82,10 @@ transport.iceServers = [
 <ParamField name="videoCodec" type="string">
   Preferred video codec to use. If not specified, your browser default will be
   used.
+</ParamField>
+
+<ParamField name="mediaManager" type="MediaManager" default="DailyMediaManager">
+  The media manager to use for handling local audio and video streams. This should not be overridden unless you have a specific reason to use a different media manager. The default is `DailyMediaManager`, which is suitable for most use cases. Note that the `DailyMediaManager` does not use any of Daily's services, it simply takes advantage of vast media support provided by the Daily library.
 </ParamField>
 
 ### TransportConnectionParams

--- a/client/js/transports/websocket.mdx
+++ b/client/js/transports/websocket.mdx
@@ -53,6 +53,11 @@ type WebSocketTransportOptions = {
   recorderSampleRate?: number;
   playerSampleRate?: number;
 };
+
+export interface WebSocketTransportConstructorOptions
+  extends WebSocketTransportOptions {
+  mediaManager?: MediaManager;
+}
 ```
 
 #### Properties
@@ -73,6 +78,10 @@ type WebSocketTransportOptions = {
 
 <ParamField name="playerSampleRate" type="number">
   Sample rate for which to decode the incoming audio for output. Default is `24000`.
+</ParamField>
+
+<ParamField name="mediaManager" type="MediaManager" default="DailyMediaManager">
+  The media manager to use for handling local audio and video streams. This should not be overridden unless you have a specific reason to use a different media manager. The default is `DailyMediaManager`, which is suitable for most use cases. Note that the `DailyMediaManager` does not use any of Daily's services, it simply takes advantage of vast media support provided by the Daily library.
 </ParamField>
 
 ### TransportConnectionParams


### PR DESCRIPTION
… that now take an optional media manager

Draft because this should not go in until these PRs (https://github.com/pipecat-ai/pipecat-client-web/pull/134 & https://github.com/pipecat-ai/pipecat-client-web-transports/pull/51) have been released