### PR TITLE
docs: update subagents docs for PR #14

### DIFF
--- a/api-reference/pipecat-subagents/agent-runner.mdx
+++ b/api-reference/pipecat-subagents/agent-runner.mdx
@@ -22,12 +22,12 @@ await runner.run()
 
 ## Configuration
 
-<ParamField path="name" type="Optional[str]" default="None">
+<ParamField path="name" type="str | None" default="None">
   Unique name for this runner. Defaults to a UUID-based name. Must be unique
   across all runners in a distributed setup.
 </ParamField>
 
-<ParamField path="bus" type="Optional[AgentBus]" default="None">
+<ParamField path="bus" type="AgentBus | None" default="None">
   The [`AgentBus`](/api-reference/pipecat-subagents/bus#agentbus) instance.
   Creates an
   [`AsyncQueueBus`](/api-reference/pipecat-subagents/bus#asyncqueuebus) if not
@@ -81,26 +81,26 @@ Start all agents and block until shutdown. Starts all registered agents, fires t
 ### end
 
 ```python
-async def end(self, reason: Optional[str] = None) -> None
+async def end(self, reason: str | None = None) -> None
 ```
 
 Gracefully end all agents and shut down. Ends root agents first; parent agents propagate shutdown to their children automatically. Idempotent.
 
-| Parameter | Type            | Default | Description                      |
-| --------- | --------------- | ------- | -------------------------------- |
-| `reason`  | `Optional[str]` | `None`  | Human-readable reason for ending |
+| Parameter | Type        | Default | Description                      |
+| --------- | ----------- | ------- | -------------------------------- |
+| `reason`  | `str | None` | `None`  | Human-readable reason for ending |
 
 ### cancel
 
 ```python
-async def cancel(self, reason: Optional[str] = None) -> None
+async def cancel(self, reason: str | None = None) -> None
 ```
 
 Immediately cancel all agents and shut down. Cancels root agents first; parent agents propagate cancellation to their children automatically. Idempotent.
 
-| Parameter | Type            | Default | Description                          |
-| --------- | --------------- | ------- | ------------------------------------ |
-| `reason`  | `Optional[str]` | `None`  | Human-readable reason for cancelling |
+| Parameter | Type        | Default | Description                          |
+| --------- | ----------- | ------- | ------------------------------------ |
+| `reason`  | `str | None` | `None`  | Human-readable reason for cancelling |
 
 ## Event Handlers
 

--- a/api-reference/pipecat-subagents/base-agent.mdx
+++ b/api-reference/pipecat-subagents/base-agent.mdx
@@ -29,7 +29,7 @@ from pipecat_subagents.agents import BaseAgent
   `activate_agent()` call before `on_activated` fires.
 </ParamField>
 
-<ParamField path="bridged" type="Optional[tuple[str, ...]]" default="None">
+<ParamField path="bridged" type="tuple[str, ...] | None" default="None">
   Bridge configuration for receiving pipeline frames from the bus. `None` means
   not bridged. An empty tuple `()` means bridged, accepting frames from all
   bridges. A tuple of names like `("voice",)` means bridged, accepting only
@@ -38,7 +38,7 @@ from pipecat_subagents.agents import BaseAgent
 
 <ParamField
   path="exclude_frames"
-  type="Optional[tuple[type[Frame], ...]]"
+  type="tuple[type[Frame], ...] | None"
   default="None"
 >
   Frame types to exclude from bus forwarding when bridged. Lifecycle frames
@@ -66,7 +66,7 @@ Whether this agent is currently active.
 ### parent
 
 ```python
-agent.parent -> Optional[str]
+agent.parent -> str | None
 ```
 
 The name of the parent agent, or `None` if this is a root agent.
@@ -74,7 +74,7 @@ The name of the parent agent, or `None` if this is a root agent.
 ### registry
 
 ```python
-agent.registry -> Optional[AgentRegistry]
+agent.registry -> AgentRegistry | None
 ```
 
 The shared agent registry, if set by a runner.
@@ -90,7 +90,7 @@ Whether this agent is bridged (receives pipeline frames from the bus).
 ### started_at
 
 ```python
-agent.started_at -> Optional[float]
+agent.started_at -> float | None
 ```
 
 Unix timestamp when this agent became ready, or `None` if not yet started.
@@ -114,7 +114,7 @@ The `PipelineTask` for this agent. Raises `RuntimeError` if the pipeline task ha
 ### task_id
 
 ```python
-agent.task_id -> Optional[str]
+agent.task_id -> str | None
 ```
 
 The ID of the task this agent is currently working on, or `None` if idle.
@@ -163,14 +163,14 @@ Called when a pipeline error occurs. Override to handle errors (e.g. propagate v
 ### on_activated
 
 ```python
-async def on_activated(self, args: Optional[dict]) -> None
+async def on_activated(self, args: dict | None) -> None
 ```
 
 Called when this agent is activated. Override to react to activation.
 
-| Parameter | Type             | Description                        |
-| --------- | ---------------- | ---------------------------------- |
-| `args`    | `Optional[dict]` | Optional arguments from the caller |
+| Parameter | Type         | Description                        |
+| --------- | ------------ | ---------------------------------- |
+| `args`    | `dict | None` | Optional arguments from the caller |
 
 ### on_deactivated
 
@@ -225,16 +225,16 @@ async def activate_agent(
     self,
     agent_name: str,
     *,
-    args: Optional[AgentActivationArgs] = None,
+    args: AgentActivationArgs | None = None,
 ) -> None
 ```
 
 Activate an agent by name. The target agent's `on_activated` hook will be called with the provided arguments.
 
-| Parameter    | Type                            | Default | Description                           |
-| ------------ | ------------------------------- | ------- | ------------------------------------- |
-| `agent_name` | `str`                           |         | Name of the agent to activate         |
-| `args`       | `Optional[AgentActivationArgs]` | `None`  | Arguments forwarded to `on_activated` |
+| Parameter    | Type                        | Default | Description                           |
+| ------------ | --------------------------- | ------- | ------------------------------------- |
+| `agent_name` | `str`                       |         | Name of the agent to activate         |
+| `args`       | `AgentActivationArgs | None` | `None`  | Arguments forwarded to `on_activated` |
 
 ### deactivate_agent
 
@@ -255,16 +255,16 @@ async def handoff_to(
     self,
     agent_name: str,
     *,
-    args: Optional[AgentActivationArgs] = None,
+    args: AgentActivationArgs | None = None,
 ) -> None
 ```
 
 Hand off to another agent. Deactivates this agent and activates the target. For independent control, use `activate_agent()` and `deactivate_agent()` directly.
 
-| Parameter    | Type                            | Default | Description                           |
-| ------------ | ------------------------------- | ------- | ------------------------------------- |
-| `agent_name` | `str`                           |         | Name of the agent to hand off to      |
-| `args`       | `Optional[AgentActivationArgs]` | `None`  | Arguments forwarded to `on_activated` |
+| Parameter    | Type                        | Default | Description                           |
+| ------------ | --------------------------- | ------- | ------------------------------------- |
+| `agent_name` | `str`                       |         | Name of the agent to hand off to      |
+| `args`       | `AgentActivationArgs | None` | `None`  | Arguments forwarded to `on_activated` |
 
 ### watch_agent
 
@@ -281,14 +281,14 @@ Request notification when an agent registers. If the agent is already registered
 ### end
 
 ```python
-async def end(self, *, reason: Optional[str] = None) -> None
+async def end(self, *, reason: str | None = None) -> None
 ```
 
 Request a graceful end of the session.
 
-| Parameter | Type            | Default | Description                      |
-| --------- | --------------- | ------- | -------------------------------- |
-| `reason`  | `Optional[str]` | `None`  | Human-readable reason for ending |
+| Parameter | Type        | Default | Description                      |
+| --------- | ----------- | ------- | -------------------------------- |
+| `reason`  | `str | None` | `None`  | Human-readable reason for ending |
 
 ### cancel
 
@@ -307,20 +307,20 @@ async def request_task(
     self,
     agent_name: str,
     *,
-    name: Optional[str] = None,
-    payload: Optional[dict] = None,
-    timeout: Optional[float] = None,
+    name: str | None = None,
+    payload: dict | None = None,
+    timeout: float | None = None,
 ) -> str
 ```
 
 Send a task request to a single agent (fire-and-forget). Waits for the agent to be ready before sending the request. Does not wait for the task to complete; use callbacks (`on_task_response`, `on_task_completed`) or `task()` for that.
 
-| Parameter    | Type              | Default | Description                                          |
-| ------------ | ----------------- | ------- | ---------------------------------------------------- |
-| `agent_name` | `str`             |         | Name of the agent to send the task to                |
-| `name`       | `Optional[str]`   | `None`  | Task name for routing to a named `@task` handler     |
-| `payload`    | `Optional[dict]`  | `None`  | Structured data describing the work                  |
-| `timeout`    | `Optional[float]` | `None`  | Timeout in seconds; auto-cancels after this duration |
+| Parameter    | Type          | Default | Description                                          |
+| ------------ | ------------- | ------- | ---------------------------------------------------- |
+| `agent_name` | `str`         |         | Name of the agent to send the task to                |
+| `name`       | `str | None`   | `None`  | Task name for routing to a named `@task` handler     |
+| `payload`    | `dict | None`  | `None`  | Structured data describing the work                  |
+| `timeout`    | `float | None` | `None`  | Timeout in seconds; auto-cancels after this duration |
 
 **Returns:** The generated `task_id`.
 
@@ -331,20 +331,20 @@ def task(
     self,
     agent_name: str,
     *,
-    name: Optional[str] = None,
-    payload: Optional[dict] = None,
-    timeout: Optional[float] = None,
+    name: str | None = None,
+    payload: dict | None = None,
+    timeout: float | None = None,
 ) -> TaskContext
 ```
 
 Create a single-agent task context manager. Waits for the agent to be ready, sends a task request, and waits for the response on exit. Supports `async for` inside the block to receive intermediate events.
 
-| Parameter    | Type              | Default | Description                                      |
-| ------------ | ----------------- | ------- | ------------------------------------------------ |
-| `agent_name` | `str`             |         | Name of the agent to send the task to            |
-| `name`       | `Optional[str]`   | `None`  | Task name for routing to a named `@task` handler |
-| `payload`    | `Optional[dict]`  | `None`  | Structured data describing the work              |
-| `timeout`    | `Optional[float]` | `None`  | Timeout in seconds                               |
+| Parameter    | Type          | Default | Description                                      |
+| ------------ | ------------- | ------- | ------------------------------------------------ |
+| `agent_name` | `str`         |         | Name of the agent to send the task to            |
+| `name`       | `str | None`   | `None`  | Task name for routing to a named `@task` handler |
+| `payload`    | `dict | None`  | `None`  | Structured data describing the work              |
+| `timeout`    | `float | None` | `None`  | Timeout in seconds                               |
 
 **Returns:** A [`TaskContext`](/api-reference/pipecat-subagents/types#taskcontext) to use with `async with`.
 
@@ -363,22 +363,22 @@ print(t.response)
 async def request_task_group(
     self,
     *agent_names: str,
-    name: Optional[str] = None,
-    payload: Optional[dict] = None,
-    timeout: Optional[float] = None,
+    name: str | None = None,
+    payload: dict | None = None,
+    timeout: float | None = None,
     cancel_on_error: bool = True,
 ) -> str
 ```
 
 Send a task request to multiple agents (fire-and-forget). Waits for all agents to be ready before sending requests.
 
-| Parameter         | Type              | Default | Description                                     |
-| ----------------- | ----------------- | ------- | ----------------------------------------------- |
-| `*agent_names`    | `str`             |         | Names of the agents to send the task to         |
-| `name`            | `Optional[str]`   | `None`  | Task name for routing to named `@task` handlers |
-| `payload`         | `Optional[dict]`  | `None`  | Structured data describing the work             |
-| `timeout`         | `Optional[float]` | `None`  | Timeout in seconds                              |
-| `cancel_on_error` | `bool`            | `True`  | Whether to cancel the group if a worker errors  |
+| Parameter         | Type          | Default | Description                                     |
+| ----------------- | ------------- | ------- | ----------------------------------------------- |
+| `*agent_names`    | `str`         |         | Names of the agents to send the task to         |
+| `name`            | `str | None`   | `None`  | Task name for routing to named `@task` handlers |
+| `payload`         | `dict | None`  | `None`  | Structured data describing the work             |
+| `timeout`         | `float | None` | `None`  | Timeout in seconds                              |
+| `cancel_on_error` | `bool`        | `True`  | Whether to cancel the group if a worker errors  |
 
 **Returns:** The generated `task_id` shared by all agents in the group.
 
@@ -388,22 +388,22 @@ Send a task request to multiple agents (fire-and-forget). Waits for all agents t
 def task_group(
     self,
     *agent_names: str,
-    name: Optional[str] = None,
-    payload: Optional[dict] = None,
-    timeout: Optional[float] = None,
+    name: str | None = None,
+    payload: dict | None = None,
+    timeout: float | None = None,
     cancel_on_error: bool = True,
 ) -> TaskGroupContext
 ```
 
 Create a task group context manager. Waits for agents to be ready, sends task requests, and waits for all responses on exit. Supports `async for` inside the block to receive intermediate events.
 
-| Parameter         | Type              | Default | Description                                     |
-| ----------------- | ----------------- | ------- | ----------------------------------------------- |
-| `*agent_names`    | `str`             |         | Names of the agents to send the task to         |
-| `name`            | `Optional[str]`   | `None`  | Task name for routing to named `@task` handlers |
-| `payload`         | `Optional[dict]`  | `None`  | Structured data describing the work             |
-| `timeout`         | `Optional[float]` | `None`  | Timeout in seconds                              |
-| `cancel_on_error` | `bool`            | `True`  | Whether to cancel the group if a worker errors  |
+| Parameter         | Type          | Default | Description                                     |
+| ----------------- | ------------- | ------- | ----------------------------------------------- |
+| `*agent_names`    | `str`         |         | Names of the agents to send the task to         |
+| `name`            | `str | None`   | `None`  | Task name for routing to named `@task` handlers |
+| `payload`         | `dict | None`  | `None`  | Structured data describing the work             |
+| `timeout`         | `float | None` | `None`  | Timeout in seconds                              |
+| `cancel_on_error` | `bool`        | `True`  | Whether to cancel the group if a worker errors  |
 
 **Returns:** A [`TaskGroupContext`](/api-reference/pipecat-subagents/types#taskgroupcontext) to use with `async with`.
 
@@ -420,15 +420,15 @@ for name, result in tg.responses.items():
 ### cancel_task
 
 ```python
-async def cancel_task(self, task_id: str, *, reason: Optional[str] = None) -> None
+async def cancel_task(self, task_id: str, *, reason: str | None = None) -> None
 ```
 
 Cancel a running task group.
 
-| Parameter | Type            | Default | Description                            |
-| --------- | --------------- | ------- | -------------------------------------- |
-| `task_id` | `str`           |         | The task identifier to cancel          |
-| `reason`  | `Optional[str]` | `None`  | Human-readable reason for cancellation |
+| Parameter | Type        | Default | Description                            |
+| --------- | ----------- | ------- | -------------------------------------- |
+| `task_id` | `str`       |         | The task identifier to cancel          |
+| `reason`  | `str | None` | `None`  | Human-readable reason for cancellation |
 
 ### request_task_update
 
@@ -448,7 +448,7 @@ Request a progress update from a task agent.
 ```python
 async def send_task_response(
     self,
-    response: Optional[dict] = None,
+    response: dict | None = None,
     *,
     status: TaskStatus = TaskStatus.COMPLETED,
     urgent: bool = False,
@@ -459,7 +459,7 @@ Send a task response back to the requester. After sending, the agent is ready to
 
 | Parameter  | Type                                                              | Default     | Description                  |
 | ---------- | ----------------------------------------------------------------- | ----------- | ---------------------------- |
-| `response` | `Optional[dict]`                                                  | `None`      | Result data                  |
+| `response` | `dict | None`                                                     | `None`      | Result data                  |
 | `status`   | [`TaskStatus`](/api-reference/pipecat-subagents/types#taskstatus) | `COMPLETED` | Completion status            |
 | `urgent`   | `bool`                                                            | `False`     | Deliver with system priority |
 
@@ -468,7 +468,7 @@ Send a task response back to the requester. After sending, the agent is ready to
 ```python
 async def send_task_update(
     self,
-    update: Optional[dict] = None,
+    update: dict | None = None,
     *,
     urgent: bool = False,
 ) -> None
@@ -476,46 +476,46 @@ async def send_task_update(
 
 Send a progress update to the requester.
 
-| Parameter | Type             | Default | Description                  |
-| --------- | ---------------- | ------- | ---------------------------- |
-| `update`  | `Optional[dict]` | `None`  | Progress data                |
-| `urgent`  | `bool`           | `False` | Deliver with system priority |
+| Parameter | Type         | Default | Description                  |
+| --------- | ------------ | ------- | ---------------------------- |
+| `update`  | `dict | None` | `None`  | Progress data                |
+| `urgent`  | `bool`       | `False` | Deliver with system priority |
 
 ### send_task_stream_start
 
 ```python
-async def send_task_stream_start(self, data: Optional[dict] = None) -> None
+async def send_task_stream_start(self, data: dict | None = None) -> None
 ```
 
 Begin streaming task results back to the requester.
 
-| Parameter | Type             | Default | Description                        |
-| --------- | ---------------- | ------- | ---------------------------------- |
-| `data`    | `Optional[dict]` | `None`  | Optional metadata about the stream |
+| Parameter | Type         | Default | Description                        |
+| --------- | ------------ | ------- | ---------------------------------- |
+| `data`    | `dict | None` | `None`  | Optional metadata about the stream |
 
 ### send_task_stream_data
 
 ```python
-async def send_task_stream_data(self, data: Optional[dict] = None) -> None
+async def send_task_stream_data(self, data: dict | None = None) -> None
 ```
 
 Send a streaming chunk to the requester.
 
-| Parameter | Type             | Default | Description       |
-| --------- | ---------------- | ------- | ----------------- |
-| `data`    | `Optional[dict]` | `None`  | The chunk payload |
+| Parameter | Type         | Default | Description       |
+| --------- | ------------ | ------- | ----------------- |
+| `data`    | `dict | None` | `None`  | The chunk payload |
 
 ### send_task_stream_end
 
 ```python
-async def send_task_stream_end(self, data: Optional[dict] = None) -> None
+async def send_task_stream_end(self, data: dict | None = None) -> None
 ```
 
 End the current stream and mark this agent's task as complete.
 
-| Parameter | Type             | Default | Description             |
-| --------- | ---------------- | ------- | ----------------------- |
-| `data`    | `Optional[dict]` | `None`  | Optional final metadata |
+| Parameter | Type         | Default | Description             |
+| --------- | ------------ | ------- | ----------------------- |
+| `data`    | `dict | None` | `None`  | Optional final metadata |
 
 ## Task Hooks
 

--- a/api-reference/pipecat-subagents/bus.mdx
+++ b/api-reference/pipecat-subagents/bus.mdx
@@ -120,7 +120,7 @@ runner = AgentRunner(bus=bus)
   A `redis.asyncio.Redis` client instance.
 </ParamField>
 
-<ParamField path="serializer" type="Optional[MessageSerializer]" default="None">
+<ParamField path="serializer" type="MessageSerializer | None" default="None">
   The
   [`MessageSerializer`](/api-reference/pipecat-subagents/serializers#messageserializer)
   for encoding/decoding messages. Defaults to
@@ -157,18 +157,18 @@ pipeline = Pipeline([transport.input(), bridge, transport.output()])
   Name of this agent, used as message source.
 </ParamField>
 
-<ParamField path="target_agent" type="Optional[str]" default="None">
+<ParamField path="target_agent" type="str | None" default="None">
   When set, only exchange frames with this agent.
 </ParamField>
 
-<ParamField path="bridge" type="Optional[str]" default="None">
+<ParamField path="bridge" type="str | None" default="None">
   Optional bridge name for routing. When set, outgoing frames are tagged with
   this name and only incoming frames with the same bridge name are accepted.
 </ParamField>
 
 <ParamField
   path="exclude_frames"
-  type="Optional[tuple[type[Frame], ...]]"
+  type="tuple[type[Frame], ...] | None"
   default="None"
 >
   Extra frame types that should never cross the bus (on top of lifecycle frames

--- a/api-reference/pipecat-subagents/decorators.mdx
+++ b/api-reference/pipecat-subagents/decorators.mdx
@@ -34,7 +34,7 @@ async def my_tool(self, params, arg: str):
   `LLMAgent` tools.
 </ParamField>
 
-<ParamField path="timeout" type="Optional[float]" default="None">
+<ParamField path="timeout" type="float | None" default="None">
   Timeout in seconds for this tool call. Defaults to `None` (uses the LLM
   service default).
 </ParamField>
@@ -91,7 +91,7 @@ async def on_research(self, message):
 
 ### Parameters
 
-<ParamField path="name" type="Optional[str]" default="None">
+<ParamField path="name" type="str | None" default="None">
   Task name to match. When set, this handler only receives requests with a
   matching name. When `None`, handles all unnamed requests (or requests with no
   matching named handler).

--- a/api-reference/pipecat-subagents/flows-agent.mdx
+++ b/api-reference/pipecat-subagents/flows-agent.mdx
@@ -49,7 +49,7 @@ Inherits all parameters from [`BaseAgent`](/api-reference/pipecat-subagents/base
 
 <ParamField
   path="context_strategy"
-  type="Optional[ContextStrategyConfig]"
+  type="ContextStrategyConfig | None"
   default="None"
 >
   Optional context strategy forwarded to `FlowManager`. See
@@ -58,7 +58,7 @@ Inherits all parameters from [`BaseAgent`](/api-reference/pipecat-subagents/base
 
 <ParamField
   path="global_functions"
-  type="Optional[List[FlowsFunctionSchema | FlowsDirectFunction]]"
+  type="list[FlowsFunctionSchema | FlowsDirectFunction] | None"
   default="None"
 >
   Optional list of functions available at every node, forwarded to
@@ -71,7 +71,7 @@ Inherits all parameters from [`BaseAgent`](/api-reference/pipecat-subagents/base
   Whether the agent starts active. Defaults to `False`.
 </ParamField>
 
-<ParamField path="bridged" type="Optional[tuple[str, ...]]" default="()">
+<ParamField path="bridged" type="tuple[str, ...] | None" default="()">
   Bridge configuration. Defaults to an empty tuple (bridged, accepting all
   bridges).
 </ParamField>
@@ -83,7 +83,7 @@ Inherits all properties from [`BaseAgent`](/api-reference/pipecat-subagents/base
 ### flow_manager
 
 ```python
-agent.flow_manager -> Optional[FlowManager]
+agent.flow_manager -> FlowManager | None
 ```
 
 The `FlowManager` instance, available after the pipeline task is created.
@@ -127,11 +127,11 @@ Return the node to resume from when re-entering this agent. Called on subsequent
 ### on_activated
 
 ```python
-async def on_activated(self, args: Optional[dict]) -> None
+async def on_activated(self, args: dict | None) -> None
 ```
 
 Initialize or resume the flow on activation. On first call, initializes the flow at `build_initial_node()`. On subsequent calls, sets the node from `build_resume_node()`.
 
-| Parameter | Type             | Description                   |
-| --------- | ---------------- | ----------------------------- |
-| `args`    | `Optional[dict]` | Optional activation arguments |
+| Parameter | Type         | Description                   |
+| --------- | ------------ | ----------------------------- |
+| `args`    | `dict | None` | Optional activation arguments |

--- a/api-reference/pipecat-subagents/llm-agent.mdx
+++ b/api-reference/pipecat-subagents/llm-agent.mdx
@@ -43,7 +43,7 @@ Inherits all parameters from [`BaseAgent`](/api-reference/pipecat-subagents/base
   handoff.
 </ParamField>
 
-<ParamField path="bridged" type="Optional[tuple[str, ...]]" default="None">
+<ParamField path="bridged" type="tuple[str, ...] | None" default="None">
   Bridge configuration. See
   [`BaseAgent`](/api-reference/pipecat-subagents/base-agent#configuration) for
   details.
@@ -106,14 +106,14 @@ Create the LLM with tools registered. Calls `build_llm()` and registers all `@to
 ### on_activated
 
 ```python
-async def on_activated(self, args: Optional[dict]) -> None
+async def on_activated(self, args: dict | None) -> None
 ```
 
 Configure the LLM with tools and activation messages. When `args` contains `messages`, they are appended to the LLM context. When `args` contains `run_llm` (defaults to `True` when messages are set), the LLM is triggered after appending.
 
-| Parameter | Type             | Description                                                                                                          |
-| --------- | ---------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `args`    | `Optional[dict]` | Activation arguments (see [`LLMAgentActivationArgs`](/api-reference/pipecat-subagents/types#llmagentactivationargs)) |
+| Parameter | Type         | Description                                                                                                          |
+| --------- | ------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `args`    | `dict | None` | Activation arguments (see [`LLMAgentActivationArgs`](/api-reference/pipecat-subagents/types#llmagentactivationargs)) |
 
 ### handoff_to
 
@@ -122,18 +122,18 @@ async def handoff_to(
     self,
     agent_name: str,
     *,
-    args: Optional[AgentActivationArgs] = None,
-    result_callback: Optional[FunctionCallResultCallback] = None,
+    args: AgentActivationArgs | None = None,
+    result_callback: FunctionCallResultCallback | None = None,
 ) -> None
 ```
 
 Hand off to another agent. When called from a `@tool` handler, pass `params.result_callback` to ensure any pending LLM output is fully delivered before handing off.
 
-| Parameter         | Type                                   | Default | Description                                     |
-| ----------------- | -------------------------------------- | ------- | ----------------------------------------------- |
-| `agent_name`      | `str`                                  |         | Name of the agent to hand off to                |
-| `args`            | `Optional[AgentActivationArgs]`        | `None`  | Arguments forwarded to `on_activated`           |
-| `result_callback` | `Optional[FunctionCallResultCallback]` | `None`  | The `result_callback` from `FunctionCallParams` |
+| Parameter         | Type                                | Default | Description                                     |
+| ----------------- | ----------------------------------- | ------- | ----------------------------------------------- |
+| `agent_name`      | `str`                               |         | Name of the agent to hand off to                |
+| `args`            | `AgentActivationArgs | None`        | `None`  | Arguments forwarded to `on_activated`           |
+| `result_callback` | `FunctionCallResultCallback | None` | `None`  | The `result_callback` from `FunctionCallParams` |
 
 ### end
 
@@ -141,17 +141,17 @@ Hand off to another agent. When called from a `@tool` handler, pass `params.resu
 async def end(
     self,
     *,
-    reason: Optional[str] = None,
-    result_callback: Optional[FunctionCallResultCallback] = None,
+    reason: str | None = None,
+    result_callback: FunctionCallResultCallback | None = None,
 ) -> None
 ```
 
 Request a graceful end of the session. When called from a `@tool` handler, pass `params.result_callback` to ensure any pending LLM output is fully delivered before ending.
 
-| Parameter         | Type                                   | Default | Description                                     |
-| ----------------- | -------------------------------------- | ------- | ----------------------------------------------- |
-| `reason`          | `Optional[str]`                        | `None`  | Human-readable reason for ending                |
-| `result_callback` | `Optional[FunctionCallResultCallback]` | `None`  | The `result_callback` from `FunctionCallParams` |
+| Parameter         | Type                                | Default | Description                                     |
+| ----------------- | ----------------------------------- | ------- | ----------------------------------------------- |
+| `reason`          | `str | None`                        | `None`  | Human-readable reason for ending                |
+| `result_callback` | `FunctionCallResultCallback | None` | `None`  | The `result_callback` from `FunctionCallParams` |
 
 ### process_deferred_tool_frames
 

--- a/api-reference/pipecat-subagents/messages.mdx
+++ b/api-reference/pipecat-subagents/messages.mdx
@@ -38,7 +38,7 @@ All messages inherit these fields from `BusDataMessage` or `BusSystemMessage`:
 | Field    | Type            | Default | Description                                             |
 | -------- | --------------- | ------- | ------------------------------------------------------- |
 | `source` | `str`           |         | Name of the agent or component that sent this message   |
-| `target` | `Optional[str]` | `None`  | Name of the intended recipient, or `None` for broadcast |
+| `target` | `str | None` | `None`  | Name of the intended recipient, or `None` for broadcast |
 
 ## Frame Transport
 
@@ -51,10 +51,10 @@ All messages inherit these fields from `BusDataMessage` or `BusSystemMessage`:
 | Field       | Type             | Default | Description                                                   |
 | ----------- | ---------------- | ------- | ------------------------------------------------------------- |
 | `source`    | `str`            |         | Sending agent name                                            |
-| `target`    | `Optional[str]`  | `None`  | Recipient agent name                                          |
+| `target`    | `str | None`     | `None`  | Recipient agent name                                          |
 | `frame`     | `Frame`          |         | The Pipecat frame to transport                                |
 | `direction` | `FrameDirection` |         | Direction the frame should travel in the recipient's pipeline |
-| `bridge`    | `Optional[str]`  | `None`  | Bridge name for routing in multi-bridge setups                |
+| `bridge`    | `str | None`     | `None`  | Bridge name for routing in multi-bridge setups                |
 
 ## Agent Lifecycle
 
@@ -69,27 +69,27 @@ All messages inherit these fields from `BusDataMessage` or `BusSystemMessage`:
 
 ### BusActivateAgentMessage
 
-| Field    | Type             | Default | Description                                      |
-| -------- | ---------------- | ------- | ------------------------------------------------ |
-| `source` | `str`            |         | Sending agent name                               |
-| `target` | `Optional[str]`  | `None`  | Agent to activate                                |
-| `args`   | `Optional[dict]` | `None`  | Activation arguments forwarded to `on_activated` |
+| Field    | Type         | Default | Description                                      |
+| -------- | ------------ | ------- | ------------------------------------------------ |
+| `source` | `str`        |         | Sending agent name                               |
+| `target` | `str | None` | `None`  | Agent to activate                                |
+| `args`   | `dict | None` | `None`  | Activation arguments forwarded to `on_activated` |
 
 ### BusEndMessage / BusEndAgentMessage
 
-| Field    | Type            | Default | Description                      |
-| -------- | --------------- | ------- | -------------------------------- |
-| `source` | `str`           |         | Sending agent name               |
-| `target` | `Optional[str]` | `None`  | Recipient agent name             |
-| `reason` | `Optional[str]` | `None`  | Human-readable reason for ending |
+| Field    | Type        | Default | Description                      |
+| -------- | ----------- | ------- | -------------------------------- |
+| `source` | `str`       |         | Sending agent name               |
+| `target` | `str | None` | `None`  | Recipient agent name             |
+| `reason` | `str | None` | `None`  | Human-readable reason for ending |
 
 ### BusCancelMessage / BusCancelAgentMessage
 
-| Field    | Type            | Default | Description                            |
-| -------- | --------------- | ------- | -------------------------------------- |
-| `source` | `str`           |         | Sending agent name                     |
-| `target` | `Optional[str]` | `None`  | Recipient agent name                   |
-| `reason` | `Optional[str]` | `None`  | Human-readable reason for cancellation |
+| Field    | Type        | Default | Description                            |
+| -------- | ----------- | ------- | -------------------------------------- |
+| `source` | `str`       |         | Sending agent name                     |
+| `target` | `str | None` | `None`  | Recipient agent name                   |
+| `reason` | `str | None` | `None`  | Human-readable reason for cancellation |
 
 ## Registry & Errors
 
@@ -111,14 +111,14 @@ All messages inherit these fields from `BusDataMessage` or `BusSystemMessage`:
 
 ### BusAgentReadyMessage
 
-| Field        | Type              | Default | Description                                         |
-| ------------ | ----------------- | ------- | --------------------------------------------------- |
-| `source`     | `str`             |         | Agent name                                          |
-| `runner`     | `str`             |         | Name of the runner managing this agent              |
-| `parent`     | `Optional[str]`   | `None`  | Name of the parent agent, or `None` for root agents |
-| `active`     | `bool`            | `False` | Whether the agent started active                    |
-| `bridged`    | `bool`            | `False` | Whether the agent is bridged                        |
-| `started_at` | `Optional[float]` | `None`  | Unix timestamp when the agent became ready          |
+| Field        | Type          | Default | Description                                         |
+| ------------ | ------------- | ------- | --------------------------------------------------- |
+| `source`     | `str`         |         | Agent name                                          |
+| `runner`     | `str`         |         | Name of the runner managing this agent              |
+| `parent`     | `str | None`   | `None`  | Name of the parent agent, or `None` for root agents |
+| `active`     | `bool`        | `False` | Whether the agent started active                    |
+| `bridged`    | `bool`        | `False` | Whether the agent is bridged                        |
+| `started_at` | `float | None` | `None`  | Unix timestamp when the agent became ready          |
 
 ### BusAgentErrorMessage / BusAgentLocalErrorMessage
 
@@ -141,41 +141,41 @@ All messages inherit these fields from `BusDataMessage` or `BusSystemMessage`:
 
 ### BusTaskRequestMessage
 
-| Field       | Type             | Default | Description                             |
-| ----------- | ---------------- | ------- | --------------------------------------- |
-| `source`    | `str`            |         | Requester agent name                    |
-| `target`    | `Optional[str]`  | `None`  | Worker agent name                       |
-| `task_id`   | `str`            |         | Unique task identifier                  |
-| `task_name` | `Optional[str]`  | `None`  | Task name for routing to named handlers |
-| `payload`   | `Optional[dict]` | `None`  | Structured data describing the work     |
+| Field       | Type         | Default | Description                             |
+| ----------- | ------------ | ------- | --------------------------------------- |
+| `source`    | `str`        |         | Requester agent name                    |
+| `target`    | `str | None` | `None`  | Worker agent name                       |
+| `task_id`   | `str`        |         | Unique task identifier                  |
+| `task_name` | `str | None` | `None`  | Task name for routing to named handlers |
+| `payload`   | `dict | None` | `None`  | Structured data describing the work     |
 
 ### BusTaskResponseMessage / BusTaskResponseUrgentMessage
 
 | Field      | Type                                                              | Default | Description          |
 | ---------- | ----------------------------------------------------------------- | ------- | -------------------- |
 | `source`   | `str`                                                             |         | Worker agent name    |
-| `target`   | `Optional[str]`                                                   | `None`  | Requester agent name |
+| `target`   | `str | None`                                                      | `None`  | Requester agent name |
 | `task_id`  | `str`                                                             |         | The task identifier  |
 | `status`   | [`TaskStatus`](/api-reference/pipecat-subagents/types#taskstatus) |         | Completion status    |
-| `response` | `Optional[dict]`                                                  | `None`  | Result data          |
+| `response` | `dict | None`                                                     | `None`  | Result data          |
 
 ### BusTaskUpdateMessage / BusTaskUpdateUrgentMessage
 
-| Field     | Type             | Default | Description          |
-| --------- | ---------------- | ------- | -------------------- |
-| `source`  | `str`            |         | Worker agent name    |
-| `target`  | `Optional[str]`  | `None`  | Requester agent name |
-| `task_id` | `str`            |         | The task identifier  |
-| `update`  | `Optional[dict]` | `None`  | Progress data        |
+| Field     | Type         | Default | Description          |
+| --------- | ------------ | ------- | -------------------- |
+| `source`  | `str`        |         | Worker agent name    |
+| `target`  | `str | None` | `None`  | Requester agent name |
+| `task_id` | `str`        |         | The task identifier  |
+| `update`  | `dict | None` | `None`  | Progress data        |
 
 ### BusTaskCancelMessage
 
-| Field     | Type            | Default | Description                            |
-| --------- | --------------- | ------- | -------------------------------------- |
-| `source`  | `str`           |         | Requester agent name                   |
-| `target`  | `Optional[str]` | `None`  | Worker agent name                      |
-| `task_id` | `str`           |         | The task identifier                    |
-| `reason`  | `Optional[str]` | `None`  | Human-readable reason for cancellation |
+| Field     | Type        | Default | Description                            |
+| --------- | ----------- | ------- | -------------------------------------- |
+| `source`  | `str`       |         | Requester agent name                   |
+| `target`  | `str | None` | `None`  | Worker agent name                      |
+| `task_id` | `str`       |         | The task identifier                    |
+| `reason`  | `str | None` | `None`  | Human-readable reason for cancellation |
 
 ## Task Streaming
 
@@ -187,9 +187,9 @@ All messages inherit these fields from `BusDataMessage` or `BusSystemMessage`:
 
 ### BusTaskStreamStartMessage / BusTaskStreamDataMessage / BusTaskStreamEndMessage
 
-| Field     | Type             | Default | Description                                                            |
-| --------- | ---------------- | ------- | ---------------------------------------------------------------------- |
-| `source`  | `str`            |         | Worker agent name                                                      |
-| `target`  | `Optional[str]`  | `None`  | Requester agent name                                                   |
-| `task_id` | `str`            |         | The task identifier                                                    |
-| `data`    | `Optional[dict]` | `None`  | Stream metadata (start), chunk payload (data), or final metadata (end) |
+| Field     | Type         | Default | Description                                                            |
+| --------- | ------------ | ------- | ---------------------------------------------------------------------- |
+| `source`  | `str`        |         | Worker agent name                                                      |
+| `target`  | `str | None` | `None`  | Requester agent name                                                   |
+| `task_id` | `str`        |         | The task identifier                                                    |
+| `data`    | `dict | None` | `None`  | Stream metadata (start), chunk payload (data), or final metadata (end) |

--- a/api-reference/pipecat-subagents/proxy-agents.mdx
+++ b/api-reference/pipecat-subagents/proxy-agents.mdx
@@ -70,12 +70,12 @@ await runner.add_agent(proxy)
   agent name only, regardless of target.
 </ParamField>
 
-<ParamField path="headers" type="Optional[dict[str, str]]" default="None">
+<ParamField path="headers" type="dict[str, str] | None" default="None">
   Optional HTTP headers sent with the WebSocket handshake (e.g. for
   authentication).
 </ParamField>
 
-<ParamField path="serializer" type="Optional[MessageSerializer]" default="None">
+<ParamField path="serializer" type="MessageSerializer | None" default="None">
   Serializer for bus messages. Defaults to
   [`JSONMessageSerializer`](/api-reference/pipecat-subagents/serializers#jsonmessageserializer).
 </ParamField>
@@ -154,7 +154,7 @@ async def websocket_endpoint(websocket: WebSocket):
   agent name only, regardless of target.
 </ParamField>
 
-<ParamField path="serializer" type="Optional[MessageSerializer]" default="None">
+<ParamField path="serializer" type="MessageSerializer | None" default="None">
   Serializer for bus messages. Defaults to
   [`JSONMessageSerializer`](/api-reference/pipecat-subagents/serializers#jsonmessageserializer).
 </ParamField>

--- a/api-reference/pipecat-subagents/serializers.mdx
+++ b/api-reference/pipecat-subagents/serializers.mdx
@@ -32,7 +32,7 @@ Convert a bus message to bytes.
 
 ```python
 @abstractmethod
-def deserialize(self, data: bytes) -> Optional[BusMessage]
+def deserialize(self, data: bytes) -> BusMessage | None
 ```
 
 Reconstruct a bus message from bytes.
@@ -107,7 +107,7 @@ def deserialize(
     self,
     data: dict[str, Any],
     deserialize_value: DeserializeFunc,
-    target_type: Optional[type] = None,
+    target_type: type | None = None,
 ) -> Any
 ```
 
@@ -117,4 +117,4 @@ Reconstruct an object from a dict.
 | ------------------- | ---------------------- | ------- | ------------------------------------------------- |
 | `data`              | `dict[str, Any]`       |         | The dict representation produced by `serialize()` |
 | `deserialize_value` | `Callable[[Any], Any]` |         | Callback to recursively deserialize nested values |
-| `target_type`       | `Optional[type]`       | `None`  | The resolved target class                         |
+| `target_type`       | `type | None`          | `None`  | The resolved target class                         |

--- a/api-reference/pipecat-subagents/types.mdx
+++ b/api-reference/pipecat-subagents/types.mdx
@@ -26,9 +26,9 @@ from pipecat_subagents.agents.base_agent import AgentActivationArgs
 
 Base activation arguments for any agent.
 
-| Field      | Type             | Default | Description                                       |
-| ---------- | ---------------- | ------- | ------------------------------------------------- |
-| `metadata` | `Optional[dict]` | `None`  | Optional structured data passed during activation |
+| Field      | Type         | Default | Description                                       |
+| ---------- | ------------ | ------- | ------------------------------------------------- |
+| `metadata` | `dict | None` | `None`  | Optional structured data passed during activation |
 
 ### Methods
 
@@ -48,11 +48,11 @@ from pipecat_subagents.agents.llm_agent import LLMAgentActivationArgs
 
 Activation arguments for [`LLMAgent`](/api-reference/pipecat-subagents/llm-agent). Extends [`AgentActivationArgs`](#agentactivationargs).
 
-| Field      | Type             | Default | Description                                                                                |
-| ---------- | ---------------- | ------- | ------------------------------------------------------------------------------------------ |
-| `metadata` | `Optional[dict]` | `None`  | Optional structured data passed during activation                                          |
-| `messages` | `Optional[list]` | `None`  | LLM context messages to inject on activation                                               |
-| `run_llm`  | `Optional[bool]` | `None`  | Whether to run the LLM after appending messages. Defaults to `True` when `messages` is set |
+| Field      | Type         | Default | Description                                                                                |
+| ---------- | ------------ | ------- | ------------------------------------------------------------------------------------------ |
+| `metadata` | `dict | None` | `None`  | Optional structured data passed during activation                                          |
+| `messages` | `list | None` | `None`  | LLM context messages to inject on activation                                               |
+| `run_llm`  | `bool | None` | `None`  | Whether to run the LLM after appending messages. Defaults to `True` when `messages` is set |
 
 ## TaskContext
 
@@ -130,11 +130,11 @@ from pipecat_subagents.agents.task_context import TaskGroupEvent
 
 An event received from a worker during task group execution.
 
-| Field        | Type             | Description                               |
-| ------------ | ---------------- | ----------------------------------------- |
-| `type`       | `str`            | The event type (see constants below)      |
-| `agent_name` | `str`            | The name of the agent that sent the event |
-| `data`       | `Optional[dict]` | Optional event payload                    |
+| Field        | Type         | Description                               |
+| ------------ | ------------ | ----------------------------------------- |
+| `type`       | `str`        | The event type (see constants below)      |
+| `agent_name` | `str`        | The name of the agent that sent the event |
+| `data`       | `dict | None` | Optional event payload                    |
 
 ### Event Type Constants
 
@@ -179,13 +179,13 @@ from pipecat_subagents.types import AgentRegistryEntry
 
 Information about an agent in a registry snapshot.
 
-| Field        | Type              | Default | Description                                         |
-| ------------ | ----------------- | ------- | --------------------------------------------------- |
-| `name`       | `str`             |         | The agent's name                                    |
-| `parent`     | `Optional[str]`   | `None`  | Name of the parent agent, or `None` for root agents |
-| `active`     | `bool`            | `False` | Whether the agent is currently active               |
-| `bridged`    | `bool`            | `False` | Whether the agent is bridged                        |
-| `started_at` | `Optional[float]` | `None`  | Unix timestamp when the agent became ready          |
+| Field        | Type          | Default | Description                                         |
+| ------------ | ------------- | ------- | --------------------------------------------------- |
+| `name`       | `str`         |         | The agent's name                                    |
+| `parent`     | `str | None`   | `None`  | Name of the parent agent, or `None` for root agents |
+| `active`     | `bool`        | `False` | Whether the agent is currently active               |
+| `bridged`    | `bool`        | `False` | Whether the agent is bridged                        |
+| `started_at` | `float | None` | `None`  | Unix timestamp when the agent became ready          |
 
 ## AgentRegistry
 
@@ -208,7 +208,7 @@ Tracks all known agents across local and remote runners. Owned by the [`AgentRun
 #### get
 
 ```python
-def get(self, agent_name: str) -> Optional[AgentReadyData]
+def get(self, agent_name: str) -> AgentReadyData | None
 ```
 
 Look up a registered agent by name.


### PR DESCRIPTION
Automated documentation update for [pipecat-subagents PR #14](https://github.com/pipecat-ai/pipecat-subagents/pull/14).

## Changes

Updated all subagents API reference pages to use modern Python 3.11+ type annotation syntax:

### Files updated (10 total)
- `api-reference/pipecat-subagents/agent-runner.mdx`
- `api-reference/pipecat-subagents/base-agent.mdx`
- `api-reference/pipecat-subagents/bus.mdx`
- `api-reference/pipecat-subagents/decorators.mdx`
- `api-reference/pipecat-subagents/flows-agent.mdx`
- `api-reference/pipecat-subagents/llm-agent.mdx`
- `api-reference/pipecat-subagents/messages.mdx`
- `api-reference/pipecat-subagents/proxy-agents.mdx`
- `api-reference/pipecat-subagents/serializers.mdx`
- `api-reference/pipecat-subagents/types.mdx`

### Type annotation modernization
- `Optional[X]` → `X | None` (115 occurrences)
- `List[X]` → `list[X]` (1 occurrence)

Updated in:
- `<ParamField>` type attributes
- Function/property type signatures in code blocks
- Type columns in parameter/field tables

## Gaps identified

None. All changed source files were mapped to documentation pages, and no guide files referenced the old type syntax.