### PR TITLE
docs: update for pipecat PR #4211

### DIFF
--- a/api-reference/server/services/llm/openai-responses.mdx
+++ b/api-reference/server/services/llm/openai-responses.mdx
@@ -212,9 +212,14 @@ print(response)  # "The capital of France is Paris."
 | --------------------------- | ----------------------------------------------------------------------- |
 | `on_completion_timeout`     | Called when an LLM completion request times out                         |
 | `on_function_calls_started` | Called when function calls are received and execution is about to start |
+| `on_connection_error`       | Called when a WebSocket connection error occurs                         |
 
 ```python
 @llm.event_handler("on_completion_timeout")
 async def on_completion_timeout(service):
     print("LLM completion timed out")
+
+@llm.event_handler("on_connection_error")
+async def on_connection_error(service, error):
+    print(f"LLM connection error: {error}")
 ```


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4211](https://github.com/pipecat-ai/pipecat/pull/4211).

## Changes

**server/services/llm/openai-responses.mdx**
- Added `on_connection_error` event handler to Event Handlers section
- Added example usage showing how to handle WebSocket connection errors

## Summary

PR #4211 refactored the OpenAI Responses LLM service to use a new `WebsocketLLMService` base class, which introduces standardized WebSocket connection management across LLM services. This includes a new `on_connection_error` event handler that allows applications to respond to WebSocket connection failures.

## Gaps identified

None