### PR TITLE
docs: update subagents docs for PR #13

### DIFF
--- a/api-reference/pipecat-subagents/base-agent.mdx
+++ b/api-reference/pipecat-subagents/base-agent.mdx
@@ -87,6 +87,14 @@ agent.bridged -> bool
 
 Whether this agent is bridged (receives pipeline frames from the bus).
 
+### ready
+
+```python
+agent.ready -> bool
+```
+
+Whether this agent's pipeline has started and is ready to operate.
+
 ### started_at
 
 ```python


### PR DESCRIPTION
Automated documentation update for [pipecat-subagents PR #13](https://github.com/pipecat-ai/pipecat-subagents/pull/13).

## Changes
- **api-reference/pipecat-subagents/base-agent.mdx** - Added `ready` property to Properties section. This new boolean property indicates whether the agent's pipeline has started and is ready to operate.

## Gaps identified
None