### PR TITLE
Add Voice.ai TTS service documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -200,6 +200,7 @@
                   "server/services/tts/rime",
                   "server/services/tts/sarvam",
                   "server/services/tts/speechmatics",
+                  "server/services/tts/voiceai",
                   "server/services/tts/xtts"
                 ]
               },

--- a/server/services/supported-services.mdx
+++ b/server/services/supported-services.mdx
@@ -113,6 +113,7 @@ Text-to-Speech services receive text input and output audio streams or chunks.
 | [Rime](/server/services/tts/rime)                 | `pip install "pipecat-ai[rime]"`         |
 | [Sarvam](/server/services/tts/sarvam)             | No dependencies required                 |
 | [Speechmatics](/server/services/tts/speechmatics) | `pip install "pipecat-ai[speechmatics]"` |
+| [Voice.ai](/server/services/tts/voiceai)         | `pip install "pipecat-ai[voiceai]"`      |
 | [XTTS](/server/services/tts/xtts)                 | `pip install "pipecat-ai[xtts]"`         |
 
 ## Speech-to-Speech

--- a/server/services/tts/voiceai.mdx
+++ b/server/services/tts/voiceai.mdx
@@ -1,0 +1,62 @@
+---
+title: "Voice.ai"
+description: "Text-to-speech service using Voice.ai's TTS API"
+---
+
+## Overview
+
+Voice.ai provides high-quality text-to-speech synthesis using Voice.ai's TTS WebSocket API with ultra-low latency and support for multiple concurrent TTS streams. The service offers various voice models and languages optimized for conversational AI applications requiring low latency and automatic interruption handling.
+
+<CardGroup cols={2}>
+  <Card
+    title="Voice.ai TTS API Reference"
+    icon="code"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.voiceai.tts.html"
+  >
+    Pipecat's API methods for Voice.ai TTS integration
+  </Card>
+  <Card
+    title="Example Implementation"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/foundational/07zl-interruptible-voiceai.py"
+  >
+    Complete example with Voice.ai TTS and interruption handling
+  </Card>
+  <Card
+    title="Voice.ai"
+    icon="book"
+    href="https://voice.ai"
+  >
+    Voice.ai platform and developer resources
+  </Card>
+  <Card
+    title="Voice Library"
+    icon="microphone"
+    href="https://voice.ai/app/dashboard/voices"
+  >
+    Browse and create voices for TTS
+  </Card>
+</CardGroup>
+
+## Installation
+
+To use Voice.ai services, install the required dependencies:
+
+```bash
+pip install "pipecat-ai[voiceai]"
+```
+
+## Prerequisites
+
+### Voice.ai Account Setup
+
+Before using Voice.ai TTS services, you need:
+
+1. **Voice.ai Account**: Sign up at [Voice.ai](https://voice.ai/)
+2. **API Key**: Generate an API key from your account
+3. **Voice Selection**: Choose a voice ID for synthesis
+
+### Required Environment Variables
+
+- `VOICEAI_API_KEY`: Your Voice.ai API key for authentication
+- `VOICEAI_VOICE_ID`: (Optional) The voice identifier to use for TTS; omit for default voice


### PR DESCRIPTION
Adds documentation for the Voice.ai text-to-speech integration in Pipecat.

**Contents**
- New [Voice.ai TTS](/server/services/tts/voiceai) page: overview, installation, prerequisites, and environment variables 
- Voice.ai listed in the [Supported Services](/server/services/supported-services) Text-to-Speech table
- Cards for API reference, example implementation, Voice.ai platform, and Voice Library

**Dependency**
This doc change relies on the Voice.ai integration in the main Pipecat repo. Until [pipecat-ai/pipecat#3655](https://github.com/pipecat-ai/pipecat/pull/3655) is merged and the reference server is rebuilt:
- The **API Reference** link (reference-server.pipecat.ai) will 404
- The **Example Implementation** link (GitHub) will 404

The doc links point to the correct URLs for after that PR is merged. The Voice.ai and Voice Library links work today.