### PR TITLE
feat: add SmolVLM community vision service integration

### DIFF
--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -103,6 +103,6 @@ VAD services analyze audio input to detect when a user starts and stops speaking
 
 Vision services receive a streaming video input and output text describing the video input.
 
-| Service                         | Repository | Maintainer(s) |
-| ------------------------------- | ---------- | ------------- |
-| _No community integrations yet_ |            |               |
+| Service                         | Repository                                         | Maintainer(s)                                        |
+| ------------------------------- | -------------------------------------------------- | ---------------------------------------------------- |                                        
+| SmolVLM                         | https://github.com/rahulsolanki001/pipecat-smolvlm | [rahul solanki] (https://github.com/rahulsolanki001) |


### PR DESCRIPTION
**Summary**

This PR adds pipecat-smolvlm to the community integrations listing — a VisionService integration for [SmolVLM](https://huggingface.co/HuggingFaceTB/SmolVLM-256M-Instruct), a family of compact, locally-hosted vision-language models from HuggingFace.
SmolVLM runs entirely on-device with no network dependency, no per-image billing, and no data leaving your infrastructure. This makes it a natural fit for latency-sensitive or privacy-conscious voice agent deployments.

**Integration highlights**

- Hardware support — auto-detects CUDA (bfloat16 + Flash Attention 2), Apple MPS (bfloat16), Intel XPU, and CPU (float32). Pass use_cpu=True to override.
- Three model sizes — 256M (default, ~1 GB), 500M, and 2B, all switchable via settings.model with no code changes.
- Non-blocking inference — model.generate() runs in asyncio.to_thread so the event loop is never blocked.
- Correct frame flow — yields VisionFullResponseStartFrame → VisionTextFrame → VisionFullResponseEndFrame, or a single ErrorFrame on failure, fully consistent with Pipecat's vision service contract.
- Per-image prompts — reads frame.text as the prompt when present; falls back to configurable default_prompt.