### PR TITLE
docs: update for pipecat PR #4320

### DIFF
--- a/api-reference/server/services/tts/smallest.mdx
+++ b/api-reference/server/services/tts/smallest.mdx
@@ -47,7 +47,7 @@ export SMALLEST_API_KEY=your_api_key
   Smallest AI API key for authentication.
 </ParamField>
 
-<ParamField path="base_url" type="str" default="wss://waves-api.smallest.ai">
+<ParamField path="base_url" type="str" default="wss://api.smallest.ai">
   Base WebSocket URL for the Smallest API. Override for custom or proxied
   deployments.
 </ParamField>


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4320](https://github.com/pipecat-ai/pipecat/pull/4320).

## Changes
- **api-reference/server/services/tts/smallest.mdx**: Updated `base_url` configuration parameter default from `wss://waves-api.smallest.ai` to `wss://api.smallest.ai` to match Smallest AI v4.0.0 API changes

## Gaps identified
None