### PR TITLE
Update Pipecat Flows docs for 1.0 accuracy

### DIFF
--- a/api-reference/pipecat-flows/flow-manager.mdx
+++ b/api-reference/pipecat-flows/flow-manager.mdx
@@ -47,7 +47,7 @@ All parameters are keyword-only.
 
 <ParamField
   path="global_functions"
-  type="List[FlowsFunctionSchema | FlowsDirectFunction]"
+  type="list[FlowsFunctionSchema | FlowsDirectFunction]"
   default="None"
 >
   Functions that will be available at every node. These are registered once
@@ -61,7 +61,7 @@ All parameters are keyword-only.
 ### state
 
 ```python
-flow_manager.state -> Dict[str, Any]
+flow_manager.state -> dict[str, Any]
 ```
 
 Shared state dictionary that persists across node transitions. Use this to store and retrieve conversation data such as user preferences, collected information, or any data that needs to be accessible across different nodes.
@@ -77,7 +77,7 @@ name = flow_manager.state.get("user_name", "Unknown")
 ### transport
 
 ```python
-flow_manager.transport -> Optional[BaseTransport]
+flow_manager.transport -> BaseTransport | None
 ```
 
 The transport instance provided during initialization, or `None` if not set. Use this to interact with the communication platform (e.g., mute participants, access room info).
@@ -92,7 +92,7 @@ async def my_handler(args, flow_manager):
 ### current_node
 
 ```python
-flow_manager.current_node -> Optional[str]
+flow_manager.current_node -> str | None
 ```
 
 The identifier of the currently active conversation node. Returns `None` before initialization or if no node has been set.
@@ -124,7 +124,7 @@ async def my_handler(args, flow_manager):
 ### initialize
 
 ```python
-await flow_manager.initialize(initial_node: Optional[NodeConfig] = None) -> None
+await flow_manager.initialize(initial_node: NodeConfig | None = None) -> None
 ```
 
 Initialize the flow manager. Must be called before any node transitions can occur.
@@ -170,7 +170,7 @@ await flow_manager.set_node_from_config({
 ### get_current_context
 
 ```python
-flow_manager.get_current_context() -> List[dict]
+flow_manager.get_current_context() -> list[dict]
 ```
 
 Get the current conversation context as a list of messages, including developer messages, user messages, and assistant responses.

--- a/api-reference/pipecat-flows/types.mdx
+++ b/api-reference/pipecat-flows/types.mdx
@@ -7,7 +7,7 @@ description: "Type definitions and configuration schemas for Pipecat Flows"
 
 Configuration for a single node in a conversation flow. `task_messages` is the only required field.
 
-<ParamField path="task_messages" type="List[dict]" required>
+<ParamField path="task_messages" type="list[dict]" required>
   List of message dicts defining the current node's objectives. These tell the
   LLM what to do in this conversation state.
 
@@ -36,7 +36,7 @@ Configuration for a single node in a conversation flow. `task_messages` is the o
 
 </ParamField>
 
-<ParamField path="role_messages" type="List[Dict[str, Any]]" deprecated>
+<ParamField path="role_messages" type="list[dict[str, Any]]" deprecated>
   Deprecated list-of-dicts format for the bot's role and personality. Use
   [`role_message`](#) (`str`) instead. Will be removed in 2.0.0.
 
@@ -50,7 +50,7 @@ Configuration for a single node in a conversation flow. `task_messages` is the o
 
 <ParamField
   path="functions"
-  type="List[Dict | FlowsFunctionSchema | FlowsDirectFunction]"
+  type="list[FlowsFunctionSchema | FlowsDirectFunction]"
 >
   List of function definitions available in this node. Accepts
   [`FlowsFunctionSchema`](#flowsfunctionschema) objects or [direct
@@ -58,12 +58,12 @@ Configuration for a single node in a conversation flow. `task_messages` is the o
   Types](/api-reference/pipecat-flows/overview#function-types).
 </ParamField>
 
-<ParamField path="pre_actions" type="List[ActionConfig]">
+<ParamField path="pre_actions" type="list[ActionConfig]">
   Actions to execute before LLM inference when transitioning to this node. See
   [ActionConfig](#actionconfig).
 </ParamField>
 
-<ParamField path="post_actions" type="List[ActionConfig]">
+<ParamField path="post_actions" type="list[ActionConfig]">
   Actions to execute after LLM inference when transitioning to this node. If
   `respond_immediately` is `False`, post-actions are deferred until after the
   first LLM response in this node. See [ActionConfig](#actionconfig).
@@ -95,7 +95,7 @@ Dataclass for defining function call schemas with Flows-specific properties. Pro
   call the function.
 </ParamField>
 
-<ParamField path="properties" type="Dict[str, Any]" required>
+<ParamField path="properties" type="dict[str, Any]" required>
   Dictionary defining the function's parameters using JSON Schema format.
 
 ```python
@@ -114,7 +114,7 @@ Dataclass for defining function call schemas with Flows-specific properties. Pro
 
 </ParamField>
 
-<ParamField path="required" type="List[str]" required>
+<ParamField path="required" type="list[str]" required>
   List of required parameter names from `properties`.
 </ParamField>
 
@@ -273,7 +273,7 @@ config = ContextStrategyConfig(
 Decorator that attaches metadata to a Pipecat direct function for use in Flows.
 
 ```python
-@flows_direct_function(*, cancel_on_interruption: bool = False, timeout_secs: Optional[float] = None)
+@flows_direct_function(*, cancel_on_interruption: bool = False, timeout_secs: float | None = None)
 ```
 
 | Parameter                | Type    | Default | Description                                                                               |
@@ -341,7 +341,7 @@ Base return type for function results. The `status` field indicates the outcome.
 ### FlowArgs
 
 ```python
-FlowArgs = Dict[str, Any]
+FlowArgs = dict[str, Any]
 ```
 
 Type alias for function handler arguments. Contains the parameters extracted from the LLM's function call.
@@ -349,7 +349,7 @@ Type alias for function handler arguments. Contains the parameters extracted fro
 ### ConsolidatedFunctionResult
 
 ```python
-ConsolidatedFunctionResult = Tuple[Optional[FlowResult], Optional[NodeConfig]]
+ConsolidatedFunctionResult = tuple[FlowResult | None, NodeConfig | None]
 ```
 
 Return type for consolidated function handlers that both do work and specify the next node:

--- a/pipecat-flows/migration/migration-1.0.mdx
+++ b/pipecat-flows/migration/migration-1.0.mdx
@@ -169,7 +169,7 @@ from pipecat_flows import FlowManager, NodeConfig
 def create_greeting_node() -> NodeConfig:
     return {
         "role_message": "You are a helpful assistant.",
-        "task_messages": [{"role": "user", "content": "Greet the user."}],
+        "task_messages": [{"role": "developer", "content": "Greet the user."}],
         "functions": [collect_info_func],
     }
 


### PR DESCRIPTION
- Fix "role": "user" -> "role": "developer" in migration guide
- Remove Dict from NodeConfig.functions type (dict format removed in 1.0)
- Modernize type annotations in API reference to match source: Dict -> dict, List -> list, Optional[X] -> X | None, Tuple -> tuple