### PR TITLE
docs: update for pipecat PR #4251

### DIFF
--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -108,6 +108,7 @@ Text-to-Speech services receive text input and output audio streams or chunks.
 | [Kokoro](/api-reference/server/services/tts/kokoro)             | `pip install "pipecat-ai[kokoro]"`       |
 | [LMNT](/api-reference/server/services/tts/lmnt)                 | `pip install "pipecat-ai[lmnt]"`         |
 | [MiniMax](/api-reference/server/services/tts/minimax)           | No dependencies required                 |
+| [Mistral](/api-reference/server/services/tts/mistral)           | `pip install "pipecat-ai[mistral]"`      |
 | [Neuphonic](/api-reference/server/services/tts/neuphonic)       | `pip install "pipecat-ai[neuphonic]"`    |
 | [NVIDIA](/api-reference/server/services/tts/nvidia)             | `pip install "pipecat-ai[nvidia]"`       |
 | [OpenAI](/api-reference/server/services/tts/openai)             | `pip install "pipecat-ai[openai]"`       |

--- a/api-reference/server/services/tts/mistral.mdx
+++ b/api-reference/server/services/tts/mistral.mdx
@@ -1,0 +1,125 @@
+---
+title: "Mistral"
+description: "Text-to-speech services using Mistral's Voxtral TTS API"
+---
+
+## Overview
+
+Mistral provides high-quality text-to-speech synthesis through the Voxtral TTS API. The service uses HTTP streaming with Server-Sent Events to deliver PCM-encoded audio at 24kHz, with automatic resampling to any requested sample rate.
+
+<CardGroup cols={2}>
+  <Card
+    title="Mistral TTS API Reference"
+    icon="code"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.mistral.tts.html"
+  >
+    Pipecat's API methods for Mistral TTS integration
+  </Card>
+  <Card
+    title="Example Implementation"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-mistral.py"
+  >
+    Complete example with voice conversation
+  </Card>
+  <Card
+    title="Mistral Documentation"
+    icon="book"
+    href="https://docs.mistral.ai/"
+  >
+    Official Mistral API documentation and features
+  </Card>
+</CardGroup>
+
+## Installation
+
+To use Mistral TTS, install the required dependencies:
+
+```bash
+pip install "pipecat-ai[mistral]"
+```
+
+## Prerequisites
+
+### Mistral Account Setup
+
+Before using Mistral TTS services, you need:
+
+1. **Mistral Account**: Sign up at [Mistral](https://mistral.ai/)
+2. **API Key**: Generate an API key from your account dashboard
+3. **Voice Selection**: Choose voice IDs from the Mistral voice library
+
+### Required Environment Variables
+
+- `MISTRAL_API_KEY`: Your Mistral API key for authentication
+
+## Configuration
+
+<ParamField path="api_key" type="str">
+  Mistral API key for authentication. If `None`, uses the `MISTRAL_API_KEY` environment variable.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="None">
+  Output audio sample rate in Hz. When `None`, uses the pipeline's configured sample rate. Audio is automatically resampled from Mistral's native 24kHz.
+</ParamField>
+
+<ParamField path="settings" type="MistralTTSService.Settings" default="None">
+  Runtime-configurable settings. See [Settings](#settings) below.
+</ParamField>
+
+### Settings
+
+Runtime-configurable settings passed via the `settings` constructor argument using `MistralTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
+
+| Parameter  | Type             | Default                  | Description                                               |
+| ---------- | ---------------- | ------------------------ | --------------------------------------------------------- |
+| `model`    | `str`            | `voxtral-mini-tts-2603` | TTS model identifier.                                     |
+| `voice`    | `str`            | `None`                   | Voice identifier for synthesis.                           |
+| `language` | `Language \| str`| `None`                   | Language for speech synthesis. _(Inherited from base settings.)_ |
+
+## Usage
+
+### Basic Setup
+
+```python
+import os
+from pipecat.services.mistral.tts import MistralTTSService
+
+tts = MistralTTSService(
+    api_key=os.getenv("MISTRAL_API_KEY"),
+    settings=MistralTTSService.Settings(
+        voice="c69964a6-ab8b-4f8a-9465-ec0925096ec8",
+    ),
+)
+```
+
+### With Custom Model
+
+```python
+tts = MistralTTSService(
+    api_key=os.getenv("MISTRAL_API_KEY"),
+    settings=MistralTTSService.Settings(
+        model="voxtral-mini-tts-2603",
+        voice="your-voice-id",
+    ),
+)
+```
+
+### With Custom Sample Rate
+
+```python
+tts = MistralTTSService(
+    api_key=os.getenv("MISTRAL_API_KEY"),
+    sample_rate=16000,  # Output at 16kHz instead of default
+    settings=MistralTTSService.Settings(
+        voice="your-voice-id",
+    ),
+)
+```
+
+## Notes
+
+- **Streaming**: The service uses Server-Sent Events for real-time audio streaming.
+- **Resampling**: Audio is automatically resampled from Mistral's native 24kHz to any requested sample rate.
+- **Audio format**: The service receives float32 PCM audio from the API and converts it to int16 PCM for the Pipecat pipeline.
+- **Metrics**: The service supports metrics generation for monitoring TTS performance.

--- a/docs.json
+++ b/docs.json
@@ -427,6 +427,7 @@
                       "api-reference/server/services/tts/kokoro",
                       "api-reference/server/services/tts/lmnt",
                       "api-reference/server/services/tts/minimax",
+                      "api-reference/server/services/tts/mistral",
                       "api-reference/server/services/tts/neuphonic",
                       "api-reference/server/services/tts/nvidia",
                       "api-reference/server/services/tts/openai",


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4251](https://github.com/pipecat-ai/pipecat/pull/4251).

## Changes

### New service page
- **api-reference/server/services/tts/mistral.mdx**: Created documentation page for MistralTTSService
  - Overview of Mistral's Voxtral TTS API with HTTP streaming via Server-Sent Events
  - Installation instructions (`pip install "pipecat-ai[mistral]"`)
  - Prerequisites (API key setup)
  - Configuration parameters (api_key, sample_rate, settings)
  - Settings table (model, voice, language)
  - Usage examples (basic setup, custom model, custom sample rate)
  - Notes on streaming, resampling from 24kHz, audio format conversion, and metrics support

### Navigation updates
- **docs.json**: Added `api-reference/server/services/tts/mistral` to Text-to-Speech group (alphabetically between minimax and neuphonic)

### Service listing updates
- **api-reference/server/services/supported-services.mdx**: Added Mistral to TTS services table with installation command

## Gaps identified

None