### PR TITLE
docs: update for pipecat PR #4217

### DIFF
--- a/api-reference/server/frames/control-frames.mdx
+++ b/api-reference/server/frames/control-frames.mdx
@@ -213,7 +213,16 @@ Inherits from `UninterruptibleFrame`, ensuring it reaches downstream processors 
 </ParamField>
 
 <ParamField path="cancel_on_interruption" type="bool" default="False">
-  Whether the function call should be cancelled if the user interrupts.
+  Whether the function call should be cancelled if the user interrupts. When
+  `False`, the call is treated as asynchronous: the LLM continues the
+  conversation immediately without waiting for the result, and the result is
+  injected later via a developer message.
+</ParamField>
+
+<ParamField path="group_id" type="Optional[str]" default="None">
+  Shared identifier for all function calls from the same LLM response batch.
+  Used to determine when the last call in a group completes so the LLM can be
+  triggered exactly once.
 </ParamField>
 
 ## TTS State

--- a/api-reference/server/utilities/service-switchers/llm-switcher.mdx
+++ b/api-reference/server/utilities/service-switchers/llm-switcher.mdx
@@ -91,7 +91,10 @@ llm_switcher.register_function(
 </ParamField>
 
 <ParamField path="cancel_on_interruption" type="bool" default="True">
-  Whether to cancel this function call when a user interruption occurs.
+  Whether to cancel this function call when a user interruption occurs. When
+  `False`, the call is treated as asynchronous: the LLM continues the
+  conversation immediately without waiting for the result, and the result is
+  injected later via a developer message.
 </ParamField>
 
 <ParamField path="timeout_secs" type="Optional[float]" default="None">
@@ -115,7 +118,10 @@ llm_switcher.register_direct_function(
 </ParamField>
 
 <ParamField path="cancel_on_interruption" type="bool" default="True">
-  Whether to cancel this function call when a user interruption occurs.
+  Whether to cancel this function call when a user interruption occurs. When
+  `False`, the call is treated as asynchronous: the LLM continues the
+  conversation immediately without waiting for the result, and the result is
+  injected later via a developer message.
 </ParamField>
 
 <ParamField path="timeout_secs" type="Optional[float]" default="None">

--- a/pipecat/learn/function-calling.mdx
+++ b/pipecat/learn/function-calling.mdx
@@ -321,10 +321,12 @@ llm.register_direct_function(
 **Key registration options:**
 
 - **`cancel_on_interruption=True`** (default): Function call is cancelled if user interrupts
-- **`cancel_on_interruption=False`**: Function call continues even if user interrupts
+- **`cancel_on_interruption=False`**: Function call continues as async; LLM doesn't wait for result before continuing
 - **`timeout_secs=None`** (default): Optional per-tool timeout in seconds. Overrides the global `function_call_timeout_secs` for this specific function
 
-Use `cancel_on_interruption=False` for critical operations that should complete even if the user starts speaking. Function calls are async, so you can continue the conversation while the function executes. Once the result returns, the LLM will automatically incorporate it into the conversation context. LLMs vary in terms of how well they incorporate changes to _previous_ messages, so you may need to experiment with your LLM provider to see how it handles this.
+Use `cancel_on_interruption=False` for long-running operations or when you want the LLM to continue the conversation without waiting. When set to `False`, the function call is treated as **asynchronous**: the LLM continues the conversation immediately without waiting for the result. Once the result returns, it's injected back into the context as a developer message, triggering a new LLM inference at that point. This allows for truly non-blocking function calls where the conversation can proceed while the function executes in the background.
+
+Use `cancel_on_interruption=True` (the default) when the LLM should wait for the function result before responding. This ensures the LLM has the complete information before generating its next response.
 
 Use `timeout_secs` to set a specific timeout for a function that differs from the global default. For example, you might want a longer timeout for database queries or shorter timeouts for quick lookups.
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4217](https://github.com/pipecat-ai/pipecat/pull/4217).

## Changes

### api-reference/server/frames/control-frames.mdx
- Added `group_id` parameter to `FunctionCallInProgressFrame` — shared identifier for function calls from the same LLM response batch
- Updated `cancel_on_interruption` description to clarify async behavior: when `False`, the LLM continues immediately without waiting for the result

### api-reference/server/utilities/service-switchers/llm-switcher.mdx
- Updated `cancel_on_interruption` parameter descriptions in both `register_function()` and `register_direct_function()` to explain async function calling behavior

### pipecat/learn/function-calling.mdx
- Enhanced explanation of `cancel_on_interruption=False` behavior in the function calling guide
- Clarified that async function calls allow the LLM to continue conversation without waiting for results
- Added clearer guidance on when to use `True` vs `False` for this parameter

## Gaps identified

None. The `group_parallel_tools` parameter added to `LLMService` is an advanced constructor parameter with a sensible default (`True`). Since LLM service doc pages don't currently document base class constructor parameters (only provider-specific ones), and this parameter isn't essential for basic usage, it was not added to individual service pages.