### PR TITLE
docs: update for pipecat PR #4214

### DIFF
--- a/api-reference/server/rtvi/rtvi-processor.mdx
+++ b/api-reference/server/rtvi/rtvi-processor.mdx
@@ -48,6 +48,10 @@ async def on_client_ready(rtvi):
     await task.queue_frames([...])
 ```
 
+<Note>
+  The processor validates the client's RTVI protocol version during the handshake. If the client's major version doesn't match the server's protocol version, an error response is sent but the connection continues. Check server logs for version compatibility warnings.
+</Note>
+
 ### Bot Ready State
 
 The server must mark the bot as ready before it can process client messages:


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4214](https://github.com/pipecat-ai/pipecat/pull/4214).

## Changes
- **server/frameworks/rtvi/rtvi-processor.mdx** — Added note about RTVI protocol version compatibility checking during client-ready handshake. The processor now validates that the client's major version matches the server's protocol version and sends error responses for incompatible versions.

## Gaps identified
None