### PR TITLE
docs: update for pipecat PR #4208

### DIFF
--- a/api-reference/server/services/llm/google-vertex.mdx
+++ b/api-reference/server/services/llm/google-vertex.mdx
@@ -11,7 +11,7 @@ description: "LLM service implementation using Google's Vertex AI with OpenAI-co
   <Card
     title="Vertex AI LLM API Reference"
     icon="code"
-    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.google.llm_vertex.html"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.google.vertex.llm.html"
   >
     Pipecat's API methods for Google Vertex AI integration
   </Card>

--- a/api-reference/server/services/llm/nvidia.mdx
+++ b/api-reference/server/services/llm/nvidia.mdx
@@ -11,7 +11,7 @@ description: "LLM service implementation using NVIDIA's NIM (NVIDIA Inference Mi
   <Card
     title="NVIDIA NIM LLM API Reference"
     icon="code"
-    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.nim.llm.html"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.nvidia.llm.html"
   >
     Pipecat's API methods for NVIDIA NIM integration
   </Card>
@@ -130,7 +130,6 @@ llm = NvidiaLLMService(
 ## Notes
 
 - NVIDIA NIM uses incremental token reporting. The service accumulates token usage metrics during processing and reports the final totals at the end of each request.
-- The legacy `NimLLMService` import from `pipecat.services.nim` is deprecated. Use `NvidiaLLMService` from `pipecat.services.nvidia` instead.
 - NIM supports both cloud-hosted and on-premises deployments. For on-premises, override the `base_url` to point to your local NIM endpoint.
 
 <Tip>

--- a/api-reference/server/services/s2s/gemini-live-vertex.mdx
+++ b/api-reference/server/services/s2s/gemini-live-vertex.mdx
@@ -17,7 +17,7 @@ description: "A real-time, multimodal conversational AI service powered by Googl
   <Card
     title="Gemini Live Vertex API Reference"
     icon="code"
-    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.google.gemini_live.llm_vertex.html"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.google.gemini_live.vertex.llm.html"
   >
     Pipecat's API methods for Gemini Live Vertex AI integration
   </Card>

--- a/api-reference/server/services/stt/nvidia.mdx
+++ b/api-reference/server/services/stt/nvidia.mdx
@@ -14,7 +14,7 @@ NVIDIA Riva provides two STT service implementations:
   <Card
     title="NVIDIA Riva STT API Reference"
     icon="code"
-    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.riva.stt.html"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.nvidia.stt.html"
   >
     Pipecat's API methods for NVIDIA Riva STT integration
   </Card>

--- a/api-reference/server/services/tts/nvidia.mdx
+++ b/api-reference/server/services/tts/nvidia.mdx
@@ -11,7 +11,7 @@ description: "Text-to-speech service implementation using NVIDIA Riva"
   <Card
     title="NVIDIA Riva TTS API Reference"
     icon="code"
-    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.riva.tts.html"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.nvidia.tts.html"
   >
     Pipecat's API methods for NVIDIA Riva TTS integration
   </Card>

--- a/pipecat/features/openai-audio-models-and-apis.mdx
+++ b/pipecat/features/openai-audio-models-and-apis.mdx
@@ -70,7 +70,7 @@ Which approach should you choose?
 ### Realtime API
 
 - Models: `gpt-realtime-1.5`, `gpt-realtime`
-- Pipecat service: `OpenAIRealtimeBetaLLMService` ([reference docs](/api-reference/server/services/s2s/openai))
+- Pipecat service: `OpenAIRealtimeLLMService` ([reference docs](/api-reference/server/services/s2s/openai))
 - OpenAI docs ([overview](https://platform.openai.com/docs/guides/realtime))
 
 ### Speech API


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4208](https://github.com/pipecat-ai/pipecat/pull/4208).

## Changes

### Updated service name references
- **guides/features/openai-audio-models-and-apis.mdx** — Updated OpenAI Realtime API service name from `OpenAIRealtimeBetaLLMService` to `OpenAIRealtimeLLMService`

### Updated API reference links (deprecated import paths → current paths)
- **server/services/tts/nvidia.mdx** — Updated API reference link from `pipecat.services.riva.tts` to `pipecat.services.nvidia.tts`
- **server/services/stt/nvidia.mdx** — Updated API reference link from `pipecat.services.riva.stt` to `pipecat.services.nvidia.stt`
- **server/services/llm/nvidia.mdx** — Updated API reference link from `pipecat.services.nim.llm` to `pipecat.services.nvidia.llm` and removed deprecation note for `NimLLMService` (now fully removed)
- **server/services/llm/google-vertex.mdx** — Updated API reference link from `pipecat.services.google.llm_vertex` to `pipecat.services.google.vertex.llm`
- **server/services/s2s/gemini-live-vertex.mdx** — Updated API reference link from `pipecat.services.google.gemini_live.llm_vertex` to `pipecat.services.google.gemini_live.vertex.llm`

## Gaps identified

None — all deprecated module removals that affect documentation have been addressed. The deprecated modules removed in PR #4208 were already marked as deprecated in the docs (with updated import paths already shown in usage examples).