### PR TITLE
docs: update for pipecat PR #4344

### DIFF
--- a/api-reference/server/services/tts/elevenlabs.mdx
+++ b/api-reference/server/services/tts/elevenlabs.mdx
@@ -245,6 +245,7 @@ async with aiohttp.ClientSession() as session:
 - **Multilingual models required for `language`**: Setting `language` with a non-multilingual model (e.g. `eleven_turbo_v2_5`) has no effect. Use `eleven_multilingual_v2` or similar.
 - **WebSocket vs HTTP**: The WebSocket service supports word-level timestamps and interruption handling, making it significantly better for interactive conversations. The HTTP service is simpler but lacks these features.
 - **Text aggregation**: Sentence aggregation is enabled by default (`text_aggregation_mode=TextAggregationMode.SENTENCE`). Buffering until sentence boundaries produces more natural speech. Set `text_aggregation_mode=TextAggregationMode.TOKEN` to stream tokens directly for lower latency. The `auto_mode` parameter is automatically configured based on the aggregation mode for optimal quality.
+- **Word timestamp accuracy**: Word timestamps accurately reflect the spoken audio, not just the input text. When using pronunciation dictionaries or text normalization (`apply_text_normalization`), the service consumes ElevenLabs' normalized alignment data to ensure downstream consumers (captions, transcripts, context aggregation) match what the listener actually hears.
 
 ## Event Handlers
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4344](https://github.com/pipecat-ai/pipecat/pull/4344).

## Changes
- **api-reference/server/services/tts/elevenlabs.mdx** — Added note about word timestamp accuracy when using pronunciation dictionaries or text normalization

## Summary
PR #4344 fixed a bug where ElevenLabs TTS services emitted word timestamps matching the input text rather than the spoken audio when pronunciation dictionaries or text normalization were active. The services now consume normalized alignment data from ElevenLabs, ensuring word timestamps accurately reflect what the listener hears.

Added a note to the documentation explaining this behavior and its impact on downstream consumers (captions, transcripts, context aggregation).

## Gaps identified
None