### PR TITLE
docs: update for pipecat PR #4334

### DIFF
--- a/api-reference/server/services/stt/sarvam.mdx
+++ b/api-reference/server/services/stt/sarvam.mdx
@@ -68,10 +68,10 @@ Before using Sarvam STT services, you need:
   Sarvam API key for authentication.
 </ParamField>
 
-<ParamField path="model" type="str" default="saarika:v2.5" deprecated>
+<ParamField path="model" type="str" default="saaras:v3" deprecated>
   Sarvam model to use. Allowed values: `"saarika:v2.5"` (standard STT),
   `"saaras:v2.5"` (STT-Translate, auto-detects language), `"saaras:v3"`
-  (advanced, supports mode and prompts). *Deprecated in v0.0.105. Use
+  (advanced, supports mode and fine-grained VAD). *Deprecated in v0.0.105. Use
   `settings=SarvamSTTService.Settings(...)` instead.*
 </ParamField>
 
@@ -125,13 +125,23 @@ Before using Sarvam STT services, you need:
 
 Runtime-configurable settings passed via the `settings` constructor argument using `SarvamSTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter              | Type              | Default | Description                                                                                                                                                                                                                        |
-| ---------------------- | ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `model`                | `str`             | `None`  | STT model identifier. _(Inherited from base STT settings.)_                                                                                                                                                                        |
-| `language`             | `Language \| str` | `None`  | Target language for transcription. _(Inherited from base STT settings.)_ Behavior varies by model: `saarika:v2.5` defaults to "unknown" (auto-detect), `saaras:v2.5` ignores this (auto-detects), `saaras:v3` defaults to "en-IN". |
-| `prompt`               | `str`             | `None`  | Optional prompt to guide transcription/translation style. Only applicable to saaras models (v2.5 and v3).                                                                                                                          |
-| `vad_signals`          | `bool`            | `None`  | Enable VAD signals in responses. When enabled, the service broadcasts `UserStartedSpeakingFrame` and `UserStoppedSpeakingFrame` from the server.                                                                                   |
-| `high_vad_sensitivity` | `bool`            | `None`  | Enable high VAD sensitivity for more responsive speech detection.                                                                                                                                                                  |
+| Parameter                        | Type              | Default | Description                                                                                                                                                                                                                        |
+| -------------------------------- | ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model`                          | `str`             | `None`  | STT model identifier. _(Inherited from base STT settings.)_                                                                                                                                                                        |
+| `language`                       | `Language \| str` | `None`  | Target language for transcription. _(Inherited from base STT settings.)_ Behavior varies by model: `saarika:v2.5` defaults to "unknown" (auto-detect), `saaras:v2.5` ignores this (auto-detects), `saaras:v3` defaults to "en-IN". |
+| `prompt`                         | `str`             | `None`  | Optional prompt to guide transcription/translation style. Only applicable to `saaras:v2.5`.                                                                                                                                        |
+| `vad_signals`                    | `bool`            | `None`  | Enable VAD signals in responses. When enabled, the service broadcasts `UserStartedSpeakingFrame` and `UserStoppedSpeakingFrame` from the server.                                                                                   |
+| `high_vad_sensitivity`           | `bool`            | `None`  | Enable high VAD sensitivity for more responsive speech detection.                                                                                                                                                                  |
+| `positive_speech_threshold`      | `float`           | `None`  | VAD probability threshold (0.0-1.0) above which a frame is considered speech. Only for `saaras:v3`.                                                                                                                                |
+| `negative_speech_threshold`      | `float`           | `None`  | VAD probability threshold (0.0-1.0) below which a frame is considered silence. Only for `saaras:v3`.                                                                                                                               |
+| `min_speech_frames`              | `int`             | `None`  | Minimum consecutive speech frames to start a speech segment. Only for `saaras:v3`.                                                                                                                                                 |
+| `first_turn_min_speech_frames`   | `int`             | `None`  | Minimum speech frames for the first user turn. Only for `saaras:v3`.                                                                                                                                                               |
+| `negative_frames_count`          | `int`             | `None`  | Number of silence frames within the window to end a speech segment. Only for `saaras:v3`.                                                                                                                                          |
+| `negative_frames_window`         | `int`             | `None`  | Sliding window size (in frames) for counting negative frames. Only for `saaras:v3`.                                                                                                                                                |
+| `start_speech_volume_threshold`  | `float`           | `None`  | Volume level (dB) below which audio is too quiet to be speech. Only for `saaras:v3`.                                                                                                                                               |
+| `interrupt_min_speech_frames`    | `int`             | `None`  | Minimum speech frames to register a barge-in/interruption. Only for `saaras:v3`.                                                                                                                                                   |
+| `pre_speech_pad_frames`          | `int`             | `None`  | Number of audio frames to prepend before detected speech onset. Only for `saaras:v3`.                                                                                                                                              |
+| `num_initial_ignored_frames`     | `int`             | `None`  | Number of leading audio frames to skip at connection start. Only for `saaras:v3`.                                                                                                                                                  |
 
 ## Usage
 
@@ -178,8 +188,10 @@ stt = SarvamSTTService(
 
 ## Notes
 
+- **Default model changed**: As of this update, the default model is `saaras:v3` (previously `saarika:v2.5`). Applications that relied on the previous default should set `settings=SarvamSTTService.Settings(model="saarika:v2.5")` explicitly.
 - **Supported languages**: Bengali (bn-IN), Gujarati (gu-IN), Hindi (hi-IN), Kannada (kn-IN), Malayalam (ml-IN), Marathi (mr-IN), Tamil (ta-IN), Telugu (te-IN), Punjabi (pa-IN), Odia (od-IN), English (en-IN), and Assamese (as-IN).
-- **Model-specific parameter validation**: The service validates that parameters are compatible with the selected model. For example, `prompt` is not supported with `saarika:v2.5`, and `language` is not supported with `saaras:v2.5` (which auto-detects language).
+- **Model-specific parameter validation**: The service validates that parameters are compatible with the selected model. For example, `prompt` is only supported with `saaras:v2.5`, `language` is not supported with `saaras:v2.5` (which auto-detects language), and the fine-grained VAD parameters are only supported with `saaras:v3`.
+- **Fine-grained VAD tuning (saaras:v3 only)**: The `saaras:v3` model supports server-side VAD with 10 tuning parameters for speech detection thresholds, frame-count controls, pre-speech padding, interruption sensitivity, and initial-frame skipping. These parameters are only available with the `saaras:v3` model.
 - **VAD modes**: When `vad_signals=False` (default), the service relies on Pipecat's local VAD and flushes the server buffer on `VADUserStoppedSpeakingFrame`. When `vad_signals=True`, the service uses Sarvam's server-side VAD and broadcasts speaking frames from the server.
 
 <Tip>


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4334](https://github.com/pipecat-ai/pipecat/pull/4334).

## Changes

**Updated `api-reference/server/services/stt/sarvam.mdx`:**
- Changed default model from `saarika:v2.5` to `saaras:v3`
- Added 10 fine-grained VAD parameters to Settings table for `saaras:v3` model:
  - `positive_speech_threshold` - VAD probability threshold for speech detection
  - `negative_speech_threshold` - VAD probability threshold for silence detection
  - `min_speech_frames` - Minimum consecutive speech frames
  - `first_turn_min_speech_frames` - Minimum speech frames for first turn
  - `negative_frames_count` - Silence frames to end speech segment
  - `negative_frames_window` - Sliding window size for counting negative frames
  - `start_speech_volume_threshold` - Volume threshold for speech detection
  - `interrupt_min_speech_frames` - Minimum frames for barge-in detection
  - `pre_speech_pad_frames` - Audio frames to prepend before speech onset
  - `num_initial_ignored_frames` - Leading frames to skip at connection start
- Updated Notes section to reflect default model change and fine-grained VAD support
- Clarified that `prompt` parameter is only supported by `saaras:v2.5`

## Gaps identified

None