### PR TITLE
docs: add 54-char service name limit and forceRedeploy param

### DIFF
--- a/api-reference/cli/cloud/deploy.mdx
+++ b/api-reference/cli/cloud/deploy.mdx
@@ -7,7 +7,7 @@ The `deploy` command creates a new agent deployment or updates an existing one. 
 
 When no image is specified, the CLI will offer to build your agent using [Pipecat Cloud Build](/pipecat-cloud/guides/cloud-builds). This handles building and deploying without requiring you to manage a container registry. A `Dockerfile` must be present in your build context directory.
 
-If the agent name already exists, you'll be prompted to confirm the update unless the `--force` flag is used.
+If the agent name already exists, you'll be prompted to confirm the update. Use `--force` to skip this prompt and also force a new deployment even if the configuration hasn't changed (replacing all running pods).
 
 This command will wait for the active deployment / revision to enter a ready state before returning. If the deployment fails, the command will exit with an [error](/pipecat-cloud/fundamentals/error-codes) with more information.
 
@@ -91,7 +91,9 @@ See [Agent Profiles](/pipecat-cloud/fundamentals/deploy#agent-profiles) for more
 </ParamField>
 
 <ParamField path="--force / -f" type="boolean" default="false">
-  Force deployment and skip confirmation prompts. Use with caution.
+  Force a new deployment even if the configuration hasn't changed, replacing all
+  running pods. Useful for picking up updated container images when using mutable
+  tags like `latest`, or for refreshing modified secret values.
 </ParamField>
 
 <ParamField path="--yes / -y" type="boolean" default="false">
@@ -220,7 +222,7 @@ This allows you to define defaults in the config file while still overriding spe
 
 <ParamField path="agent_name" type="string" required>
 Name of the agent to deploy. Must start with a lowercase letter or number, can
-include hyphens, and must end with a lowercase letter or number.
+include hyphens, and must end with a lowercase letter or number. Maximum 54 characters.
 
 ```toml
 agent_name = "my-voice-agent"

--- a/api-reference/pipecat-cloud/rest-reference/openapi-agent-create.json
+++ b/api-reference/pipecat-cloud/rest-reference/openapi-agent-create.json
@@ -228,9 +228,10 @@
         "properties": {
           "serviceName": {
             "type": "string",
-            "description": "Name of the agent to create.\n\nMust start with a lowercase letter or number, can include hyphens, and must end with a lowercase letter or number. No uppercase letters or special characters allowed.",
+            "description": "Name of the agent to create.\n\nMust start with a lowercase letter or number, can include hyphens, and must end with a lowercase letter or number. No uppercase letters or special characters allowed. Maximum 54 characters.",
             "example": "my-voice-agent",
-            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])$",
+            "maxLength": 54
           },
           "image": {
             "type": "string",

--- a/api-reference/pipecat-cloud/rest-reference/openapi-agent-update.json
+++ b/api-reference/pipecat-cloud/rest-reference/openapi-agent-update.json
@@ -505,6 +505,12 @@
             "enum": ["agent-1x", "agent-2x", "agent-3x"],
             "default": "agent-1x",
             "example": "agent-1x"
+          },
+          "forceRedeploy": {
+            "type": "boolean",
+            "description": "Force a new deployment even if the configuration hasn't changed. Useful for picking up updated container images when using mutable tags like `latest`, or for refreshing modified secret values.",
+            "default": false,
+            "example": true
           }
         }
       },


### PR DESCRIPTION
- Add maxLength: 54 to serviceName in create agent OpenAPI spec (https://github.com/daily-co/pipecat-cloud-sandbox/pull/433)
- Add forceRedeploy boolean to update agent OpenAPI spec (https://github.com/daily-co/pipecat-cloud-sandbox/pull/430)
- Update --force flag docs to describe pod replacement behavior (https://github.com/daily-co/pipecat-cloud/pull/159)
- Add max length note to pcc-deploy.toml agent_name field