### PR TITLE
docs: update for pipecat PR #4236

### DIFF
--- a/api-reference/server/utilities/observers/observer-pattern.mdx
+++ b/api-reference/server/utilities/observers/observer-pattern.mdx
@@ -5,13 +5,6 @@ description: "Understanding and implementing observers in Pipecat"
 
 The Observer pattern in Pipecat allows non-intrusive monitoring of frames as they flow through the pipeline. Observers can watch frame traffic without affecting the pipeline's core functionality.
 
-<Warning>
-  DEPRECATED: The old observer pattern with individual parameters
-  (`on_push_frame(src, dst, frame, direction, timestamp)`) is deprecated. Use
-  the new pattern with data objects (`on_push_frame(data: FramePushed)`)
-  instead.
-</Warning>
-
 ## Base Observer
 
 All observers must inherit from `BaseObserver` and can implement these methods:


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4236](https://github.com/pipecat-ai/pipecat/pull/4236).

## Changes

**server/utilities/observers/observer-pattern.mdx**
- Removed deprecation warning for old `on_push_frame(src, dst, frame, direction, timestamp)` signature
- The old signature support was completely removed from `task_observer.py` in PR #4236
- Documentation now only shows the current `on_push_frame(data: FramePushed)` method

## Gaps identified

None. All other deprecation removals in PR #4236 (UserImageRequestFrame.context, expect_stripped_words parameter, LiveKitTransportMessage frames, and turns.mute module) were not referenced in the documentation.