### PR TITLE
docs: update for pipecat PR #4295

### DIFF
--- a/api-reference/server/utilities/context-summarization.mdx
+++ b/api-reference/server/utilities/context-summarization.mdx
@@ -31,7 +31,11 @@ Controls when automatic context summarization triggers.
   `max_unsummarized_messages` must be set.
 </ParamField>
 
-<ParamField path="summary_config" type="LLMContextSummaryConfig" default="LLMContextSummaryConfig()">
+<ParamField
+  path="summary_config"
+  type="LLMContextSummaryConfig"
+  default="LLMContextSummaryConfig()"
+>
   Configuration for how summaries are generated. See below.
 </ParamField>
 
@@ -90,7 +94,11 @@ from pipecat.frames.frames import LLMSummarizeContextFrame
 
 Push this frame into the pipeline to trigger on-demand context summarization without waiting for automatic thresholds.
 
-<ParamField path="config" type="Optional[LLMContextSummaryConfig]" default="None">
+<ParamField
+  path="config"
+  type="Optional[LLMContextSummaryConfig]"
+  default="None"
+>
   Per-request override for summary generation settings (prompt, token budget,
   messages to keep). When `None`, the summarizer's default
   `LLMContextSummaryConfig` is used.
@@ -181,8 +189,8 @@ Event data emitted when context summarization completes successfully.
 </ParamField>
 
 <ParamField path="preserved_message_count" type="int">
-  Number of messages preserved uncompressed (system message plus recent
-  messages).
+  Number of messages preserved uncompressed (initial system message at
+  `messages[0]` if present, plus recent messages).
 </ParamField>
 
 ## Deprecated: LLMContextSummarizationConfig
@@ -223,6 +231,7 @@ config = LLMAutoContextSummarizationConfig(
 ```
 
 Similarly, the `LLMAssistantAggregatorParams` fields were renamed:
+
 - `enable_context_summarization` → `enable_auto_context_summarization`
 - `context_summarization_config` → `auto_context_summarization_config`
 

--- a/pipecat/fundamentals/context-summarization.mdx
+++ b/pipecat/fundamentals/context-summarization.mdx
@@ -83,7 +83,7 @@ See the [reference page](/api-reference/server/utilities/context-summarization) 
 
 Context summarization intelligently preserves:
 
-- **System messages**: If a system message exists in the context, the first one is always kept. When using [`system_instruction`](/pipecat/learn/context-management#system-instruction-vs-context-system-messages) in LLM Settings instead, the system prompt is not part of the context messages and is automatically prepended by the service on each request, so there is nothing to preserve in the context.
+- **System messages**: If the first message (`messages[0]`) is a system message, it is preserved as the initial system prompt. Mid-conversation system messages (e.g., idle notifications or context injections) are treated as regular messages and included in the summarization range. When using [`system_instruction`](/pipecat/learn/context-management#system-instruction-vs-context-system-messages) in LLM Settings instead, the system prompt is not part of the context messages and is automatically prepended by the service on each request, so there is nothing to preserve in the context.
 - **Recent messages**: The last N messages stay uncompressed (configured by `min_messages_after_summary`)
 - **Function call sequences**: Incomplete function call/result pairs are not split during summarization
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4295](https://github.com/pipecat-ai/pipecat/pull/4295).

## Summary

PR #4295 fixed a bug in `LLMContextSummarizer` where mid-conversation system messages (e.g., idle timeout notifications) were incorrectly treated as the initial system prompt, causing "No messages to summarize" errors when using `system_instruction` instead of a system-role message at the start of context.

The fix ensures that only `messages[0]` is treated as the initial system prompt for preservation during summarization. Mid-conversation system messages are now correctly included in the summarization range.

## Changes

- **pipecat/fundamentals/context-summarization.mdx** — Clarified that only `messages[0]` is preserved as the initial system prompt, and that mid-conversation system messages are included in summarization
- **api-reference/server/utilities/context-summarization.mdx** — Updated `preserved_message_count` parameter description to specify the `messages[0]` behavior and note that mid-conversation system messages are not counted in preserved messages

## Gaps identified

None