### PR TITLE
docs: update for pipecat PR #4294

### DIFF
--- a/api-reference/server/utilities/turn-management/filter-incomplete-turns.mdx
+++ b/api-reference/server/utilities/turn-management/filter-incomplete-turns.mdx
@@ -274,7 +274,11 @@ Turn completion markers are automatically stripped from assistant transcripts em
 async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
     # message.content will be "Japan is a wonderful choice!"
     # NOT "✓ Japan is a wonderful choice!"
-    print(f"Assistant: {message.content}")
+    # Markers are automatically stripped from transcripts
+    if message.content:
+        print(f"Assistant: {message.content}")
+    if message.interrupted:
+        print("(Turn was interrupted)")
 ```
 
 ## Supported LLM Services

--- a/api-reference/server/utilities/turn-management/transcriptions.mdx
+++ b/api-reference/server/utilities/turn-management/transcriptions.mdx
@@ -32,7 +32,10 @@ async def on_user_turn_stopped(aggregator, strategy, message: UserTurnStoppedMes
 # Handle assistant transcriptions
 @assistant_aggregator.event_handler("on_assistant_turn_stopped")
 async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
-    print(f"[ASSISTANT] {message.content}")
+    if message.content:
+        print(f"[ASSISTANT] {message.content}")
+    if message.interrupted:
+        print("[ASSISTANT] (interrupted)")
 ```
 
 ## Saving Transcripts to a File
@@ -58,6 +61,7 @@ async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMes
         "role": "assistant",
         "content": message.content,
         "timestamp": message.timestamp,
+        "interrupted": message.interrupted,
     })
 
 # Save transcript when session ends

--- a/api-reference/server/utilities/turn-management/turn-events.mdx
+++ b/api-reference/server/utilities/turn-management/turn-events.mdx
@@ -179,8 +179,10 @@ Fired when the assistant finishes responding or is interrupted. This event inclu
 ```python
 @assistant_aggregator.event_handler("on_assistant_turn_stopped")
 async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
-    print(f"Assistant said: {message.content}")
+    if message.content:
+        print(f"Assistant said: {message.content}")
     print(f"Turn started at: {message.timestamp}")
+    print(f"Was interrupted: {message.interrupted}")
 ```
 
 **Parameters:**
@@ -192,7 +194,8 @@ async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMes
 
 <Note>
   This event fires when the LLM response completes, when the user interrupts, or
-  when a user image is appended to context.
+  when a user image is appended to context. The event always fires when a turn ends,
+  even if `content` is empty (e.g., the turn was interrupted before any tokens were generated).
 </Note>
 
 ### on_assistant_thought
@@ -275,7 +278,11 @@ from pipecat.processors.aggregators.llm_response_universal import AssistantTurnS
 ```
 
 <ParamField path="content" type="str">
-  The complete text content from the assistant's turn.
+  The complete text content from the assistant's turn. May be empty if the LLM returned zero tokens (e.g., turn was interrupted before any tokens were received or pushed).
+</ParamField>
+
+<ParamField path="interrupted" type="bool">
+  Whether the assistant turn was interrupted. True if the turn ended due to user interruption or cancellation, False if it completed normally.
 </ParamField>
 
 <ParamField path="timestamp" type="str">

--- a/pipecat/fundamentals/saving-transcripts.mdx
+++ b/pipecat/fundamentals/saving-transcripts.mdx
@@ -69,7 +69,10 @@ async def on_user_turn_stopped(aggregator, strategy, message: UserTurnStoppedMes
 
 @assistant_aggregator.event_handler("on_assistant_turn_stopped")
 async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
-    print(f"[{message.timestamp}] assistant: {message.content}")
+    if message.content:
+        print(f"[{message.timestamp}] assistant: {message.content}")
+    if message.interrupted:
+        print(f"[{message.timestamp}] (assistant was interrupted)")
 ```
 
 <Tip>


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4294](https://github.com/pipecat-ai/pipecat/pull/4294).

## Changes

Updated documentation for `AssistantTurnStoppedMessage` in response to changes in the universal LLM response aggregator:

### Updated pages

1. **api-reference/server/utilities/turn-management/turn-events.mdx**
   - Added `interrupted: bool` field to `AssistantTurnStoppedMessage` documentation
   - Updated `content` field description to clarify it can be empty when interrupted before tokens
   - Updated code example to check for empty content and show interrupted field usage
   - Enhanced note to clarify event always fires, even with empty content

2. **api-reference/server/utilities/turn-management/transcriptions.mdx**
   - Updated basic example to handle empty content and show interrupted status
   - Updated file-saving example to include `interrupted` field in transcript logs

3. **api-reference/server/utilities/turn-management/filter-incomplete-turns.mdx**
   - Updated transcript example to show interrupted field handling
   - Added comment about markers being stripped

4. **pipecat/fundamentals/saving-transcripts.mdx**
   - Updated example to handle empty content and show interrupted status

### Summary of source changes

The source PR fixed an issue where `on_assistant_turn_stopped` wasn't being triggered or wasn't resetting state when the LLM returned no text tokens. The changes include:

- Added `interrupted: bool` field to track whether the turn ended due to interruption
- Modified the event to always fire, even when content is empty
- Updated internal state management to properly reset on all turn endings

## Gaps identified

None