### PR TITLE
Clarify VAD is optional with ExternalUserTurnStrategies

### DIFF
--- a/api-reference/server/services/stt/deepgram.mdx
+++ b/api-reference/server/services/stt/deepgram.mdx
@@ -357,6 +357,7 @@ This sends a `Configure` message to Deepgram over the existing WebSocket connect
 ### Notes
 
 - **Turn management**: Flux provides its own turn detection via `StartOfTurn`/`EndOfTurn` events and broadcasts `UserStartedSpeakingFrame`/`UserStoppedSpeakingFrame` directly. Use `ExternalUserTurnStrategies` to avoid conflicting VAD-based turn management.
+- **VAD is optional**: When Flux drives turn detection, a VAD (such as `SileroVADAnalyzer`) in your transport is not required for core functionality. Include one if you want useful STT metrics; omit it otherwise.
 - **On-the-fly configuration**: Supports updating `keyterm`, `eot_threshold`, `eager_eot_threshold`, and `eot_timeout_ms` mid-stream via `STTUpdateSettingsFrame`. These updates are sent as `Configure` messages over the existing WebSocket connection without requiring a reconnect.
 - **EagerEndOfTurn**: Enabling `eager_eot_threshold` provides faster response times by predicting end-of-turn before it is confirmed. EagerEndOfTurn transcripts are pushed as `InterimTranscriptionFrame`s. If the user resumes speaking, a `TurnResumed` event is fired.
 
@@ -596,6 +597,7 @@ await task.queue_frame(
 ### Notes
 
 - **Turn management**: Flux provides native turn detection via `StartOfTurn`/`EndOfTurn` events and broadcasts `UserStartedSpeakingFrame`/`UserStoppedSpeakingFrame` directly. Use `ExternalUserTurnStrategies` to avoid conflicting VAD-based turn management.
+- **VAD is optional**: When Flux drives turn detection, a VAD (such as `SileroVADAnalyzer`) in your transport is not required for core functionality. Include one if you want useful STT metrics; omit it otherwise.
 - **On-the-fly configuration**: Supports updating `keyterm`, `eot_threshold`, `eager_eot_threshold`, and `eot_timeout_ms` mid-stream via `STTUpdateSettingsFrame`. These updates are sent as `Configure` messages over the existing HTTP/2 connection without requiring a reconnect.
 - **EagerEndOfTurn**: Enabling `eager_eot_threshold` provides faster response times by predicting end-of-turn before it is confirmed. EagerEndOfTurn transcripts are pushed as `InterimTranscriptionFrame`s. If the user resumes speaking, a `TurnResumed` event is fired.
 - **SageMaker deployment**: Requires a Deepgram Flux model deployed to an AWS SageMaker endpoint. Unlike Nova models, Flux provides native turn detection and does not require external VAD.

--- a/api-reference/server/services/stt/speechmatics.mdx
+++ b/api-reference/server/services/stt/speechmatics.mdx
@@ -12,7 +12,9 @@ description: "Speech-to-text service implementation using Speechmatics' real-tim
   should use `ExternalUserTurnStrategies` to let Speechmatics handle turn
   management. See [User Turn
   Strategies](/api-reference/server/utilities/turn-management/user-turn-strategies)
-  for configuration details.
+  for configuration details. A VAD in the transport (such as `SileroVADAnalyzer`)
+  is optional when Speechmatics drives turn detection via the default
+  `TurnDetectionMode.EXTERNAL` mode; include it if you want useful STT metrics.
 </Note>
 
 <CardGroup cols={2}>

--- a/api-reference/server/utilities/turn-management/external-turn-management.mdx
+++ b/api-reference/server/utilities/turn-management/external-turn-management.mdx
@@ -34,6 +34,13 @@ user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
 )
 ```
 
+<Note>
+  When the STT service is driving turn detection, a VAD in the transport (such
+  as `SileroVADAnalyzer`) is optional. It's not needed for core turn management,
+  but including one enables useful STT metrics. Drop it if you don't care about
+  those metrics.
+</Note>
+
 ## UserTurnProcessor
 
 `UserTurnProcessor` is a frame processor for managing user turn lifecycle when you need a single source of turn events shared across multiple context aggregators. It emits `UserStartedSpeakingFrame` and `UserStoppedSpeakingFrame` frames and handles interruptions.

--- a/api-reference/server/utilities/turn-management/user-turn-strategies.mdx
+++ b/api-reference/server/utilities/turn-management/user-turn-strategies.mdx
@@ -378,6 +378,13 @@ user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
 )
 ```
 
+<Note>
+  When an STT service acts as the turn controller, you can optionally include a
+  VAD (such as `SileroVADAnalyzer`) in your transport. The VAD is not required
+  for core turn management functionality, but it does enable useful STT
+  metrics. Omit it if you don't need those metrics.
+</Note>
+
 ## Usage Examples
 
 ### Default Behavior


### PR DESCRIPTION
## Summary
- When an STT service drives turn detection via `ExternalUserTurnStrategies`, a VAD (e.g. `SileroVADAnalyzer`) in the transport is optional — it's only needed for useful STT metrics, not core functionality
- Adds clarifying notes in four places: `user-turn-strategies.mdx`, `external-turn-management.mdx`, Deepgram Flux (both WebSocket and SageMaker variants), and the Speechmatics top-level note

Context: [Slack thread](https://pluot.slack.com/archives/C07SDSCSLTZ/p1776781587936959) where Kwindla flagged the inconsistency and Mark confirmed VAD alongside an STT-based turn controller is metrics-only.

## Test plan
- [ ] `mint broken-links` passes
- [ ] Mark confirms the phrasing matches the intended mental model

🤖 Generated with [Claude Code](https://claude.com/claude-code)