### PR TITLE
fix smart turn example imports

### DIFF
--- a/server/utilities/smart-turn/smart-turn-overview.mdx
+++ b/server/utilities/smart-turn/smart-turn-overview.mdx
@@ -225,7 +225,7 @@ The `LocalSmartTurnAnalyzerV2` runs inference locally using PyTorch and Hugging 
 
 ```python
 import os
-from pipecat.audio.turn.smart_turn.local_smart_turn import LocalSmartTurnAnalyzerV2
+from pipecat.audio.turn.smart_turn.local_smart_turn_v2 import LocalSmartTurnAnalyzerV2
 from pipecat.audio.turn.smart_turn.base_smart_turn import SmartTurnParams
 from pipecat.transports.base_transport import TransportParams
 


### PR DESCRIPTION
found correct imports [here](https://github.com/kwindla/macos-local-voice-agents/blob/main/server/bot.py) and verified them locally