### PR TITLE
docs: update for pipecat PR #4232

### DIFF
--- a/api-reference/server/services/s2s/openai.mdx
+++ b/api-reference/server/services/s2s/openai.mdx
@@ -126,6 +126,10 @@ _Deprecated in v0.0.105. Use `settings=OpenAIRealtimeLLMService.Settings(session
   `"high"` provides more detail.
 </ParamField>
 
+<ParamField path="**kwargs" type="Any">
+  Additional arguments passed to parent LLMService.
+</ParamField>
+
 ### Settings
 
 Runtime-configurable settings passed via the `settings` constructor argument using `OpenAIRealtimeLLMService.Settings(...)`. These can be updated mid-conversation with `LLMUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.

--- a/api-reference/server/services/stt/deepgram.mdx
+++ b/api-reference/server/services/stt/deepgram.mdx
@@ -168,11 +168,6 @@ Before using `DeepgramSageMakerSTTService` or `DeepgramFluxSageMakerSTTService`,
   Additional Deepgram features to enable.
 </ParamField>
 
-<ParamField path="should_interrupt" type="bool" default="True" deprecated>
-  Whether to interrupt the bot when Deepgram VAD detects user speech.
-  *Deprecated in v0.0.99. Will be removed along with `vad_events` support.*
-</ParamField>
-
 <ParamField path="ttfs_p99_latency" type="float" default="DEEPGRAM_TTFS_P99">
   P99 latency from speech end to final transcript in seconds. Override for your
   deployment.
@@ -201,7 +196,6 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 | `search`           | `str \| list`     | `None`             | Search terms to highlight.                                   |
 | `smart_format`     | `bool`            | `False`            | Apply smart formatting to transcripts.                       |
 | `utterance_end_ms` | `int`             | `None`             | Silence duration in ms before an utterance-end event.        |
-| `vad_events`       | `bool`            | `False`            | Enable Deepgram's built-in VAD events (deprecated).          |
 
 ### Usage
 
@@ -232,27 +226,11 @@ stt = DeepgramSTTService(
 ### Notes
 
 - **Finalize on VAD stop**: When the pipeline's VAD detects the user has stopped speaking, the service sends a [finalize](https://developers.deepgram.com/docs/finalize) request to Deepgram for faster final transcript delivery.
-- **Deprecated vad_events**: The `vad_events` setting is deprecated. Use Silero VAD instead.
 - **Multilingual support**: Deepgram Nova models support many languages. The default is `Language.EN` (English). Set `language="multi"` in settings to enable multilingual transcription, which will detect and transcribe multiple languages within the same audio stream.
 
 ### Event Handlers
 
-Supports the standard [service connection events](/api-reference/server/events/service-events) (`on_connected`, `on_disconnected`, `on_connection_error`), plus:
-
-| Event               | Description                           |
-| ------------------- | ------------------------------------- |
-| `on_speech_started` | Speech detected in the audio stream   |
-| `on_utterance_end`  | End of utterance detected by Deepgram |
-
-```python
-@stt.event_handler("on_speech_started")
-async def on_speech_started(service):
-    print("User started speaking")
-
-@stt.event_handler("on_utterance_end")
-async def on_utterance_end(service):
-    print("Utterance ended")
-```
+Supports the standard [service connection events](/api-reference/server/events/service-events) (`on_connected`, `on_disconnected`, `on_connection_error`).
 
 ## DeepgramFluxSTTService
 
@@ -260,8 +238,8 @@ async def on_utterance_end(service):
   Since Deepgram Flux provides its own user turn start and end detection, you
   should use `ExternalUserTurnStrategies` to let Flux handle turn management.
   See [User Turn
-  Strategies](/api-reference/server/utilities/turn-management/user-turn-strategies) for
-  configuration details.
+  Strategies](/api-reference/server/utilities/turn-management/user-turn-strategies)
+  for configuration details.
 </Note>
 
 <ParamField path="api_key" type="str" required>
@@ -503,8 +481,8 @@ Supports the standard [service connection events](/api-reference/server/events/s
   Since Deepgram Flux provides its own user turn start and end detection, you
   should use `ExternalUserTurnStrategies` to let Flux handle turn management.
   See [User Turn
-  Strategies](/api-reference/server/utilities/turn-management/user-turn-strategies) for
-  configuration details.
+  Strategies](/api-reference/server/utilities/turn-management/user-turn-strategies)
+  for configuration details.
 </Note>
 
 <ParamField path="endpoint_name" type="str" required>


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4232](https://github.com/pipecat-ai/pipecat/pull/4232).

## Changes

### server/services/stt/deepgram.mdx
- Removed deprecated `should_interrupt` parameter from DeepgramSTTService configuration
- Removed `vad_events` setting from Settings table (feature fully removed)
- Removed `on_speech_started` and `on_utterance_end` event handlers section
- Removed note about deprecated `vad_events` (no longer relevant)

### server/services/s2s/openai.mdx
- Added `**kwargs` parameter to configuration section for completeness

## Gaps identified

None. All source file changes that affect public API documentation have been addressed:

- ✅ `services/deepgram/stt.py` → `server/services/stt/deepgram.mdx` (updated)
- ✅ `services/openai/realtime/llm.py` → `server/services/s2s/openai.mdx` (updated)
- ✅ `services/xai/realtime/llm.py` → No doc changes needed (internal code fix only)
- ✅ `processors/user_idle_processor.py` → Already marked deprecated in docs
- ✅ `transports/base_transport.py` → Already marked deprecated in docs
- ✅ `turns/user_stop/transcription_user_turn_stop_strategy.py` → Not documented
- ✅ `observers/loggers/user_bot_latency_log_observer.py` → Already noted as deprecated