### PR TITLE
docs: update for pipecat PR #4067

### DIFF
--- a/api-reference/server/services/llm/google.mdx
+++ b/api-reference/server/services/llm/google.mdx
@@ -116,8 +116,9 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 <Note>
   `NOT_GIVEN` values are omitted from the API request, letting the Gemini API
-  use its own defaults. If `thinking` is not provided, Pipecat disables thinking
-  for Gemini 2.5 Flash models (where possible) to reduce latency.
+  use its own defaults. If `thinking` is not provided, Pipecat applies low-latency
+  thinking defaults for Flash models: Gemini 2.5 Flash uses `thinking_budget=0`
+  (disables thinking), while Gemini 3+ Flash uses `thinking_level="minimal"`.
 </Note>
 
 ### GoogleThinkingConfig
@@ -222,7 +223,7 @@ await task.queue_frame(
 ## Notes
 
 - **System instruction priority**: The `system_instruction` set via the constructor or `GoogleLLMSettings` takes priority over any system message in the context. If both are set, a warning is logged and the constructor/settings value is used.
-- **Thinking defaults**: By default, Pipecat disables thinking for Gemini 2.5 Flash models to reduce latency. To enable it, explicitly pass a `GoogleThinkingConfig` via `settings`.
+- **Thinking defaults**: By default, Pipecat applies low-latency thinking defaults for Flash models to reduce latency. Gemini 2.5 Flash uses `thinking_budget=0` (disables thinking), while Gemini 3+ Flash uses `thinking_level="minimal"`. To override this behavior, explicitly pass a `GoogleThinkingConfig` via `settings`.
 - **Multimodal support**: Gemini models natively support image and audio inputs through Google's Content/Part format. Images and audio are automatically converted from OpenAI-style contexts.
 - **Grounding with Google Search**: When grounding metadata is present in the response (e.g., from Google Search tool), the service emits `LLMSearchResponseFrame` with search results and source attributions.
 - **Context format**: The service automatically converts between OpenAI-style message formats and Google's native Content/Part format, so you can use either.


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4067](https://github.com/pipecat-ai/pipecat/pull/4067).

## Changes
- **api-reference/server/services/llm/google.mdx**: Updated thinking defaults documentation to reflect that Gemini 3+ Flash models now use `thinking_level="minimal"` for low-latency defaults, while Gemini 2.5 Flash continues to use `thinking_budget=0`.

## Gaps identified
None