### PR TITLE
docs: update for pipecat PR #4209

### DIFF
--- a/api-reference/server/services/llm/grok.mdx
+++ b/api-reference/server/services/llm/grok.mdx
@@ -93,7 +93,7 @@ from pipecat.services.xai.llm import GrokLLMService
 
 llm = GrokLLMService(
     api_key=os.getenv("XAI_API_KEY"),
-    model="grok-3-beta",
+    model="grok-3",
 )
 ```
 
@@ -105,7 +105,7 @@ from pipecat.services.xai.llm import GrokLLMService
 llm = GrokLLMService(
     api_key=os.getenv("XAI_API_KEY"),
     settings=GrokLLMService.Settings(
-        model="grok-3-beta",
+        model="grok-3",
         temperature=0.7,
         top_p=0.9,
         max_completion_tokens=1024,


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4209](https://github.com/pipecat-ai/pipecat/pull/4209).

## Changes
- **server/services/llm/grok.mdx**: Updated default model from `grok-3-beta` to `grok-3` in usage examples to reflect the general availability release of the grok-3 model

## Gaps identified
None