### PR TITLE
docs: update for pipecat PR #4162

### DIFF
--- a/api-reference/server/services/stt/smallest.mdx
+++ b/api-reference/server/services/stt/smallest.mdx
@@ -1,0 +1,163 @@
+---
+title: "Smallest AI"
+description: "Speech-to-text service using Smallest AI's Pulse WebSocket API"
+---
+
+## Overview
+
+Smallest AI provides real-time speech-to-text transcription through a WebSocket-based integration with their Waves API. The service uses the Pulse model to stream audio continuously and receive interim and final transcription results with low latency.
+
+<CardGroup cols={2}>
+  <Card
+    title="Smallest AI STT API Reference"
+    icon="code"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.smallest.stt.html"
+  >
+    Complete API reference for all parameters and methods
+  </Card>
+  <Card
+    title="Example Implementation"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-smallest.py"
+  >
+    Complete example with WebSocket streaming
+  </Card>
+</CardGroup>
+
+## Installation
+
+```bash
+pip install "pipecat-ai[smallest]"
+```
+
+## Prerequisites
+
+1. **Smallest AI Account**: Sign up at [Smallest AI](https://www.smallest.ai/)
+2. **API Key**: Generate an API key from your account dashboard
+
+Set the following environment variable:
+
+```bash
+export SMALLEST_API_KEY=your_api_key
+```
+
+## Configuration
+
+<ParamField path="api_key" type="str" required>
+  Smallest AI API key for authentication.
+</ParamField>
+
+<ParamField path="base_url" type="str" default="wss://api.smallest.ai">
+  Base WebSocket URL for the Smallest API. Override for custom or proxied
+  deployments.
+</ParamField>
+
+<ParamField path="encoding" type="str" default="linear16">
+  Audio encoding format.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="None">
+  Audio sample rate in Hz. When `None`, uses the pipeline's configured sample
+  rate.
+</ParamField>
+
+<ParamField path="settings" type="SmallestSTTService.Settings" default="None">
+  Runtime-configurable settings. See [Settings](#settings) below.
+</ParamField>
+
+<ParamField path="ttfs_p99_latency" type="float" default="SMALLEST_TTFS_P99">
+  P99 latency from speech end to final transcript in seconds. Used for
+  processing metrics.
+</ParamField>
+
+### Settings
+
+Runtime-configurable settings passed via the `settings` constructor argument using `SmallestSTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/guides/fundamentals/service-settings) for details.
+
+| Parameter             | Type              | Default       | Description                                                              |
+| --------------------- | ----------------- | ------------- | ------------------------------------------------------------------------ |
+| `model`               | `str`             | `pulse`       | Model identifier. Currently only `pulse` is supported.                   |
+| `language`            | `Language \| str` | `Language.EN` | Language code for transcription.                                         |
+| `word_timestamps`     | `bool`            | `False`       | Include word-level timestamps in transcription results.                  |
+| `full_transcript`     | `bool`            | `False`       | Include cumulative transcript in results.                                |
+| `sentence_timestamps` | `bool`            | `False`       | Include sentence-level timestamps in transcription results.              |
+| `redact_pii`          | `bool`            | `False`       | Redact personally identifiable information from transcripts.             |
+| `redact_pci`          | `bool`            | `False`       | Redact payment card information from transcripts.                        |
+| `numerals`            | `str`             | `auto`        | Convert spoken numerals to digits. Options: `auto`, `always`, or `none`. |
+| `diarize`             | `bool`            | `False`       | Enable speaker diarization to identify different speakers.               |
+
+## Usage
+
+### Basic Setup
+
+```python
+from pipecat.services.smallest.stt import SmallestSTTService
+from pipecat.transcriptions.language import Language
+
+stt = SmallestSTTService(
+    api_key=os.getenv("SMALLEST_API_KEY"),
+    settings=SmallestSTTService.Settings(
+        language=Language.EN,
+    ),
+)
+```
+
+### With Advanced Features
+
+```python
+stt = SmallestSTTService(
+    api_key=os.getenv("SMALLEST_API_KEY"),
+    settings=SmallestSTTService.Settings(
+        language=Language.ES,
+        word_timestamps=True,
+        diarize=True,
+        redact_pii=True,
+    ),
+)
+```
+
+### Updating Settings at Runtime
+
+Transcription settings can be changed mid-conversation using `STTUpdateSettingsFrame`:
+
+```python
+from pipecat.frames.frames import STTUpdateSettingsFrame
+from pipecat.services.smallest.stt import SmallestSTTSettings
+
+await task.queue_frame(
+    STTUpdateSettingsFrame(
+        delta=SmallestSTTSettings(
+            language=Language.FR,
+            word_timestamps=False,
+        )
+    )
+)
+```
+
+<Tip>
+  Changing settings will trigger a WebSocket reconnection, which may cause a
+  brief interruption in transcription.
+</Tip>
+
+## Notes
+
+- **WebSocket streaming**: The service uses WebSocket connections for real-time streaming. The connection is automatically managed and will reconnect if interrupted.
+- **VAD integration**: Uses Pipecat's VAD to detect when the user stops speaking and sends a finalize message to flush the final transcript.
+- **Keepalive**: The service sends periodic keepalive messages (every 5 seconds) to prevent idle timeouts on the WebSocket connection.
+- **Language support**: Supports 31 languages including Bulgarian, Bengali, Czech, Danish, German, English, Spanish, Estonian, Finnish, French, Gujarati, Hindi, Hungarian, Italian, Kannada, Lithuanian, Latvian, Malayalam, Marathi, Maltese, Dutch, Odia, Punjabi, Polish, Portuguese, Romanian, Russian, Slovak, Swedish, Tamil, Telugu, and Ukrainian.
+
+## Event Handlers
+
+Smallest AI STT supports the standard [service connection events](/server/events/service-events):
+
+| Event                 | Description                          |
+| --------------------- | ------------------------------------ |
+| `on_connected`        | Connected to Smallest AI WebSocket   |
+| `on_disconnected`     | Disconnected from Smallest WebSocket |
+| `on_connection_error` | WebSocket connection error occurred  |
+
+```python
+@stt.event_handler("on_connected")
+async def on_connected(service):
+    print("Connected to Smallest AI STT")
+```

--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -7,8 +7,8 @@ description: "AI services integrated with Pipecat and their setup requirements"
 
 Transports exchange audio and video streams between the user and bot.
 
-| Service                                                                   | Setup                                  |
-| ------------------------------------------------------------------------- | -------------------------------------- |
+| Service                                                                                 | Setup                                  |
+| --------------------------------------------------------------------------------------- | -------------------------------------- |
 | [DailyTransport](/api-reference/server/services/transport/daily)                        | `pip install "pipecat-ai[daily]"`      |
 | [FastAPIWebSocketTransport](/api-reference/server/services/transport/fastapi-websocket) | `pip install "pipecat-ai[websocket]"`  |
 | [HeyGenTransport](/api-reference/server/services/transport/heygen)                      | `pip install "pipecat-ai[heygen]"`     |
@@ -23,8 +23,8 @@ Transports exchange audio and video streams between the user and bot.
 
 Serializers convert between frames and media streams, enabling real-time communication over a websocket.
 
-| Service                                         | Setup                    |
-| ----------------------------------------------- | ------------------------ |
+| Service                                                       | Setup                    |
+| ------------------------------------------------------------- | ------------------------ |
 | [Exotel](/api-reference/server/services/serializers/exotel)   | No dependencies required |
 | [Genesys](/api-reference/server/services/serializers/genesys) | No dependencies required |
 | [Plivo](/api-reference/server/services/serializers/plivo)     | No dependencies required |
@@ -36,8 +36,8 @@ Serializers convert between frames and media streams, enabling real-time communi
 
 Speech-to-Text services receive and audio input and output transcriptions.
 
-| Service                                           | Setup                                    |
-| ------------------------------------------------- | ---------------------------------------- |
+| Service                                                         | Setup                                    |
+| --------------------------------------------------------------- | ---------------------------------------- |
 | [AssemblyAI](/api-reference/server/services/stt/assemblyai)     | `pip install "pipecat-ai[assemblyai]"`   |
 | [AWS Transcribe](/api-reference/server/services/stt/aws)        | `pip install "pipecat-ai[aws]"`          |
 | [Azure](/api-reference/server/services/stt/azure)               | `pip install "pipecat-ai[azure]"`        |
@@ -52,6 +52,7 @@ Speech-to-Text services receive and audio input and output transcriptions.
 | [NVIDIA](/api-reference/server/services/stt/nvidia)             | `pip install "pipecat-ai[nvidia]"`       |
 | [OpenAI](/api-reference/server/services/stt/openai)             | `pip install "pipecat-ai[openai]"`       |
 | [Sarvam](/api-reference/server/services/stt/sarvam)             | `pip install "pipecat-ai[sarvam]"`       |
+| [Smallest](/api-reference/server/services/stt/smallest)         | `pip install "pipecat-ai[smallest]"`     |
 | [Soniox](/api-reference/server/services/stt/soniox)             | `pip install "pipecat-ai[soniox]"`       |
 | [Speechmatics](/api-reference/server/services/stt/speechmatics) | `pip install "pipecat-ai[speechmatics]"` |
 | [Whisper](/api-reference/server/services/stt/whisper)           | `pip install "pipecat-ai[whisper]"`      |
@@ -60,8 +61,8 @@ Speech-to-Text services receive and audio input and output transcriptions.
 
 LLMs receive text or audio based input and output a streaming text response.
 
-| Service                                                   | Setup                                  |
-| --------------------------------------------------------- | -------------------------------------- |
+| Service                                                                 | Setup                                  |
+| ----------------------------------------------------------------------- | -------------------------------------- |
 | [Anthropic](/api-reference/server/services/llm/anthropic)               | `pip install "pipecat-ai[anthropic]"`  |
 | [AWS Bedrock](/api-reference/server/services/llm/aws)                   | `pip install "pipecat-ai[aws]"`        |
 | [Azure](/api-reference/server/services/llm/azure)                       | `pip install "pipecat-ai[azure]"`      |
@@ -90,8 +91,8 @@ LLMs receive text or audio based input and output a streaming text response.
 
 Text-to-Speech services receive text input and output audio streams or chunks.
 
-| Service                                           | Setup                                    |
-| ------------------------------------------------- | ---------------------------------------- |
+| Service                                                         | Setup                                    |
+| --------------------------------------------------------------- | ---------------------------------------- |
 | [Async](/api-reference/server/services/tts/asyncai)             | `pip install "pipecat-ai[asyncai]"`      |
 | [AWS Polly](/api-reference/server/services/tts/aws)             | `pip install "pipecat-ai[aws]"`          |
 | [Azure](/api-reference/server/services/tts/azure)               | `pip install "pipecat-ai[azure]"`        |
@@ -124,8 +125,8 @@ Text-to-Speech services receive text input and output audio streams or chunks.
 
 Speech-to-Speech services are multi-modal LLM services that take in audio, video, or text and output audio or text.
 
-| Service                                                          | Setup                                      |
-| ---------------------------------------------------------------- | ------------------------------------------ |
+| Service                                                                        | Setup                                      |
+| ------------------------------------------------------------------------------ | ------------------------------------------ |
 | [AWS Nova Sonic](/api-reference/server/services/s2s/aws)                       | `pip install "pipecat-ai[aws-nova-sonic]"` |
 | [Gemini Live](/api-reference/server/services/s2s/gemini-live)                  | `pip install "pipecat-ai[google]"`         |
 | [Gemini Live Vertex AI](/api-reference/server/services/s2s/gemini-live-vertex) | `pip install "pipecat-ai[google]"`         |
@@ -137,8 +138,8 @@ Speech-to-Speech services are multi-modal LLM services that take in audio, video
 
 Image generation services receive text inputs and output images.
 
-| Service                                            | Setup                              |
-| -------------------------------------------------- | ---------------------------------- |
+| Service                                                          | Setup                              |
+| ---------------------------------------------------------------- | ---------------------------------- |
 | [Azure](/api-reference/server/services/image-generation/azure)   | `pip install "pipecat-ai[azure]"`  |
 | [fal](/api-reference/server/services/image-generation/fal)       | `pip install "pipecat-ai[fal]"`    |
 | [Google](/api-reference/server/services/image-generation/google) | `pip install "pipecat-ai[google]"` |
@@ -148,8 +149,8 @@ Image generation services receive text inputs and output images.
 
 Video services enable you to build an avatar where audio and video are synchronized.
 
-| Service                                 | Setup                              |
-| --------------------------------------- | ---------------------------------- |
+| Service                                               | Setup                              |
+| ----------------------------------------------------- | ---------------------------------- |
 | [HeyGen](/api-reference/server/services/video/heygen) | `pip install "pipecat-ai[heygen]"` |
 | [Simli](/api-reference/server/services/video/simli)   | `pip install "pipecat-ai[simli]"`  |
 | [Tavus](/api-reference/server/services/video/tavus)   | `pip install "pipecat-ai[tavus]"`  |
@@ -158,22 +159,22 @@ Video services enable you to build an avatar where audio and video are synchroni
 
 Memory services can be used to store and retrieve conversations.
 
-| Service                              | Setup                            |
-| ------------------------------------ | -------------------------------- |
+| Service                                            | Setup                            |
+| -------------------------------------------------- | -------------------------------- |
 | [mem0](/api-reference/server/services/memory/mem0) | `pip install "pipecat-ai[mem0]"` |
 
 ## Vision
 
 Vision services receive a streaming video input and output text describing the video input.
 
-| Service                                        | Setup                                 |
-| ---------------------------------------------- | ------------------------------------- |
+| Service                                                      | Setup                                 |
+| ------------------------------------------------------------ | ------------------------------------- |
 | [Moondream](/api-reference/server/services/vision/moondream) | `pip install "pipecat-ai[moondream]"` |
 
 ## Analytics & Monitoring
 
 Analytics services help you better understand how your service operates.
 
-| Service                                     | Setup                              |
-| ------------------------------------------- | ---------------------------------- |
+| Service                                                   | Setup                              |
+| --------------------------------------------------------- | ---------------------------------- |
 | [Sentry](/api-reference/server/services/analytics/sentry) | `pip install "pipecat-ai[sentry]"` |

--- a/docs.json
+++ b/docs.json
@@ -374,6 +374,7 @@
                       "api-reference/server/services/stt/nvidia",
                       "api-reference/server/services/stt/openai",
                       "api-reference/server/services/stt/sarvam",
+                      "api-reference/server/services/stt/smallest",
                       "api-reference/server/services/stt/soniox",
                       "api-reference/server/services/stt/speechmatics",
                       "api-reference/server/services/stt/whisper",


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4162](https://github.com/pipecat-ai/pipecat/pull/4162).

## Changes

### New service page
- **server/services/stt/smallest.mdx** — Created comprehensive documentation for `SmallestSTTService`, the new real-time speech-to-text service using Smallest AI's Pulse WebSocket API

### Configuration updates
- **docs.json** — Added `server/services/stt/smallest` to Speech-to-Text navigation (alphabetically between Sarvam and Soniox)
- **server/services/supported-services.mdx** — Added Smallest AI STT to the Speech-to-Text services table

The new documentation covers:
- Overview and WebSocket streaming architecture
- Installation and prerequisites
- Constructor parameters (api_key, base_url, encoding, sample_rate, settings, ttfs_p99_latency)
- Runtime settings (model, language, word_timestamps, full_transcript, sentence_timestamps, redact_pii, redact_pci, numerals, diarize)
- Usage examples (basic setup, advanced features, runtime settings updates)
- Important notes (WebSocket management, VAD integration, keepalive, language support)
- Event handlers (on_connected, on_disconnected, on_connection_error)

## Gaps identified

None — the TTS service page already exists and did not require updates (only internal implementation details changed in the PR).