### PR TITLE
docs: update for pipecat PR #4293

### DIFF
--- a/api-reference/server/services/tts/elevenlabs.mdx
+++ b/api-reference/server/services/tts/elevenlabs.mdx
@@ -126,6 +126,11 @@ The HTTP service accepts the same parameters as the WebSocket service, with thes
   HTTP API base URL (instead of `url` for WebSocket).
 </ParamField>
 
+<ParamField path="enable_logging" type="bool" default="None">
+  Whether to enable ElevenLabs server-side logging. Set to `False` for zero
+  retention mode (enterprise only).
+</ParamField>
+
 The HTTP service uses `ElevenLabsHttpTTSSettings` which also includes:
 
 <ParamField path="optimize_streaming_latency" type="int" default="None">


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4293](https://github.com/pipecat-ai/pipecat/pull/4293).

## Changes
- **api-reference/server/services/tts/elevenlabs.mdx** — Added `enable_logging` parameter to `ElevenLabsHttpTTSService` configuration section. This parameter allows users to disable server-side logging for zero retention mode (enterprise only).

## Gaps identified
None