### PR TITLE
docs: update for pipecat PR #4219

### DIFF
--- a/api-reference/server/services/llm/aws.mdx
+++ b/api-reference/server/services/llm/aws.mdx
@@ -128,18 +128,19 @@ Before using AWS Bedrock LLM services, you need:
 
 Runtime-configurable settings passed via the `settings` constructor argument using `AWSBedrockLLMService.Settings(...)`. These can be updated mid-conversation with `LLMUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter                         | Type        | Default     | Description                                                                                        |
-| --------------------------------- | ----------- | ----------- | -------------------------------------------------------------------------------------------------- |
-| `model`                           | `str`       | `None`      | AWS Bedrock model identifier. _(Inherited from base settings.)_                                    |
-| `system_instruction`              | `str`       | `None`      | System instruction/prompt for the model. _(Inherited from base settings.)_                         |
-| `max_tokens`                      | `int`       | `NOT_GIVEN` | Maximum number of tokens to generate.                                                              |
-| `temperature`                     | `float`     | `NOT_GIVEN` | Sampling temperature (0.0 to 1.0). Lower values are more focused, higher values are more creative. |
-| `top_p`                           | `float`     | `NOT_GIVEN` | Top-p (nucleus) sampling (0.0 to 1.0). Controls diversity of output.                               |
-| `top_k`                           | `int`       | `NOT_GIVEN` | Top-k sampling parameter.                                                                          |
-| `seed`                            | `int`       | `NOT_GIVEN` | Random seed for deterministic outputs.                                                             |
-| `stop_sequences`                  | `List[str]` | `NOT_GIVEN` | List of strings that stop generation when encountered.                                             |
-| `latency`                         | `str`       | `NOT_GIVEN` | Performance mode: `"standard"` or `"optimized"`.                                                   |
-| `additional_model_request_fields` | `dict`      | `NOT_GIVEN` | Additional model-specific parameters passed directly to the API.                                   |
+| Parameter                         | Type        | Default     | Description                                                                                                                                                                                              |
+| --------------------------------- | ----------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model`                           | `str`       | `None`      | AWS Bedrock model identifier. _(Inherited from base settings.)_                                                                                                                                          |
+| `system_instruction`              | `str`       | `None`      | System instruction/prompt for the model. _(Inherited from base settings.)_                                                                                                                               |
+| `max_tokens`                      | `int`       | `NOT_GIVEN` | Maximum number of tokens to generate.                                                                                                                                                                    |
+| `temperature`                     | `float`     | `NOT_GIVEN` | Sampling temperature (0.0 to 1.0). Lower values are more focused, higher values are more creative.                                                                                                       |
+| `top_p`                           | `float`     | `NOT_GIVEN` | Top-p (nucleus) sampling (0.0 to 1.0). Controls diversity of output.                                                                                                                                     |
+| `top_k`                           | `int`       | `NOT_GIVEN` | Top-k sampling parameter.                                                                                                                                                                                |
+| `seed`                            | `int`       | `NOT_GIVEN` | Random seed for deterministic outputs.                                                                                                                                                                   |
+| `stop_sequences`                  | `List[str]` | `NOT_GIVEN` | List of strings that stop generation when encountered.                                                                                                                                                   |
+| `latency`                         | `str`       | `NOT_GIVEN` | Performance mode: `"standard"` or `"optimized"`.                                                                                                                                                         |
+| `enable_prompt_caching`           | `bool`      | `NOT_GIVEN` | Whether to enable prompt caching by adding cachePoint markers to system prompts and tool definitions. Can reduce TTFT by up to 85% for multi-turn conversations. See [AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html). |
+| `additional_model_request_fields` | `dict`      | `NOT_GIVEN` | Additional model-specific parameters passed directly to the API.                                                                                                                                         |
 
 <Note>
   `NOT_GIVEN` values are omitted from the inference config, letting the Bedrock


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4219](https://github.com/pipecat-ai/pipecat/pull/4219).

## Changes

- **server/services/llm/aws.mdx**: Added `enable_prompt_caching` parameter to Settings table
  - New boolean parameter with default `NOT_GIVEN`
  - Enables prompt caching by adding cachePoint markers to system prompts and tool definitions
  - Can reduce TTFT by up to 85% for multi-turn conversations
  - Includes link to AWS Bedrock prompt caching documentation

## Gaps identified

None