### PR TITLE
docs: update for pipecat PR #4253

### DIFF
--- a/api-reference/server/services/stt/mistral.mdx
+++ b/api-reference/server/services/stt/mistral.mdx
@@ -1,0 +1,159 @@
+---
+title: "Mistral"
+description: "Speech-to-text service using Mistral's Voxtral Realtime transcription API"
+---
+
+## Overview
+
+`MistralSTTService` provides real-time speech recognition using Mistral's Voxtral Realtime API. It uses the Mistral SDK's `RealtimeConnection` to stream audio and receive transcription events over WebSocket.
+
+Key features include:
+- Streaming transcription with interim results
+- Automatic language detection
+- VAD-driven utterance lifecycle management
+- Built-in metrics support
+
+<CardGroup cols={2}>
+  <Card
+    title="Mistral STT API Reference"
+    icon="code"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.mistral.stt.html"
+  >
+    Pipecat's API methods for Mistral STT
+  </Card>
+  <Card
+    title="Example Implementation"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-mistral.py"
+  >
+    Complete example with Mistral STT and TTS
+  </Card>
+  <Card
+    title="Transcription Example"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/transcription/transcription-mistral.py"
+  >
+    Transcription-only example
+  </Card>
+  <Card
+    title="Mistral Documentation"
+    icon="book"
+    href="https://docs.mistral.ai/"
+  >
+    Official Mistral API documentation
+  </Card>
+</CardGroup>
+
+## Installation
+
+To use Mistral STT service, install the required dependencies:
+
+```bash
+uv add "pipecat-ai[mistral]"
+```
+
+## Prerequisites
+
+Before using `MistralSTTService`, you need:
+
+1. **Mistral Account**: Sign up at [Mistral AI](https://mistral.ai/)
+2. **API Key**: Generate an API key from your account dashboard
+3. **Model Access**: Ensure you have access to the Voxtral Realtime API
+
+### Required Environment Variables
+
+- `MISTRAL_API_KEY`: Your Mistral API key for authentication
+
+## Configuration
+
+<ParamField path="api_key" type="str">
+  Mistral API key for authentication.
+</ParamField>
+
+<ParamField path="base_url" type="str" default="None">
+  Custom API endpoint URL. Leave empty for the default Mistral endpoint.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="None">
+  Audio sample rate in Hz. When `None`, uses the pipeline's configured sample
+  rate.
+</ParamField>
+
+<ParamField path="target_streaming_delay_ms" type="int" default="None">
+  Streaming delay for accuracy/latency tradeoff. Higher values may improve
+  accuracy at the cost of latency.
+</ParamField>
+
+<ParamField path="ttfs_p99_latency" type="float" default="MISTRAL_TTFS_P99">
+  P99 latency from speech end to final transcript in seconds. Override for your
+  deployment.
+</ParamField>
+
+<ParamField path="settings" type="MistralSTTService.Settings" default="None">
+  Runtime-configurable settings for the STT service. See [Settings](#settings)
+  below.
+</ParamField>
+
+### Settings
+
+Runtime-configurable settings passed via the `settings` constructor argument using `MistralSTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
+
+| Parameter  | Type              | Default                                  | Description                                                  |
+| ---------- | ----------------- | ---------------------------------------- | ------------------------------------------------------------ |
+| `model`    | `str`             | `"voxtral-mini-transcribe-realtime-2602"` | Mistral STT model to use. _(Inherited from base STT settings.)_ |
+| `language` | `Language \| str` | `None`                                   | Language hint for transcription. _(Inherited from base STT settings.)_ |
+
+## Usage
+
+### Basic Setup
+
+```python
+import os
+from pipecat.services.mistral import MistralSTTService
+
+stt = MistralSTTService(
+    api_key=os.getenv("MISTRAL_API_KEY"),
+)
+```
+
+### With Custom Settings
+
+```python
+import os
+from pipecat.services.mistral import MistralSTTService
+
+stt = MistralSTTService(
+    api_key=os.getenv("MISTRAL_API_KEY"),
+    target_streaming_delay_ms=1000,
+    settings=MistralSTTService.Settings(
+        model="voxtral-mini-transcribe-realtime-2602",
+        language="en",
+    ),
+)
+```
+
+## Notes
+
+- **SDK-managed WebSocket**: The service extends `STTService` directly (rather than `WebsocketSTTService`) because the Mistral SDK manages the WebSocket connection internally.
+- **Language detection**: When `language` is not specified in settings, the service automatically detects the spoken language and includes it in the transcription frames.
+- **VAD integration**: The service works with VAD (Voice Activity Detection) to manage utterance lifecycle. When the user starts speaking, it begins accumulating interim transcripts. When the user stops, it flushes remaining audio for final transcription.
+
+## Event Handlers
+
+Supports the standard [service connection events](/api-reference/server/events/service-events):
+
+| Event                 | Description                       |
+| --------------------- | --------------------------------- |
+| `on_connected`        | Transcription session created     |
+| `on_disconnected`     | Connection closed                 |
+| `on_connection_error` | Transcription error occurred      |
+
+```python
+@stt.event_handler("on_connected")
+async def on_connected(stt):
+    print("Mistral STT connected")
+
+@stt.event_handler("on_connection_error")
+async def on_connection_error(stt, error_msg):
+    print(f"Connection error: {error_msg}")
+```

--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -49,6 +49,7 @@ Speech-to-Text services receive and audio input and output transcriptions.
 | [Google](/api-reference/server/services/stt/google)             | `uv add "pipecat-ai[google]"`       |
 | [Gradium](/api-reference/server/services/stt/gradium)           | `uv add "pipecat-ai[gradium]"`      |
 | [Groq (Whisper)](/api-reference/server/services/stt/groq)       | `uv add "pipecat-ai[groq]"`         |
+| [Mistral](/api-reference/server/services/stt/mistral)           | `uv add "pipecat-ai[mistral]"`      |
 | [NVIDIA](/api-reference/server/services/stt/nvidia)             | `uv add "pipecat-ai[nvidia]"`       |
 | [OpenAI](/api-reference/server/services/stt/openai)             | `uv add "pipecat-ai[openai]"`       |
 | [Sarvam](/api-reference/server/services/stt/sarvam)             | `uv add "pipecat-ai[sarvam]"`       |

--- a/api-reference/server/services/tts/mistral.mdx
+++ b/api-reference/server/services/tts/mistral.mdx
@@ -1,11 +1,17 @@
 ---
 title: "Mistral"
-description: "Text-to-speech services using Mistral's Voxtral TTS API"
+description: "Text-to-speech service using Mistral's Voxtral TTS API"
 ---
 
 ## Overview
 
-Mistral provides high-quality text-to-speech synthesis through the Voxtral TTS API. The service uses HTTP streaming with Server-Sent Events to deliver PCM-encoded audio at 24kHz, with automatic resampling to any requested sample rate.
+`MistralTTSService` provides text-to-speech synthesis using Mistral's Voxtral TTS API. It uses HTTP streaming with Server-Sent Events to generate PCM-encoded audio at 24kHz.
+
+Key features include:
+- Streaming TTS with real-time audio generation
+- Automatic resampling to pipeline sample rate
+- Built-in metrics support
+- Multiple voice options
 
 <CardGroup cols={2}>
   <Card
@@ -13,27 +19,27 @@ Mistral provides high-quality text-to-speech synthesis through the Voxtral TTS A
     icon="code"
     href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.mistral.tts.html"
   >
-    Pipecat's API methods for Mistral TTS integration
+    Pipecat's API methods for Mistral TTS
   </Card>
   <Card
     title="Example Implementation"
     icon="play"
     href="https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-mistral.py"
   >
-    Complete example with voice conversation
+    Complete example with Mistral STT and TTS
   </Card>
   <Card
     title="Mistral Documentation"
     icon="book"
     href="https://docs.mistral.ai/"
   >
-    Official Mistral API documentation and features
+    Official Mistral API documentation
   </Card>
 </CardGroup>
 
 ## Installation
 
-To use Mistral TTS, install the required dependencies:
+To use Mistral TTS service, install the required dependencies:
 
 ```bash
 uv add "pipecat-ai[mistral]"
@@ -41,13 +47,11 @@ uv add "pipecat-ai[mistral]"
 
 ## Prerequisites
 
-### Mistral Account Setup
+Before using `MistralTTSService`, you need:
 
-Before using Mistral TTS services, you need:
-
-1. **Mistral Account**: Sign up at [Mistral](https://mistral.ai/)
+1. **Mistral Account**: Sign up at [Mistral AI](https://mistral.ai/)
 2. **API Key**: Generate an API key from your account dashboard
-3. **Voice Selection**: Choose voice IDs from the Mistral voice library
+3. **Model Access**: Ensure you have access to the Voxtral TTS API
 
 ### Required Environment Variables
 
@@ -56,28 +60,29 @@ Before using Mistral TTS services, you need:
 ## Configuration
 
 <ParamField path="api_key" type="str">
-  Mistral API key for authentication. If `None`, uses the `MISTRAL_API_KEY`
-  environment variable.
+  Mistral API key for authentication.
 </ParamField>
 
 <ParamField path="sample_rate" type="int" default="None">
-  Output audio sample rate in Hz. When `None`, uses the pipeline's configured
-  sample rate. Audio is automatically resampled from Mistral's native 24kHz.
+  Output audio sample rate in Hz. Audio is resampled from Mistral's native 24kHz
+  when a different rate is requested. When `None`, uses the pipeline's
+  configured sample rate.
 </ParamField>
 
 <ParamField path="settings" type="MistralTTSService.Settings" default="None">
-  Runtime-configurable settings. See [Settings](#settings) below.
+  Runtime-configurable settings for the TTS service. See [Settings](#settings)
+  below.
 </ParamField>
 
 ### Settings
 
 Runtime-configurable settings passed via the `settings` constructor argument using `MistralTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter  | Type              | Default                 | Description                                                      |
-| ---------- | ----------------- | ----------------------- | ---------------------------------------------------------------- |
-| `model`    | `str`             | `voxtral-mini-tts-2603` | TTS model identifier.                                            |
-| `voice`    | `str`             | `None`                  | Voice identifier for synthesis.                                  |
-| `language` | `Language \| str` | `None`                  | Language for speech synthesis. _(Inherited from base settings.)_ |
+| Parameter  | Type              | Default                  | Description                                 |
+| ---------- | ----------------- | ------------------------ | ------------------------------------------- |
+| `model`    | `str`             | `"voxtral-mini-tts-2603"` | Mistral TTS model to use. _(Inherited.)_    |
+| `voice`    | `str`             | `None`                   | Voice identifier. _(Inherited.)_            |
+| `language` | `Language \| str` | `None`                   | Language for synthesis. _(Inherited.)_      |
 
 ## Usage
 
@@ -85,24 +90,25 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import os
-from pipecat.services.mistral.tts import MistralTTSService
+from pipecat.services.mistral import MistralTTSService
 
 tts = MistralTTSService(
     api_key=os.getenv("MISTRAL_API_KEY"),
-    settings=MistralTTSService.Settings(
-        voice="c69964a6-ab8b-4f8a-9465-ec0925096ec8",
-    ),
 )
 ```
 
-### With Custom Model
+### With Custom Settings
 
 ```python
+import os
+from pipecat.services.mistral import MistralTTSService
+
 tts = MistralTTSService(
     api_key=os.getenv("MISTRAL_API_KEY"),
     settings=MistralTTSService.Settings(
         model="voxtral-mini-tts-2603",
         voice="your-voice-id",
+        language="en",
     ),
 )
 ```
@@ -110,18 +116,21 @@ tts = MistralTTSService(
 ### With Custom Sample Rate
 
 ```python
+import os
+from pipecat.services.mistral import MistralTTSService
+
 tts = MistralTTSService(
     api_key=os.getenv("MISTRAL_API_KEY"),
-    sample_rate=16000,  # Output at 16kHz instead of default
-    settings=MistralTTSService.Settings(
-        voice="your-voice-id",
-    ),
+    sample_rate=16000,  # Resample from 24kHz to 16kHz
 )
 ```
 
 ## Notes
 
-- **Streaming**: The service uses Server-Sent Events for real-time audio streaming.
-- **Resampling**: Audio is automatically resampled from Mistral's native 24kHz to any requested sample rate.
-- **Audio format**: The service receives float32 PCM audio from the API and converts it to int16 PCM for the Pipecat pipeline.
-- **Metrics**: The service supports metrics generation for monitoring TTS performance.
+- **Audio format conversion**: The Mistral API returns base64-encoded float32 PCM chunks via Server-Sent Events. The service automatically converts these to int16 PCM for the Pipecat pipeline.
+- **Native sample rate**: Mistral's TTS API outputs audio at 24kHz. When a different sample rate is specified, the service automatically resamples the audio.
+- **Streaming**: The service uses HTTP streaming with Server-Sent Events for real-time audio generation, allowing for low-latency synthesis.
+
+## Event Handlers
+
+This service does not currently expose connection event handlers, as it uses HTTP streaming rather than persistent WebSocket connections.

--- a/docs.json
+++ b/docs.json
@@ -413,6 +413,7 @@
                       "api-reference/server/services/stt/gladia",
                       "api-reference/server/services/stt/google",
                       "api-reference/server/services/stt/groq",
+                      "api-reference/server/services/stt/mistral",
                       "api-reference/server/services/stt/nvidia",
                       "api-reference/server/services/stt/openai",
                       "api-reference/server/services/stt/sarvam",


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4253](https://github.com/pipecat-ai/pipecat/pull/4253).

## Changes

### New service pages
- **api-reference/server/services/stt/mistral.mdx** — Complete documentation for `MistralSTTService` using Voxtral Realtime API
  - Streaming transcription with interim results
  - Automatic language detection
  - VAD-driven utterance lifecycle management
  - Event handlers for connection lifecycle
  - Settings and configuration reference
  - Usage examples

- **api-reference/server/services/tts/mistral.mdx** — Complete documentation for `MistralTTSService` using Voxtral TTS API
  - HTTP streaming with Server-Sent Events
  - 24kHz native audio with automatic resampling
  - Settings and configuration reference
  - Usage examples

### Updated navigation
- **docs.json** — Added `api-reference/server/services/stt/mistral` to Speech-to-Text section (alphabetically between groq and nvidia)
- **supported-services.mdx** — Added Mistral entry to Speech-to-Text table with installation instructions

## Gaps identified
None — all new services from PR #4253 have been documented.