### PR TITLE
docs: update for pipecat PR #4325

### DIFF
--- a/api-reference/server/services/analytics/sentry.mdx
+++ b/api-reference/server/services/analytics/sentry.mdx
@@ -113,3 +113,4 @@ llm = SomeLLMService(metrics=sentry_llm)
 - **Transaction types**: The service creates two types of Sentry transactions: `ttfb` for time-to-first-byte tracking and `processing` for frame processing duration.
 - **Background processing**: Transactions are completed in a background task to avoid blocking the pipeline.
 - **Graceful shutdown**: On cleanup, the service flushes all pending transactions to Sentry with a 5-second timeout.
+- **Observer integration**: Metrics tracked by `SentryMetrics` are emitted as `MetricsFrame` objects downstream, enabling integration with pipeline observers like `UserBotLatencyObserver` and `MetricsLogObserver`.


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4325](https://github.com/pipecat-ai/pipecat/pull/4325).

## Changes

Updated `api-reference/server/services/analytics/sentry.mdx`:
- Added note about observer integration to the Notes section
- Clarifies that `SentryMetrics` emits `MetricsFrame` objects downstream, enabling integration with pipeline observers like `UserBotLatencyObserver` and `MetricsLogObserver`

This documents the behavioral fix in PR #4325, where `SentryMetrics.stop_ttfb_metrics()` and `SentryMetrics.stop_processing_metrics()` were updated to properly return `MetricsFrame` objects, allowing them to be pushed downstream to observers.

## Gaps identified

None