### PR TITLE
docs: update for pipecat PR #4215

### DIFF
--- a/api-reference/pipecat-flows/flow-manager.mdx
+++ b/api-reference/pipecat-flows/flow-manager.mdx
@@ -23,8 +23,9 @@ All parameters are keyword-only.
 </ParamField>
 
 <ParamField path="context_aggregator" type="Any" required>
-  Context aggregator for managing conversation context. Typically obtained from
-  `create_context_aggregator()` on the LLM service.
+  Context aggregator for managing conversation context. Typically created using
+  `LLMContextAggregatorPair` from
+  `pipecat.processors.aggregators.llm_response_universal`.
 </ParamField>
 
 <ParamField

--- a/api-reference/server/services/memory/mem0.mdx
+++ b/api-reference/server/services/memory/mem0.mdx
@@ -173,6 +173,6 @@ else:
 
 - **At least one ID required**: You must provide at least one of `user_id`, `agent_id`, or `run_id`. A `ValueError` is raised if none are provided.
 - **Cloud vs local**: Use `api_key` for Mem0's cloud API, or `local_config` for a self-hosted Mem0 instance using `Memory.from_config()`.
-- **Pipeline placement**: Place the `Mem0MemoryService` before your LLM service in the pipeline. It intercepts `LLMContextFrame`, `OpenAILLMContextFrame`, and `LLMMessagesFrame` to enhance context with relevant memories before passing them downstream.
+- **Pipeline placement**: Place the `Mem0MemoryService` before your LLM service in the pipeline. It intercepts `LLMContextFrame` and `LLMMessagesFrame` to enhance context with relevant memories before passing them downstream.
 - **Non-blocking operation**: All Mem0 API calls (storage, retrieval, search) run in background threads to avoid blocking the event loop. Message storage is fire-and-forget, so it doesn't delay downstream processing.
 - **Message role filtering**: Only messages with `user` or `assistant` roles are stored in Mem0. Messages with other roles (such as `system` or `developer`) are automatically filtered out, as the Mem0 API does not accept them.


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4215](https://github.com/pipecat-ai/pipecat/pull/4215).

## Changes

- **server/frameworks/flows/flow-manager.mdx** — Updated `context_aggregator` parameter description to reference `LLMContextAggregatorPair` instead of the deprecated `create_context_aggregator()` method
- **server/services/memory/mem0.mdx** — Removed `OpenAILLMContextFrame` from pipeline placement notes (only `LLMContextFrame` and `LLMMessagesFrame` remain)

## Context

PR #4215 removed deprecated service-specific context and aggregator machinery:
- Removed `create_context_aggregator()` from all LLM services
- Removed `OpenAILLMContext`, `OpenAILLMContextFrame`, and service-specific context classes
- All services now use the universal `LLMContext` and `LLMContextAggregatorPair`

## Gaps identified

None