### PR TITLE
Document LemonSlice transport architecture and custom UI embedding

### DIFF
--- a/api-reference/server/services/transport/lemonslice.mdx
+++ b/api-reference/server/services/transport/lemonslice.mdx
@@ -9,6 +9,14 @@ description: "AI avatar video service for adding LemonSlice avatars to Daily roo
 
 When used, the Pipecat bot connects to a Daily room alongside the LemonSlice avatar and user. The bot receives audio input from participants, processes it through your pipeline, and sends TTS audio to the LemonSlice avatar for synchronized video rendering.
 
+## Transport architecture
+
+`LemonSliceTransport` always uses Daily as the underlying WebRTC transport. There is no standalone WebRTC variant. The avatar joins a Daily room, either one you supply via `daily_room_url` or one LemonSlice provisions for you.
+
+**Embedding in a custom UI:** Daily Prebuilt is not required. Use [`@pipecat-ai/client-js`](/client/js/introduction) or [`@pipecat-ai/client-react`](/client/react/introduction) to connect to the session and render the avatar participant's video track inside your own modal or component. The Pipecat bot, the LemonSlice avatar, and your custom UI all connect to the same Daily room.
+
+**Combining with other LLM services (e.g. Bedrock AgentCore):** the avatar transport is independent of your LLM choice. Any LLM service that fits in a Pipecat pipeline can drive a `LemonSliceTransport` bot.
+
 <CardGroup cols={2}>
   <Card
     title="LemonSliceTransport API Reference"


### PR DESCRIPTION
## Summary
https://app.kapa.ai/3f992771-54c9-4b98-83c7-944159b93d4f/coverage-gaps/clusters/dc77e742-5314-4fbc-8b9f-f0deb5d8b888

- Adds a `Transport architecture` section to the LemonSlice transport reference
- Clarifies that `LemonSliceTransport` always uses Daily as the underlying WebRTC layer (no standalone variant), per `pipecat/src/pipecat/transports/lemonslice/api.py` hardcoding `transport_type: "daily"`
- Points users who want to embed the avatar in their own UI to `@pipecat-ai/client-js` and `@pipecat-ai/client-react` instead of Daily Prebuilt
- Notes that LLM/runtime choice (e.g. Bedrock AgentCore) is independent of the avatar transport

Addresses a kapa.ai coverage gap where users repeatedly asked whether LemonSlice could run on a non-Daily transport, be embedded in a webpage modal, or be combined with Agentcore.

## Test plan

- [x] `mint dev` and confirm the new section renders correctly
- [x] `mint broken-links` passes for the new `/client/js/introduction` and `/client/react/introduction` links

🤖 Generated with [Claude Code](https://claude.com/claude-code)