### PR TITLE
docs: update for pipecat PR #4265

### DIFF
--- a/api-reference/server/services/tts/elevenlabs.mdx
+++ b/api-reference/server/services/tts/elevenlabs.mdx
@@ -89,6 +89,15 @@ export ELEVENLABS_API_KEY=your_api_key
   sample rate.
 </ParamField>
 
+<ParamField path="auto_mode" type="bool" default="None">
+  Whether to enable ElevenLabs' auto mode, which reduces latency by disabling
+  server-side chunk scheduling and buffering. Recommended when sending complete
+  sentences or phrases. When `None` (default), auto mode is automatically
+  enabled for `SENTENCE` aggregation and disabled for `TOKEN` aggregation —
+  because token streaming relies on the server-side chunk scheduler to
+  accumulate enough text for natural-sounding synthesis.
+</ParamField>
+
 <ParamField
   path="text_aggregation_mode"
   type="TextAggregationMode"
@@ -230,7 +239,7 @@ async with aiohttp.ClientSession() as session:
 
 - **Multilingual models required for `language`**: Setting `language` with a non-multilingual model (e.g. `eleven_turbo_v2_5`) has no effect. Use `eleven_multilingual_v2` or similar.
 - **WebSocket vs HTTP**: The WebSocket service supports word-level timestamps and interruption handling, making it significantly better for interactive conversations. The HTTP service is simpler but lacks these features.
-- **Text aggregation**: Sentence aggregation is enabled by default (`text_aggregation_mode=TextAggregationMode.SENTENCE`). Buffering until sentence boundaries produces more natural speech. Set `text_aggregation_mode=TextAggregationMode.TOKEN` to stream tokens directly for lower latency, but you must also set `auto_mode=False` in `settings` when using TOKEN mode.
+- **Text aggregation**: Sentence aggregation is enabled by default (`text_aggregation_mode=TextAggregationMode.SENTENCE`). Buffering until sentence boundaries produces more natural speech. Set `text_aggregation_mode=TextAggregationMode.TOKEN` to stream tokens directly for lower latency. The `auto_mode` parameter is automatically configured based on the aggregation mode for optimal quality.
 
 ## Event Handlers
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4265](https://github.com/pipecat-ai/pipecat/pull/4265).

## Changes

**api-reference/server/services/tts/elevenlabs.mdx**:
- Added `auto_mode` parameter to Configuration section with updated default behavior
- Updated Notes section to reflect that `auto_mode` is now automatically configured based on `text_aggregation_mode`

The PR fixes incorrect `auto_mode` behavior when using `TextAggregationMode.TOKEN`. Previously, `auto_mode` defaulted to `True` which degraded speech quality in token streaming mode. Now `auto_mode` defaults to `None` and is automatically derived:
- `auto_mode=True` for `SENTENCE` aggregation (complete sentences benefit from reduced latency)
- `auto_mode=False` for `TOKEN` aggregation (token streaming needs server-side buffering for natural synthesis)

## Gaps identified

None