### PR TITLE
docs: update for pipecat PR #4282

### DIFF
--- a/api-reference/server/services/stt/cartesia.mdx
+++ b/api-reference/server/services/stt/cartesia.mdx
@@ -100,7 +100,7 @@ Before using Cartesia STT services, you need:
 
 ### Settings
 
-Runtime-configurable settings passed via the `settings` constructor argument using `CartesiaSTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
+Runtime-configurable settings passed via the `settings` constructor argument using `CartesiaSTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`, which triggers an automatic reconnection with the new parameters. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
 | Parameter  | Type              | Default         | Description                                                              |
 | ---------- | ----------------- | --------------- | ------------------------------------------------------------------------ |
@@ -138,6 +138,7 @@ stt = CartesiaSTTService(
 
 - **Inactivity timeout**: Cartesia disconnects WebSocket connections after 3 minutes of inactivity. The timeout resets with each message sent. Silence-based keepalive is enabled by default to prevent disconnections.
 - **Auto-reconnect on send**: If the connection is closed (e.g., due to timeout), the service automatically reconnects when the next audio data is sent.
+- **Runtime settings updates**: Changing settings (e.g., `language` or `model`) via `STTUpdateSettingsFrame` automatically reconnects the service with the new parameters. This enables dynamic language switching during a conversation.
 - **Finalize on VAD stop**: When the pipeline's VAD detects the user has stopped speaking, the service sends a `"finalize"` command to flush the transcription session and produce a final result.
 
 <Tip>


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4282](https://github.com/pipecat-ai/pipecat/pull/4282).

## Changes

### Updated reference pages
- `api-reference/server/services/stt/cartesia.mdx` — Updated Settings section and Notes section to document runtime settings update support with automatic reconnection

## Summary

PR #4282 added support for runtime settings updates to `CartesiaSTTService`. Previously, calling `STTUpdateSettingsFrame` with new settings (e.g., changing language or model) was silently ignored. Now, the service automatically reconnects with the new parameters when settings are changed.

Documentation updates:
- **Settings section**: Added note that `STTUpdateSettingsFrame` triggers automatic reconnection
- **Notes section**: Added new bullet about runtime settings updates enabling dynamic language switching

## Gaps identified

None — all changed source files were mapped and updated.