### PR TITLE
Add GCP and AWS ECR deployment documentation to README

### DIFF
--- a/deployment/pipecat-cloud/fundamentals/deploy.mdx
+++ b/deployment/pipecat-cloud/fundamentals/deploy.mdx
@@ -65,6 +65,176 @@ pcc agent status my-first-agent
 
 If a deployment was successful and ready to be started, you should see a `ready` status.
 
+## Private Container Registry Deployments
+
+When using private container registries, you'll need to configure image pull secrets to authenticate with your registry. Below are guides for the most common cloud platforms.
+
+### GCP Artifact Registry
+
+For GCP Artifact Registry, you can use a service account JSON key to authenticate:
+
+```bash
+# First, authenticate Docker with your service account key
+cat key-file.json | docker login -u _json_key --password-stdin https://LOCATION-docker.pkg.dev
+
+# Create image credentials in Pipecat Cloud using the same service account
+pcc image-credentials create my-gcp-credentials \
+  --registry https://LOCATION-docker.pkg.dev \
+  --username _json_key \
+  --password "$(cat key-file.json)"
+```
+
+Replace:
+
+- `LOCATION` with your Artifact Registry location (e.g., `us-central1`, `asia-east1`)
+- `key-file.json` with the path to your service account JSON key file
+
+Reference the image credentials in your `pcc-deploy.toml` file:
+
+```toml
+agent_name = "my-first-agent"
+image = "LOCATION-docker.pkg.dev/PROJECT-ID/REPO-NAME/my-first-agent:0.1"
+secret_set = "my-first-agent-secrets"
+image_credentials = "my-gcp-credentials"
+
+[scaling]
+    min_instances = 0
+```
+
+Or specify it directly in the CLI:
+
+```bash
+pcc deploy my-first-agent LOCATION-docker.pkg.dev/PROJECT-ID/REPO-NAME/my-first-agent:0.1 \
+  --secret-set my-first-agent-secrets \
+  --image-credentials my-gcp-credentials
+```
+
+<Note>
+  The service account used for image credentials should have the `Artifact
+  Registry Reader` role or equivalent permissions to pull images from your
+  private repository.
+</Note>
+
+### AWS ECR
+
+If you're using AWS ECR with private repositories for Pipecat Cloud deployments, you'll need to configure image pull secrets to authenticate with your registry. ECR tokens expire every 12 hours, so you'll also need to set up automatic token refresh.
+
+Build and tag your Docker image, then push to ECR:
+
+```bash
+# Build and tag your image
+docker build --platform=linux/arm64 -t my-agent:latest .
+docker tag my-agent:latest <aws_account_id>.dkr.ecr.<region>.amazonaws.com/your-repo:tag
+
+# Push to ECR
+docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/your-repo:tag
+```
+
+<Note>
+  Pipecat Cloud may pull your image on deploy and again during scale-outs, so
+  credentials must be valid whenever new pods start.
+</Note>
+
+Use the Pipecat Cloud REST API to store your ECR registry credentials:
+
+```bash
+# Get ECR login token
+ECR_TOKEN=$(aws ecr get-login-password --region <region>)
+
+# Create image pull secret using REST API
+curl --request PUT \
+  --url https://api.pipecat.daily.co/v1/secrets/my-ecr-credentials \
+  --header 'Authorization: Bearer <your-private-api-token>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "secrets": [
+      {
+        "secretKey": "username",
+        "secretValue": "AWS"
+      },
+      {
+        "secretKey": "password",
+        "secretValue": "'$ECR_TOKEN'"
+      },
+      {
+        "secretKey": "registry",
+        "secretValue": "<aws_account_id>.dkr.ecr.<region>.amazonaws.com"
+      }
+    ]
+  }'
+```
+
+Replace:
+
+- `<region>` with your AWS region (e.g., `us-east-1`, `us-west-2`)
+- `<aws_account_id>` with your AWS account ID
+- `<your-private-api-token>` with your Pipecat Cloud private API token
+
+Reference the image credentials in your `pcc-deploy.toml` file:
+
+```toml
+agent_name = "my-ecr-agent"
+image = "<aws_account_id>.dkr.ecr.<region>.amazonaws.com/your-repo:tag"
+secret_set = "my-agent-secrets"
+image_credentials = "my-ecr-credentials"
+
+[scaling]
+    min_instances = 0
+```
+
+Or specify it directly in the CLI:
+
+```bash
+pcc deploy my-ecr-agent <aws_account_id>.dkr.ecr.<region>.amazonaws.com/your-repo:tag \
+  --secret-set my-agent-secrets \
+  --image-credentials my-ecr-credentials
+```
+
+ECR passwords expire every 12 hours, so set up a scheduled job to refresh the token:
+
+```bash
+#!/bin/bash
+# refresh-ecr-token.sh
+
+# Get fresh ECR token
+ECR_TOKEN=$(aws ecr get-login-password --region <region>)
+
+# Update the existing image pull secret
+curl --request PUT \
+  --url https://api.pipecat.daily.co/v1/secrets/my-ecr-credentials \
+  --header 'Authorization: Bearer <your-private-api-token>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "secrets": [
+      {
+        "secretKey": "username",
+        "secretValue": "AWS"
+      },
+      {
+        "secretKey": "password",
+        "secretValue": "'$ECR_TOKEN'"
+      },
+      {
+        "secretKey": "registry",
+        "secretValue": "<aws_account_id>.dkr.ecr.<region>.amazonaws.com"
+      }
+    ]
+  }'
+```
+
+Schedule this script to run every 6-8 hours using cron or your preferred scheduler.
+
+Operational tips:
+
+- Image pulls can happen during scale-outs, not just at initial deploy—keep the secret valid continuously
+- If you see agents failing to become ready with no logs, check that your ECR credentials aren't expired
+- Consider setting up monitoring alerts for ECR token expiration
+
+<Note>
+  Ensure your AWS credentials have the necessary permissions to access ECR,
+  including `ecr:GetAuthorizationToken` and `ecr:BatchGetImage` policies.
+</Note>
+
 ## Modifying a deployment
 
 Agents are referenced as a mutable manifest in Pipecat Cloud.

--- a/deployment/pipecat-cloud/fundamentals/deploy.mdx
+++ b/deployment/pipecat-cloud/fundamentals/deploy.mdx
@@ -29,6 +29,12 @@ The `deploy` command requires both of the following arguments:
 
 For a list of deployment configuration options, please see the [CLI reference](../cli-reference/deploy).
 
+<Note>
+  Using a private container registry? See our [Container Registry
+  guides](../guides/container-registries/overview) for setup instructions for
+  GCP Artifact Registry, AWS ECR, and other private registries.
+</Note>
+
 You will be asked to confirm your deployment configuration before proceeding.
 
 ### Deployment status
@@ -64,176 +70,6 @@ pcc agent status my-first-agent
 ```
 
 If a deployment was successful and ready to be started, you should see a `ready` status.
-
-## Private Container Registry Deployments
-
-When using private container registries, you'll need to configure image pull secrets to authenticate with your registry. Below are guides for the most common cloud platforms.
-
-### GCP Artifact Registry
-
-For GCP Artifact Registry, you can use a service account JSON key to authenticate:
-
-```bash
-# First, authenticate Docker with your service account key
-cat key-file.json | docker login -u _json_key --password-stdin https://LOCATION-docker.pkg.dev
-
-# Create image credentials in Pipecat Cloud using the same service account
-pcc image-credentials create my-gcp-credentials \
-  --registry https://LOCATION-docker.pkg.dev \
-  --username _json_key \
-  --password "$(cat key-file.json)"
-```
-
-Replace:
-
-- `LOCATION` with your Artifact Registry location (e.g., `us-central1`, `asia-east1`)
-- `key-file.json` with the path to your service account JSON key file
-
-Reference the image credentials in your `pcc-deploy.toml` file:
-
-```toml
-agent_name = "my-first-agent"
-image = "LOCATION-docker.pkg.dev/PROJECT-ID/REPO-NAME/my-first-agent:0.1"
-secret_set = "my-first-agent-secrets"
-image_credentials = "my-gcp-credentials"
-
-[scaling]
-    min_instances = 0
-```
-
-Or specify it directly in the CLI:
-
-```bash
-pcc deploy my-first-agent LOCATION-docker.pkg.dev/PROJECT-ID/REPO-NAME/my-first-agent:0.1 \
-  --secret-set my-first-agent-secrets \
-  --image-credentials my-gcp-credentials
-```
-
-<Note>
-  The service account used for image credentials should have the `Artifact
-  Registry Reader` role or equivalent permissions to pull images from your
-  private repository.
-</Note>
-
-### AWS ECR
-
-If you're using AWS ECR with private repositories for Pipecat Cloud deployments, you'll need to configure image pull secrets to authenticate with your registry. ECR tokens expire every 12 hours, so you'll also need to set up automatic token refresh.
-
-Build and tag your Docker image, then push to ECR:
-
-```bash
-# Build and tag your image
-docker build --platform=linux/arm64 -t my-agent:latest .
-docker tag my-agent:latest <aws_account_id>.dkr.ecr.<region>.amazonaws.com/your-repo:tag
-
-# Push to ECR
-docker push <aws_account_id>.dkr.ecr.<region>.amazonaws.com/your-repo:tag
-```
-
-<Note>
-  Pipecat Cloud may pull your image on deploy and again during scale-outs, so
-  credentials must be valid whenever new pods start.
-</Note>
-
-Use the Pipecat Cloud REST API to store your ECR registry credentials:
-
-```bash
-# Get ECR login token
-ECR_TOKEN=$(aws ecr get-login-password --region <region>)
-
-# Create image pull secret using REST API
-curl --request PUT \
-  --url https://api.pipecat.daily.co/v1/secrets/my-ecr-credentials \
-  --header 'Authorization: Bearer <your-private-api-token>' \
-  --header 'Content-Type: application/json' \
-  --data '{
-    "secrets": [
-      {
-        "secretKey": "username",
-        "secretValue": "AWS"
-      },
-      {
-        "secretKey": "password",
-        "secretValue": "'$ECR_TOKEN'"
-      },
-      {
-        "secretKey": "registry",
-        "secretValue": "<aws_account_id>.dkr.ecr.<region>.amazonaws.com"
-      }
-    ]
-  }'
-```
-
-Replace:
-
-- `<region>` with your AWS region (e.g., `us-east-1`, `us-west-2`)
-- `<aws_account_id>` with your AWS account ID
-- `<your-private-api-token>` with your Pipecat Cloud private API token
-
-Reference the image credentials in your `pcc-deploy.toml` file:
-
-```toml
-agent_name = "my-ecr-agent"
-image = "<aws_account_id>.dkr.ecr.<region>.amazonaws.com/your-repo:tag"
-secret_set = "my-agent-secrets"
-image_credentials = "my-ecr-credentials"
-
-[scaling]
-    min_instances = 0
-```
-
-Or specify it directly in the CLI:
-
-```bash
-pcc deploy my-ecr-agent <aws_account_id>.dkr.ecr.<region>.amazonaws.com/your-repo:tag \
-  --secret-set my-agent-secrets \
-  --image-credentials my-ecr-credentials
-```
-
-ECR passwords expire every 12 hours, so set up a scheduled job to refresh the token:
-
-```bash
-#!/bin/bash
-# refresh-ecr-token.sh
-
-# Get fresh ECR token
-ECR_TOKEN=$(aws ecr get-login-password --region <region>)
-
-# Update the existing image pull secret
-curl --request PUT \
-  --url https://api.pipecat.daily.co/v1/secrets/my-ecr-credentials \
-  --header 'Authorization: Bearer <your-private-api-token>' \
-  --header 'Content-Type: application/json' \
-  --data '{
-    "secrets": [
-      {
-        "secretKey": "username",
-        "secretValue": "AWS"
-      },
-      {
-        "secretKey": "password",
-        "secretValue": "'$ECR_TOKEN'"
-      },
-      {
-        "secretKey": "registry",
-        "secretValue": "<aws_account_id>.dkr.ecr.<region>.amazonaws.com"
-      }
-    ]
-  }'
-```
-
-Schedule this script to run every 6-8 hours using cron or your preferred scheduler.
-
-Operational tips:
-
-- Image pulls can happen during scale-outs, not just at initial deploy—keep the secret valid continuously
-- If you see agents failing to become ready with no logs, check that your ECR credentials aren't expired
-- Consider setting up monitoring alerts for ECR token expiration
-
-<Note>
-  Ensure your AWS credentials have the necessary permissions to access ECR,
-  including `ecr:GetAuthorizationToken` and `ecr:BatchGetImage` policies.
-</Note>
 
 ## Modifying a deployment
 

--- a/deployment/pipecat-cloud/guides/container-registries/aws-ecr.mdx
+++ b/deployment/pipecat-cloud/guides/container-registries/aws-ecr.mdx
@@ -1,0 +1,139 @@
+---
+title: AWS ECR
+description: "Deploy Pipecat Cloud agents using Amazon Elastic Container Registry"
+---
+
+If you're using AWS ECR with private repositories for Pipecat Cloud deployments, you'll need to configure image pull secrets to authenticate with your registry. **ECR tokens expire every 12 hours**, so you'll also need to set up automatic token refresh.
+
+## Authenticate Docker
+
+First, authenticate Docker with ECR:
+
+```bash
+aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
+```
+
+## Configure Image Pull Secrets
+
+Use the Pipecat Cloud REST API to store your ECR registry credentials:
+
+```bash
+# Get ECR login token
+ECR_TOKEN=$(aws ecr get-login-password --region <region>)
+
+# Create image pull secret using REST API
+curl --request PUT \
+  --url https://api.pipecat.daily.co/v1/secrets/my-ecr-credentials \
+  --header 'Authorization: Bearer <your-private-api-token>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "secrets": [
+      {
+        "secretKey": "username",
+        "secretValue": "AWS"
+      },
+      {
+        "secretKey": "password",
+        "secretValue": "'$ECR_TOKEN'"
+      },
+      {
+        "secretKey": "registry",
+        "secretValue": "<aws_account_id>.dkr.ecr.<region>.amazonaws.com"
+      }
+    ]
+  }'
+```
+
+Replace:
+
+- `<region>` with your AWS region (e.g., `us-east-1`, `us-west-2`)
+- `<aws_account_id>` with your AWS account ID
+- `<your-private-api-token>` with your Pipecat Cloud private API token
+
+## Configure Your Deployment
+
+Create a `pcc-deploy.toml` file with your ECR image configuration:
+
+```toml
+agent_name = "my-ecr-agent"
+image = "<aws_account_id>.dkr.ecr.<region>.amazonaws.com/your-repo:tag"
+secret_set = "my-agent-secrets"
+image_credentials = "my-ecr-credentials"
+
+[scaling]
+    min_instances = 0
+```
+
+## Build and Push to ECR
+
+Build and push your agent image to ECR using the Pipecat Cloud CLI:
+
+```bash
+# Build and push using your pcc-deploy.toml configuration
+pcc docker build-push
+```
+
+This command automatically builds for the correct platform (`linux/arm64`) and pushes to your configured ECR repository.
+
+<Note>
+  Pipecat Cloud may pull your image on deploy and again during scale-outs, so
+  credentials must be valid whenever new pods start.
+</Note>
+
+## Deploy Your Agent
+
+Deploy using your configured `pcc-deploy.toml`:
+
+```bash
+pcc deploy
+```
+
+## Automatic Token Refresh (Required)
+
+**ECR passwords expire every 12 hours**, so set up a scheduled job to refresh the token:
+
+```bash
+#!/bin/bash
+# refresh-ecr-token.sh
+
+# Get fresh ECR token
+ECR_TOKEN=$(aws ecr get-login-password --region <region>)
+
+# Update the existing image pull secret
+curl --request PUT \
+  --url https://api.pipecat.daily.co/v1/secrets/my-ecr-credentials \
+  --header 'Authorization: Bearer <your-private-api-token>' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "secrets": [
+      {
+        "secretKey": "username",
+        "secretValue": "AWS"
+      },
+      {
+        "secretKey": "password",
+        "secretValue": "'$ECR_TOKEN'"
+      },
+      {
+        "secretKey": "registry",
+        "secretValue": "<aws_account_id>.dkr.ecr.<region>.amazonaws.com"
+      }
+    ]
+  }'
+```
+
+Schedule this script to run every 6-8 hours using cron or your preferred scheduler.
+
+## Operational Considerations
+
+**Critical operational tips:**
+
+- **Image pulls can happen during scale-outs**, not just at initial deploy—keep the secret valid continuously
+- **If you see agents failing to become ready with no logs**, check that your ECR credentials aren't expired
+- **Consider setting up monitoring alerts** for ECR token expiration
+- **Test your refresh script** to ensure it works before relying on it in production
+
+<Note>
+  Ensure your AWS credentials have the necessary permissions to access ECR,
+  including `ecr:GetAuthorizationToken` and `ecr:BatchGetImage` policies.
+</Note>

--- a/deployment/pipecat-cloud/guides/container-registries/gcp-artifact-registry.mdx
+++ b/deployment/pipecat-cloud/guides/container-registries/gcp-artifact-registry.mdx
@@ -1,0 +1,76 @@
+---
+title: GCP Artifact Registry
+description: "Deploy Pipecat Cloud agents using Google Cloud Artifact Registry"
+---
+
+For GCP Artifact Registry, you can use a service account JSON key to authenticate with your private registry.
+
+## Authenticate Docker
+
+First, authenticate Docker with your service account key:
+
+```bash
+# Authenticate Docker with your service account key
+cat key-file.json | docker login -u _json_key --password-stdin https://<location>-docker.pkg.dev
+```
+
+## Configure Image Pull Secrets
+
+Create image credentials in Pipecat Cloud using the same service account:
+
+```bash
+pcc secrets image-pull-secret my-gcp-credentials https://<location>-docker.pkg.dev
+```
+
+When prompted, enter:
+
+- Username: `_json_key`
+- Password: The contents of your service account JSON key file
+
+## Configure Your Deployment
+
+Create a `pcc-deploy.toml` file with your Artifact Registry image configuration:
+
+```toml
+agent_name = "my-gcp-agent"
+image = "<location>-docker.pkg.dev/<project-id>/<repo-name>/my-agent:0.1"
+secret_set = "my-agent-secrets"
+image_credentials = "my-gcp-credentials"
+
+[scaling]
+    min_instances = 0
+```
+
+## Build and Push to Artifact Registry
+
+Build and push your agent image using the Pipecat Cloud CLI:
+
+```bash
+# Build and push using your pcc-deploy.toml configuration
+pcc docker build-push
+```
+
+This command automatically builds for the correct platform (`linux/arm64`) and pushes to your configured Artifact Registry repository.
+
+## Deploy Your Agent
+
+Deploy using your configured `pcc-deploy.toml`:
+
+```bash
+pcc deploy
+```
+
+## Configuration Reference
+
+Replace the following placeholders with your actual values:
+
+- `<location>` with your Artifact Registry location (e.g., `us-central1`, `asia-east1`)
+- `<project-id>` with your Google Cloud project ID
+- `<repo-name>` with your Artifact Registry repository name
+- `key-file.json` with the path to your service account JSON key file
+
+<Note>
+  The service account used for image credentials should have the `Artifact
+  Registry Reader` role or equivalent permissions to pull images from your
+  private repository.
+</Note>

--- a/deployment/pipecat-cloud/guides/container-registries/overview.mdx
+++ b/deployment/pipecat-cloud/guides/container-registries/overview.mdx
@@ -1,0 +1,79 @@
+---
+title: Container Registry Overview
+sidebarTitle: Overview
+description: "Deploy Pipecat Cloud agents from private container registries"
+---
+
+When deploying agents to Pipecat Cloud, you can use images from both public and private container registries. While public images work out of the box, private images from any registry (including Docker Hub) require authentication setup.
+
+## Public vs Private Images
+
+**Public images** from any registry, including Docker Hub, work with Pipecat Cloud without additional configuration. However, **we strongly recommend using private images** for better data privacy and security when deploying production agents.
+
+For **Docker Hub specifically**, even when using public images, we recommend setting up image pull secrets due to Docker Hub's low rate limits for unauthenticated pulls. See our [Image pull secrets guide](../../fundamentals/secrets#image-pull-secrets) for setup instructions.
+
+## Private Registry Setup
+
+For **private images** from any registry (including private Docker Hub repositories), you'll need to configure image pull secrets for authentication.
+
+### Docker Hub Private Images
+
+For private Docker Hub repositories, see the [Image pull secrets section](../../fundamentals/secrets#image-pull-secrets) in our Secrets guide for complete setup instructions.
+
+### Other Private Registries
+
+For other private registry providers, choose your platform below for detailed setup instructions:
+
+<CardGroup cols={2}>
+  <Card
+    title="Google Cloud Artifact Registry"
+    icon="google"
+    href="./gcp-artifact-registry"
+  >
+    Complete setup guide for GCP Artifact Registry, including service account
+    configuration and authentication.
+  </Card>
+
+  <Card title="Amazon ECR" icon="aws" href="./aws-ecr">
+    Detailed AWS ECR integration with automatic token refresh setup for
+    continuous deployment.
+  </Card>
+</CardGroup>
+
+## General Process
+
+All private registry integrations follow a similar pattern:
+
+1. **Authenticate Docker** with your registry locally
+2. **Create image credentials** in Pipecat Cloud using the CLI
+3. **Reference credentials** in your deployment configuration
+4. **Deploy your agent** using the private image
+
+```bash
+# Create image pull secret
+pcc secrets image-pull-secret my-registry-creds https://your-registry-url
+```
+
+Then configure your `pcc-deploy.toml` file:
+
+```toml
+agent_name = "my-agent"
+image = "your-registry-url/my-agent:tag"
+image_credentials = "my-registry-creds"
+secret_set = "my-secrets"
+
+[scaling]
+    min_agents = 0
+```
+
+Finally, deploy:
+
+```bash
+pcc deploy
+```
+
+## Need Another Registry?
+
+If you're using a different container registry (Azure Container Registry, GitHub Container Registry, Harbor, etc.), the general process above applies. The main differences are typically in the authentication method and registry URL format.
+
+For assistance with other registry providers, please reach out on our [Discord community](https://discord.gg/pipecat).

--- a/docs.json
+++ b/docs.json
@@ -487,6 +487,14 @@
                 "group": "Guides",
                 "pages": [
                   "deployment/pipecat-cloud/guides/capacity-planning",
+                  {
+                    "group": "Container Registries",
+                    "pages": [
+                      "deployment/pipecat-cloud/guides/container-registries/overview",
+                      "deployment/pipecat-cloud/guides/container-registries/aws-ecr",
+                      "deployment/pipecat-cloud/guides/container-registries/gcp-artifact-registry"
+                    ]
+                  },
                   "deployment/pipecat-cloud/guides/daily-webrtc",
                   "deployment/pipecat-cloud/guides/krisp-noise-cancellation",
                   {


### PR DESCRIPTION
## Summary

This PR adds comprehensive deployment documentation for GCP Artifact Registry and AWS ECR to the README.md file, providing developers with step-by-step guides for deploying Pipecat agents using private container registries.

## Changes

### GCP Artifact Registry Section
- Instructions for creating image credentials with service account JSON key
- Examples for both `pcc-deploy.toml` configuration and CLI deployment
- Required permissions and security considerations

### AWS ECR Section  
- Complete 4-step deployment process including image building and pushing
- REST API integration for managing image pull secrets
- Automatic token refresh solution for ECR's 12-hour expiration
- Operational tips and troubleshooting guidance
- Bash script template for automated token management
