### PR TITLE
docs: update for pipecat PR #4249

### DIFF
--- a/api-reference/server/services/tts/nvidia.mdx
+++ b/api-reference/server/services/tts/nvidia.mdx
@@ -1,33 +1,33 @@
 ---
-title: "NVIDIA Riva"
-description: "Text-to-speech service implementation using NVIDIA Riva"
+title: "NVIDIA Nemotron Speech"
+description: "Text-to-speech service implementation using NVIDIA Nemotron Speech"
 ---
 
 ## Overview
 
-`NvidiaTTSService` provides high-quality text-to-speech synthesis through NVIDIA Riva's cloud-based AI models accessible via gRPC API. The service offers multilingual support, configurable quality settings, and streaming audio generation optimized for real-time applications.
+`NvidiaTTSService` provides high-quality text-to-speech synthesis through NVIDIA Nemotron Speech's cloud-based AI models accessible via gRPC API. The service offers multilingual support, configurable quality settings, cross-sentence audio stitching, and streaming audio generation optimized for real-time applications.
 
 <CardGroup cols={2}>
   <Card
-    title="NVIDIA Riva TTS API Reference"
+    title="NVIDIA Nemotron Speech TTS API Reference"
     icon="code"
     href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.riva.tts.html"
   >
-    Pipecat's API methods for NVIDIA Riva TTS integration
+    Pipecat's API methods for NVIDIA Nemotron Speech TTS integration
   </Card>
   <Card
     title="Example Implementation"
     icon="play"
     href="https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-nvidia.py"
   >
-    Complete example with Riva NIM
+    Complete example with Nemotron Speech NIM
   </Card>
   <Card
-    title="NVIDIA Riva Documentation"
+    title="NVIDIA TTS NIM Documentation"
     icon="book"
-    href="https://docs.nvidia.com/deeplearning/riva/user-guide/docs/tts/tts-overview.html"
+    href="https://docs.nvidia.com/nim/speech/latest/tts/"
   >
-    Official NVIDIA Riva TTS documentation
+    Official NVIDIA TTS NIM documentation
   </Card>
   <Card
     title="NVIDIA Developer Portal"
@@ -40,7 +40,7 @@ description: "Text-to-speech service implementation using NVIDIA Riva"
 
 ## Installation
 
-To use NVIDIA Riva services, install the required dependencies:
+To use NVIDIA Nemotron Speech services, install the required dependencies:
 
 ```bash
 pip install "pipecat-ai[nvidia]"
@@ -48,28 +48,32 @@ pip install "pipecat-ai[nvidia]"
 
 ## Prerequisites
 
-### NVIDIA Riva Setup
+### NVIDIA Nemotron Speech Setup
 
-Before using Riva TTS services, you need:
+Before using Nemotron Speech TTS services, you need:
 
 1. **NVIDIA Developer Account**: Sign up at [NVIDIA Developer Portal](https://developer.nvidia.com/)
-2. **API Key**: Generate an NVIDIA API key for Riva services
-3. **Riva Access**: Ensure access to NVIDIA Riva TTS services
+2. **API Key**: Generate an NVIDIA API key for Nemotron Speech services (required for cloud endpoint)
+3. **Nemotron Speech Access**: Ensure access to NVIDIA Nemotron Speech TTS services
+
+For local deployments, see the [NVIDIA TTS NIM documentation](https://docs.nvidia.com/nim/speech/latest/tts/).
 
 ### Required Environment Variables
 
-- `NVIDIA_API_KEY`: Your NVIDIA API key for authentication
+- `NVIDIA_API_KEY`: Your NVIDIA API key for authentication (required for cloud endpoint, not needed for local deployments)
 
 ## Configuration
 
 ### NvidiaTTSService
 
-<ParamField path="api_key" type="str" required>
-  NVIDIA API key for authentication.
+<ParamField path="api_key" type="str" default="None">
+  NVIDIA API key for authentication. Required when using the cloud endpoint.
+  Not needed for local deployments.
 </ParamField>
 
 <ParamField path="server" type="str" default="grpc.nvcf.nvidia.com:443">
-  gRPC server endpoint.
+  gRPC server endpoint. Defaults to NVIDIA's cloud endpoint. For local
+  deployments, pass the local address (e.g. `localhost:50051`).
 </ParamField>
 
 <ParamField path="voice_id" type="str" default="Magpie-Multilingual.EN-US.Aria" deprecated>
@@ -93,7 +97,20 @@ _Deprecated in v0.0.105. Use `settings=NvidiaTTSService.Settings(...)` instead._
 </ParamField>
 
 <ParamField path="use_ssl" type="bool" default="True">
-  Whether to use SSL for the NVIDIA Riva server connection.
+  Whether to use SSL for the gRPC connection. Defaults to True for the NVIDIA
+  cloud endpoint. Set to False for local deployments.
+</ParamField>
+
+<ParamField path="custom_dictionary" type="dict" default="None">
+  Custom pronunciation dictionary mapping words (graphemes) to IPA phonetic
+  representations (phonemes), e.g. `{"NVIDIA": "ɛn.vɪ.diː.ʌ"}`. See [NVIDIA TTS
+  NIM phoneme
+  support](https://docs.nvidia.com/nim/speech/latest/tts/phoneme-support.html)
+  for the list of supported IPA phonemes.
+</ParamField>
+
+<ParamField path="encoding" type="AudioEncoding" default="AudioEncoding.LINEAR_PCM">
+  Output audio encoding format. Defaults to `AudioEncoding.LINEAR_PCM`.
 </ParamField>
 
 <ParamField path="params" type="InputParams" default="None" deprecated>
@@ -159,7 +176,9 @@ tts = NvidiaTTSService(
 
 ## Notes
 
-- **gRPC-based**: NVIDIA Riva uses gRPC (not HTTP or WebSocket) for communication with the TTS service.
+- **gRPC-based**: NVIDIA Nemotron Speech uses gRPC (not HTTP or WebSocket) for communication with the TTS service.
+- **Cross-sentence stitching**: Multiple sentences within an LLM turn are fed into a single `SynthesizeOnline` gRPC stream for seamless audio across sentence boundaries (requires Magpie TTS model v1.7.0+).
+- **Runtime settings updates**: Voice, language, and quality can be updated mid-conversation with `TTSUpdateSettingsFrame`. New values take effect on the next synthesis turn, not for the current turn's in-flight requests.
 - **Model cannot be changed after initialization**: The model and function ID must be set during construction via `model_function_map`. Calling `set_model()` after initialization will log a warning and have no effect.
-- **SSL enabled by default**: The service connects to NVIDIA's cloud endpoint with SSL. Set `use_ssl=False` only for local or custom Riva deployments.
-- **Blocking gRPC calls**: Audio generation uses `asyncio.to_thread` to avoid blocking the event loop, since the underlying Riva client uses synchronous gRPC calls.
+- **SSL enabled by default**: The service connects to NVIDIA's cloud endpoint with SSL. Set `use_ssl=False` only for local or custom Nemotron Speech deployments.
+- **Metrics generation**: This service supports metric generation via `can_generate_metrics()`. Metrics are automatically stopped when an audio context is interrupted.


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4249](https://github.com/pipecat-ai/pipecat/pull/4249).

## Changes

### Updated reference pages

- **api-reference/server/services/tts/nvidia.mdx**
  - **Rebranding**: Updated all references from "NVIDIA Riva" to "NVIDIA Nemotron Speech"
  - **Title and description**: Changed to reflect Nemotron Speech branding
  - **Overview**: Added mention of cross-sentence audio stitching feature
  - **Card links**: Updated documentation link to point to new TTS NIM docs
  - **Prerequisites**: 
    - Updated setup section for Nemotron Speech
    - Clarified that API key is only required for cloud endpoint
    - Added reference to local deployment documentation
  - **Configuration**:
    - `api_key`: Changed from required to optional (default="None"), added note about local deployments
    - `server`: Enhanced description to mention local deployment support (e.g., `localhost:50051`)
    - `use_ssl`: Clarified usage for cloud vs local deployments
    - `custom_dictionary`: NEW parameter for IPA-based custom pronunciation
    - `encoding`: NEW parameter for output audio encoding format
  - **Notes**: 
    - Updated gRPC note to reference Nemotron Speech
    - Added cross-sentence stitching note (requires Magpie TTS v1.7.0+)
    - Added runtime settings updates note (can update voice/language/quality mid-conversation)
    - Updated SSL note to reference Nemotron Speech
    - Added metrics generation note
    - Removed outdated "blocking gRPC calls" note

## Gaps identified

None