### PR TITLE
docs: update for pipecat PR #4213

### DIFF
--- a/api-reference/server/services/image-generation/google.mdx
+++ b/api-reference/server/services/image-generation/google.mdx
@@ -96,7 +96,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 <Note>
   `NOT_GIVEN` values are omitted from the request, letting the service use its
-  own defaults (`"imagen-3.0-generate-002"` for model, `1` for
+  own defaults (`"imagen-4.0-generate-001"` for model, `1` for
   number_of_images). Only parameters that are explicitly set are included.
 </Note>
 
@@ -118,7 +118,7 @@ image_gen = GoogleImageGenService(
 image_gen = GoogleImageGenService(
     api_key=os.getenv("GOOGLE_API_KEY"),
     settings=GoogleImageGenService.Settings(
-        model="imagen-3.0-generate-002",
+        model="imagen-4.0-generate-001",
         number_of_images=2,
         negative_prompt="blurry, low quality",
     ),


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4213](https://github.com/pipecat-ai/pipecat/pull/4213).

## Changes

### Updated reference pages
- `server/services/image-generation/google.mdx` — Updated default model version from `imagen-3.0-generate-002` to `imagen-4.0-generate-001` in:
  - Settings note documenting default values
  - Usage example code showing model configuration

## Gaps identified

None

---

🤖 Generated via automated docs sync workflow