### PR TITLE
docs: link API keys dashboard entry to account/tokens page

### DIFF
--- a/pipecat-cloud/guides/personal-access-tokens.mdx
+++ b/pipecat-cloud/guides/personal-access-tokens.mdx
@@ -22,7 +22,7 @@ Personal Access Tokens (PATs) let you authenticate with Pipecat Cloud without an
 
 ## Creating a PAT
 
-Generate a PAT from the [Pipecat Cloud dashboard](https://pipecat.daily.co/):
+Generate a PAT from the [Pipecat Cloud dashboard](https://pipecat.daily.co/account/tokens):
 
 <Steps>
   <Step title="Open account settings">


### PR DESCRIPTION
## Summary

- Updates the "Creating a PAT" dashboard link in `pipecat-cloud/guides/personal-access-tokens.mdx` to point directly to `https://pipecat.daily.co/account/tokens` instead of the generic dashboard homepage
- Improves discoverability of the Account Settings / Personal Access Token page (PCC-727)

## Test plan

- [x] Verify the link in the "Creating a PAT" section opens the correct Account Settings tokens page