### PR TITLE
docs: update for pipecat PR #4311

### DIFF
--- a/api-reference/server/services/stt/cartesia.mdx
+++ b/api-reference/server/services/stt/cartesia.mdx
@@ -138,7 +138,7 @@ stt = CartesiaSTTService(
 
 - **Inactivity timeout**: Cartesia disconnects WebSocket connections after 3 minutes of inactivity. The timeout resets with each message sent. Silence-based keepalive is enabled by default to prevent disconnections.
 - **Auto-reconnect on send**: If the connection is closed (e.g., due to timeout), the service automatically reconnects when the next audio data is sent.
-- **Runtime settings updates**: Changing settings (e.g., `language` or `model`) via `STTUpdateSettingsFrame` automatically reconnects the service with the new parameters. This enables dynamic language switching during a conversation.
+- **Runtime settings updates**: Changing settings (e.g., `language` or `model`) via `STTUpdateSettingsFrame` triggers a reconnection with the new parameters. To avoid audio loss, reconnection is deferred until the current user turn ends (i.e., until `UserStoppedSpeakingFrame` is received). Audio frames arriving during the reconnect are buffered and replayed once the new connection is ready. This enables safe dynamic language switching mid-conversation.
 - **Finalize on VAD stop**: When the pipeline's VAD detects the user has stopped speaking, the service sends a `"finalize"` command to flush the transcription session and produce a final result.
 
 <Tip>

--- a/api-reference/server/services/stt/deepgram.mdx
+++ b/api-reference/server/services/stt/deepgram.mdx
@@ -227,6 +227,7 @@ stt = DeepgramSTTService(
 
 - **Finalize on VAD stop**: When the pipeline's VAD detects the user has stopped speaking, the service sends a [finalize](https://developers.deepgram.com/docs/finalize) request to Deepgram for faster final transcript delivery.
 - **Multilingual support**: Deepgram Nova models support many languages. The default is `Language.EN` (English). Set `language="multi"` in settings to enable multilingual transcription, which will detect and transcribe multiple languages within the same audio stream.
+- **Runtime settings updates**: Changing settings via `STTUpdateSettingsFrame` triggers a reconnection with the new parameters. To avoid audio loss, reconnection is deferred until the current user turn ends (i.e., until `UserStoppedSpeakingFrame` is received). Audio frames arriving during the reconnect are buffered and replayed once the new connection is ready.
 
 ### Event Handlers
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4311](https://github.com/pipecat-ai/pipecat/pull/4311).

## Changes

### api-reference/server/services/stt/cartesia.mdx
Updated the "Runtime settings updates" note to explain the new safe reconnection behavior:
- Reconnection is deferred until the user stops speaking (`UserStoppedSpeakingFrame`)
- Audio frames are buffered during reconnection and replayed once the connection is ready
- Prevents audio loss when settings change mid-speech

### api-reference/server/services/stt/deepgram.mdx
Added a new "Runtime settings updates" note in the Notes section to document the same safe reconnection behavior for DeepgramSTTService.

## Gaps identified
None