### PR TITLE
docs: update for pipecat PR #4228

### DIFF
--- a/api-reference/server/frames/system-frames.mdx
+++ b/api-reference/server/frames/system-frames.mdx
@@ -19,11 +19,6 @@ The first frame pushed into a pipeline, initializing all processors. Every proce
   Output audio sample rate in Hz.
 </ParamField>
 
-<ParamField path="allow_interruptions" type="bool" default="False">
-  Whether user interruptions are allowed. Deprecated since 0.0.99: use
-  interruption strategies instead.
-</ParamField>
-
 <ParamField path="enable_metrics" type="bool" default="False">
   Enable performance metrics collection from processors.
 </ParamField>
@@ -34,14 +29,6 @@ The first frame pushed into a pipeline, initializing all processors. Every proce
 
 <ParamField path="enable_usage_metrics" type="bool" default="False">
   Enable usage metrics (token counts, API calls) from services.
-</ParamField>
-
-<ParamField
-  path="interruption_strategies"
-  type="List[BaseInterruptionStrategy]"
-  default="[]"
->
-  List of interruption strategies for the pipeline. Deprecated since 0.0.99.
 </ParamField>
 
 <ParamField path="report_only_initial_ttfb" type="bool" default="False">

--- a/api-reference/server/pipeline/pipeline-params.mdx
+++ b/api-reference/server/pipeline/pipeline-params.mdx
@@ -28,17 +28,6 @@ task = PipelineTask(pipeline, params=params)
 
 ## Available Parameters
 
-<ParamField path="allow_interruptions" type="bool" default="True" deprecated>
-  <Warning>
-    DEPRECATED: This parameter is deprecated. Configure interruption behavior
-    via [User Turn
-    Strategies](/api-reference/server/utilities/turn-management/user-turn-strategies) instead.
-    See the `enable_interruptions` parameter on start strategies.
-  </Warning>
-  Whether to allow pipeline interruptions. When enabled, a user's speech will
-  immediately interrupt the bot's response.
-</ParamField>
-
 <ParamField path="audio_in_sample_rate" type="int" default="16000">
   Input audio sample rate in Hz.
 

--- a/api-reference/server/services/stt/google.mdx
+++ b/api-reference/server/services/stt/google.mdx
@@ -195,7 +195,7 @@ await task.queue_frame(
 - **Streaming time limit**: Google Cloud STT has a 5-minute streaming limit per connection. The service automatically handles stream reconnection at 4 minutes to provide seamless transcription without interruption.
 - **Multi-language support**: Pass a list of `Language` values to `languages` for multi-language recognition. The first language is the primary language.
 - **Regional endpoints**: Use the `location` parameter to route requests through regional endpoints (e.g., `"us-central1"`, `"europe-west1"`) for data residency requirements. The default `"global"` endpoint works for most use cases.
-- **Stream abort on inactivity**: If no audio is sent for ~10 seconds (e.g., when audio frames are blocked by an `STTMuteFilter`), Google automatically closes the stream. The service recovers by automatically reconnecting.
+- **Stream abort on inactivity**: If no audio is sent for ~10 seconds (e.g., when audio frames are blocked), Google automatically closes the stream. The service recovers by automatically reconnecting.
 - **Authentication priority**: The service checks for credentials in this order: `credentials` (JSON string), `credentials_path` (file), then Application Default Credentials.
 
 <Tip>


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4228](https://github.com/pipecat-ai/pipecat/pull/4228).

## Changes

**`server/pipeline/pipeline-params.mdx`** — Removed `allow_interruptions` parameter from PipelineParams documentation. This parameter was removed from the source code as it was deprecated in v0.0.99.

**`server/frames/system-frames.mdx`** — Removed `allow_interruptions` and `interruption_strategies` parameters from StartFrame documentation. Both parameters were removed from the source code.

**`server/services/stt/google.mdx`** — Updated note about stream abort on inactivity to remove specific reference to `STTMuteFilter` (which was deprecated and deleted), now just says "when audio frames are blocked".

## Context

PR #4228 removed all deprecated turn management code that was replaced by `LLMUserAggregator`'s `user_turn_strategies` and `user_mute_strategies` parameters in v0.0.99. These documentation changes reflect the removal of those deprecated parameters.

## Gaps identified

None. The deprecated documentation pages for `STTMuteFilter`, `TranscriptProcessor`, and `interruption-strategies` already have prominent deprecation warnings directing users to the new APIs, so no additional changes are needed for those pages.