### PR TITLE
docs: update for pipecat PR #4268

### DIFF
--- a/api-reference/server/services/transport/lemonslice.mdx
+++ b/api-reference/server/services/transport/lemonslice.mdx
@@ -126,7 +126,11 @@ Configuration for creating a new LemonSlice session.
 </ParamField>
 
 <ParamField path="lemonslice_properties" type="dict" default="None">
-  Additional properties to pass to the LemonSlice session.
+  Additional connection properties to pass to the LemonSlice session.
+</ParamField>
+
+<ParamField path="api_url" type="str" default="None">
+  Override the LemonSlice API URL endpoint.
 </ParamField>
 
 ### LemonSliceParams
@@ -169,14 +173,17 @@ transport instance.
 
 ### Events Summary
 
-| Event                    | Description                                            |
-| ------------------------ | ------------------------------------------------------ |
-| `on_client_connected`    | Participant (non-avatar) connected to the session      |
-| `on_client_disconnected` | Participant (non-avatar) disconnected from the session |
+| Event                     | Description                                            |
+| ------------------------- | ------------------------------------------------------ |
+| `on_client_connected`     | Participant (non-avatar) connected to the session      |
+| `on_client_disconnected`  | Participant (non-avatar) disconnected from the session |
+| `on_avatar_connected`     | LemonSlice avatar connected to the session             |
+| `on_avatar_disconnected`  | LemonSlice avatar disconnected from the session        |
 
 <Note>
-  The LemonSlice avatar participant is automatically filtered out from these
-  events. Only human participant connections trigger the event handlers.
+  The `on_client_connected` and `on_client_disconnected` events are only
+  triggered for human participants. The LemonSlice avatar triggers separate
+  `on_avatar_connected` and `on_avatar_disconnected` events.
 </Note>
 
 ### Connection Lifecycle
@@ -215,6 +222,41 @@ async def on_client_disconnected(transport, participant):
 | ------------- | --------------------- | ---------------------- |
 | `transport`   | `LemonSliceTransport` | The transport instance |
 | `participant` | `Mapping[str, Any]`   | The participant data   |
+
+#### on_avatar_connected
+
+Fired when the LemonSlice avatar connects to the session.
+
+```python
+@transport.event_handler("on_avatar_connected")
+async def on_avatar_connected(transport, participant):
+    print(f"Avatar connected: {participant}")
+```
+
+**Parameters:**
+
+| Parameter     | Type                  | Description            |
+| ------------- | --------------------- | ---------------------- |
+| `transport`   | `LemonSliceTransport` | The transport instance |
+| `participant` | `Mapping[str, Any]`   | The participant data   |
+
+#### on_avatar_disconnected
+
+Fired when the LemonSlice avatar disconnects from the session.
+
+```python
+@transport.event_handler("on_avatar_disconnected")
+async def on_avatar_disconnected(transport, participant, reason):
+    print(f"Avatar disconnected: {participant}, reason: {reason}")
+```
+
+**Parameters:**
+
+| Parameter     | Type                  | Description                      |
+| ------------- | --------------------- | -------------------------------- |
+| `transport`   | `LemonSliceTransport` | The transport instance           |
+| `participant` | `Mapping[str, Any]`   | The participant data             |
+| `reason`      | `str`                 | The reason for the disconnection |
 
 ## Notes
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4268](https://github.com/pipecat-ai/pipecat/pull/4268).

## Changes

Updated **api-reference/server/services/transport/lemonslice.mdx**:

- **Configuration**: Added `api_url` parameter to `LemonSliceNewSessionRequest` for overriding the LemonSlice API endpoint
- **Configuration**: Updated `lemonslice_properties` description to clarify it's for connection properties
- **Event Handlers**: Added `on_avatar_connected` event handler that fires when the LemonSlice avatar joins the session
- **Event Handlers**: Added `on_avatar_disconnected` event handler that fires when the LemonSlice avatar leaves the session (includes `reason` parameter)
- **Event Handlers**: Updated the note to clarify that client events and avatar events are separate

## Gaps identified

None