### PR TITLE
docs: update subagents docs for PR #12

### DIFF
--- a/api-reference/pipecat-subagents/bus.mdx
+++ b/api-reference/pipecat-subagents/bus.mdx
@@ -41,13 +41,17 @@ Register a subscriber to receive messages from the bus.
 | ------------ | --------------- | -------------------------- |
 | `subscriber` | `BusSubscriber` | The subscriber to register |
 
+**Raises:**
+
+- `ValueError` — if a subscriber with the same name is already registered
+
 #### unsubscribe
 
 ```python
 async def unsubscribe(self, subscriber: BusSubscriber) -> None
 ```
 
-Remove a subscriber and cancel its dispatch task.
+Remove a subscriber and cancel its dispatch tasks.
 
 | Parameter    | Type            | Description              |
 | ------------ | --------------- | ------------------------ |
@@ -177,12 +181,27 @@ pipeline = Pipeline([transport.input(), bridge, transport.output()])
 
 ## BusSubscriber
 
-Mixin for objects that receive messages from an `AgentBus`. Implementors override `on_bus_message()` to handle incoming messages.
+Mixin for objects that receive messages from an `AgentBus`. Implementors override `on_bus_message()` to handle incoming messages. Concrete subscribers must provide a `name` property (typically inherited from `BaseObject`).
 
 ```python
 from pipecat_subagents.bus.subscriber import BusSubscriber
 
 class MySubscriber(BusSubscriber):
+    @property
+    def name(self) -> str:
+        return "my_subscriber"
+
     async def on_bus_message(self, message: BusMessage) -> None:
         ...
 ```
+
+### Properties
+
+#### name
+
+```python
+@property
+def name(self) -> str
+```
+
+Unique name identifying this subscriber on the bus. Required for all concrete subscribers.


### PR DESCRIPTION
Automated documentation update for [pipecat-subagents PR #12](https://github.com/pipecat-ai/pipecat-subagents/pull/12).

## Changes

**api-reference/pipecat-subagents/bus.mdx**:
- Added required `name` property to BusSubscriber section with example showing implementation
- Added Properties subsection documenting the `name` property
- Added Raises section to `subscribe()` method documenting ValueError for duplicate subscriber names
- Fixed `unsubscribe()` description to use "tasks" (plural) instead of "task"

## Summary

PR #12 changed the internal subscription storage in `AgentBus` from a list to a dict keyed by subscriber name. This required:
1. Making `BusSubscriber.name` a required abstract property
2. Adding duplicate name detection in `subscribe()` that raises ValueError

The documentation now reflects these API changes, particularly the new requirement for subscribers to provide a unique `name` property.

## Gaps identified

None. All relevant source files were mapped and documented.