### PR TITLE
docs: update for pipecat PR #4340

### DIFF
--- a/api-reference/server/services/stt/xai.mdx
+++ b/api-reference/server/services/stt/xai.mdx
@@ -1,0 +1,184 @@
+---
+title: "xAI"
+description: "Speech-to-text service implementation using xAI's real-time WebSocket API"
+---
+
+## Overview
+
+`XAISTTService` provides real-time speech-to-text transcription using xAI's WebSocket STT API with support for interim results, configurable endpointing, multichannel audio, and speaker diarization.
+
+The service streams raw audio (PCM, μ-law, or A-law) to xAI's endpoint and emits interim and final transcription frames based on the server's `is_final` and `speech_final` flags. The connection is persistent: audio is streamed continuously and the server automatically detects utterance boundaries.
+
+<CardGroup cols={2}>
+  <Card
+    title="xAI STT API Reference"
+    icon="code"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.xai.stt.html"
+  >
+    Pipecat's API methods for xAI STT integration
+  </Card>
+  <Card
+    title="Example Implementation"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/transcription/transcription-xai.py"
+  >
+    Complete transcription example with xAI STT
+  </Card>
+  <Card
+    title="Voice Agent Example"
+    icon="microphone"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-xai.py"
+  >
+    Full voice agent with xAI STT, LLM, and TTS
+  </Card>
+  <Card
+    title="xAI Documentation"
+    icon="book"
+    href="https://docs.x.ai/developers/rest-api-reference/inference/voice"
+  >
+    Official xAI voice API documentation
+  </Card>
+</CardGroup>
+
+## Installation
+
+To use xAI STT services, install the required dependencies:
+
+```bash
+uv add "pipecat-ai[xai]"
+```
+
+## Prerequisites
+
+### xAI Account Setup
+
+Before using xAI STT services, you need:
+
+1. **xAI Account**: Sign up at [xAI](https://x.ai/)
+2. **API Key**: Generate an API key from your account dashboard
+3. **Language Selection**: Choose from 16 supported languages
+
+### Required Environment Variables
+
+- `XAI_API_KEY`: Your xAI API key for authentication
+
+## Configuration
+
+### XAISTTService
+
+<ParamField path="api_key" type="str" required>
+  xAI API key for authentication (used as Bearer token for the WebSocket
+  handshake).
+</ParamField>
+
+<ParamField path="ws_url" type="str" default="wss://api.x.ai/v1/stt">
+  WebSocket endpoint URL for xAI STT.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="16000">
+  Audio sample rate in Hz. Supported values: 8000, 16000, 22050, 24000, 44100,
+  48000.
+</ParamField>
+
+<ParamField path="encoding" type="str" default="pcm">
+  Audio encoding format. One of `"pcm"` (signed 16-bit LE), `"mulaw"`, or
+  `"alaw"`.
+</ParamField>
+
+<ParamField path="settings" type="XAISTTService.Settings" default="None">
+  Runtime-configurable settings for the STT service. See [Settings](#settings)
+  below.
+</ParamField>
+
+<ParamField path="ttfs_p99_latency" type="float" default="XAI_TTFS_P99">
+  P99 latency from speech end to final transcript in seconds. Override for your
+  deployment. See
+  [stt-benchmark](https://github.com/pipecat-ai/stt-benchmark).
+</ParamField>
+
+### Settings
+
+Runtime-configurable settings passed via the `settings` constructor argument using `XAISTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
+
+| Parameter        | Type              | Default       | Description                                                                                                                  |
+| ---------------- | ----------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `model`          | `str`             | `None`        | Not applicable for xAI STT. _(Inherited from base STT settings.)_                                                            |
+| `language`       | `Language \| str` | `Language.EN` | Recognition language. Supports: AR, BN, DE, EN, ES, FR, HI, ID, IT, JA, KO, PT, RU, TR, VI, ZH. _(Inherited from base STT settings.)_ |
+| `interim_results` | `bool`            | `True`        | When True, partial transcripts are emitted approximately every 500ms.                                                        |
+| `endpointing`    | `int \| None`     | `None`        | Silence duration in milliseconds that triggers a speech-final event. Range 0-5000. Server default is 10ms.                  |
+| `multichannel`   | `bool \| None`    | `None`        | When True, transcribes each interleaved channel independently. Requires `channels` >= 2.                                     |
+| `channels`       | `int \| None`     | `None`        | Number of interleaved channels (2-8). Required when `multichannel` is True.                                                  |
+| `diarize`        | `bool \| None`    | `None`        | When True, the server attaches a `speaker` field to each word identifying the detected speaker.                             |
+
+## Usage
+
+### Basic Setup
+
+```python
+import os
+from pipecat.services.xai.stt import XAISTTService
+
+stt = XAISTTService(
+    api_key=os.getenv("XAI_API_KEY"),
+)
+```
+
+### With Custom Settings
+
+```python
+import os
+from pipecat.services.xai.stt import XAISTTService
+from pipecat.transcriptions.language import Language
+
+stt = XAISTTService(
+    api_key=os.getenv("XAI_API_KEY"),
+    sample_rate=24000,
+    settings=XAISTTService.Settings(
+        language=Language.ES,
+        interim_results=True,
+        endpointing=1000,
+        diarize=True,
+    ),
+)
+```
+
+### With Multichannel Audio
+
+```python
+import os
+from pipecat.services.xai.stt import XAISTTService
+
+stt = XAISTTService(
+    api_key=os.getenv("XAI_API_KEY"),
+    settings=XAISTTService.Settings(
+        multichannel=True,
+        channels=2,
+    ),
+)
+```
+
+## Notes
+
+- **Connection management**: The WebSocket connection is persistent and automatically reconnects if it drops mid-session. Audio is streamed continuously and the server emits `transcript.partial` events with `is_final` and `speech_final` flags to mark utterance boundaries.
+- **Language support**: xAI STT accepts two-letter language codes. When set, the server applies Inverse Text Normalization for improved accuracy.
+- **Audio encoding**: Supports PCM (signed 16-bit LE), μ-law, and A-law encoding formats. PCM is recommended for best quality.
+- **Settings updates**: Changing settings requires reconnecting to the WebSocket. The service automatically handles disconnect and reconnect when settings are updated via `STTUpdateSettingsFrame`.
+
+## Event Handlers
+
+xAI STT supports the standard [service connection events](/api-reference/server/events/service-events):
+
+| Event             | Description                   |
+| ----------------- | ----------------------------- |
+| `on_connected`    | Connected to xAI WebSocket    |
+| `on_disconnected` | Disconnected from xAI WebSocket |
+
+```python
+@stt.event_handler("on_connected")
+async def on_connected(service):
+    print("Connected to xAI STT")
+
+@stt.event_handler("on_disconnected")
+async def on_disconnected(service):
+    print("Disconnected from xAI STT")
+```

--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -56,6 +56,7 @@ Speech-to-Text services receive and audio input and output transcriptions.
 | [Soniox](/api-reference/server/services/stt/soniox)             | `uv add "pipecat-ai[soniox]"`       |
 | [Speechmatics](/api-reference/server/services/stt/speechmatics) | `uv add "pipecat-ai[speechmatics]"` |
 | [Whisper](/api-reference/server/services/stt/whisper)           | `uv add "pipecat-ai[whisper]"`      |
+| [xAI](/api-reference/server/services/stt/xai)                   | `uv add "pipecat-ai[xai]"`          |
 
 ## Large Language Models
 

--- a/docs.json
+++ b/docs.json
@@ -349,6 +349,7 @@
                       "api-reference/server/services/stt/fal",
                       "api-reference/server/services/stt/gladia",
                       "api-reference/server/services/stt/google",
+                      "api-reference/server/services/stt/gradium",
                       "api-reference/server/services/stt/groq",
                       "api-reference/server/services/stt/nvidia",
                       "api-reference/server/services/stt/openai",
@@ -357,7 +358,7 @@
                       "api-reference/server/services/stt/soniox",
                       "api-reference/server/services/stt/speechmatics",
                       "api-reference/server/services/stt/whisper",
-                      "api-reference/server/services/stt/gradium"
+                      "api-reference/server/services/stt/xai"
                     ]
                   },
                   {


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4340](https://github.com/pipecat-ai/pipecat/pull/4340).

## Changes

- **Created `api-reference/server/services/stt/xai.mdx`**: New documentation page for xAI STT service with:
  - Overview of the service and WebSocket-based real-time transcription
  - Installation instructions (`uv add "pipecat-ai[xai]"`)
  - Prerequisites (xAI account and API key setup)
  - Configuration parameters (api_key, ws_url, sample_rate, encoding, settings)
  - Settings table documenting runtime-configurable options (interim_results, endpointing, multichannel, channels, diarize)
  - Usage examples (basic setup, custom settings, multichannel audio)
  - Notes on connection management, language support, and audio encoding
  - Event handlers documentation (on_connected, on_disconnected)
  
- **Updated `docs.json`**: Added xAI STT to Speech-to-Text navigation group in alphabetical order (also fixed gradium ordering)

- **Updated `api-reference/server/services/supported-services.mdx`**: Added xAI to the Speech-to-Text services table

## Gaps identified

None