### PR TITLE
Add Replicate image generation community integration

### DIFF
--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -104,4 +104,4 @@ Vision services receive a streaming video input and output text describing the v
 
 | Service                         | Repository | Maintainer(s) |
 | ------------------------------- | ---------- | ------------- |
-| [Replicate](https://replicate.com/) | https://github.com/bnovik0v/pipecat-replicate | [bnovik0v](https://github.com/bnovik0v) |
+| _No community integrations yet_ |            |               |

--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -96,7 +96,7 @@ Image generation services receive text inputs and output images.
 
 | Service                         | Repository | Maintainer(s) |
 | ------------------------------- | ---------- | ------------- |
-| _No community integrations yet_ |            |               |
+| [Replicate](https://replicate.com/) | https://github.com/bnovik0v/pipecat-replicate | [bnovik0v](https://github.com/bnovik0v) |
 
 ## Vision
 
@@ -104,4 +104,4 @@ Vision services receive a streaming video input and output text describing the v
 
 | Service                         | Repository | Maintainer(s) |
 | ------------------------------- | ---------- | ------------- |
-| _No community integrations yet_ |            |               |
+| [Replicate](https://replicate.com/) | https://github.com/bnovik0v/pipecat-replicate | [bnovik0v](https://github.com/bnovik0v) |


### PR DESCRIPTION
## Summary

Adds [Replicate](https://replicate.com/) to the Image Generation section of the community integrations page.

- **Repository**: https://github.com/bnovik0v/pipecat-replicate
- **Service type**: Image Generation
- **Tested with**: Pipecat v0.0.108

The integration supports official Replicate models (`owner/name`) and versioned community models (`owner/name:version`) with sync prediction requests and polling fallback.

Ref: https://github.com/pipecat-ai/pipecat/pull/4288#issuecomment-4247518420