### PR TITLE
docs: update for pipecat PR #4349

### DIFF
--- a/api-reference/server/services/serializers/plivo.mdx
+++ b/api-reference/server/services/serializers/plivo.mdx
@@ -143,6 +143,6 @@ serializer = PlivoFrameSerializer(
 
 ## Notes
 
-- **Auto hang-up credentials**: When `auto_hang_up` is enabled (the default), the serializer uses `call_id`, `auth_id`, and `auth_token` to terminate the call via Plivo's REST API. If any are missing, a warning is logged and the hang-up is skipped.
+- **Auto hang-up requires credentials**: When `auto_hang_up` is enabled (the default), you must provide `call_id`, `auth_id`, and `auth_token`. A `ValueError` is raised at initialization if any are missing.
 - **Audio format**: Plivo uses 8kHz mu-law (PCMU) audio encoding. The serializer automatically converts between this format and Pipecat's PCM audio.
 - **DTMF support**: Touch-tone digit events from callers are converted to `InputDTMFFrame` objects.

--- a/api-reference/server/services/serializers/telnyx.mdx
+++ b/api-reference/server/services/serializers/telnyx.mdx
@@ -153,5 +153,5 @@ serializer = TelnyxFrameSerializer(
 ## Notes
 
 - **Multiple audio encodings**: Telnyx supports both PCMU (mu-law) and PCMA (A-law) encodings. The `inbound_encoding` and `outbound_encoding` must be specified as constructor arguments and will override any values set in `InputParams`.
-- **Auto hang-up credentials**: When `auto_hang_up` is enabled (the default), `call_control_id` and `api_key` are required to terminate the call via Telnyx's REST API. If missing, a warning is logged and the hang-up is skipped.
+- **Auto hang-up requires credentials**: When `auto_hang_up` is enabled (the default), you must provide `call_control_id` and `api_key`. A `ValueError` is raised at initialization if any are missing.
 - **DTMF support**: Touch-tone digit events from callers are converted to `InputDTMFFrame` objects.


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4349](https://github.com/pipecat-ai/pipecat/pull/4349).

## Changes

### `api-reference/server/services/serializers/plivo.mdx`
Updated the Notes section to reflect that `PlivoFrameSerializer` now raises `ValueError` at initialization when `auto_hang_up=True` (the default) but required credentials (`call_id`, `auth_id`, `auth_token`) are missing. Previously, the serializer constructed successfully and logged a warning at call-end, which could result in phantom billable sessions.

### `api-reference/server/services/serializers/telnyx.mdx`
Updated the Notes section to reflect that `TelnyxFrameSerializer` now raises `ValueError` at initialization when `auto_hang_up=True` (the default) but required credentials (`call_control_id`, `api_key`) are missing. Previously, the serializer constructed successfully and logged a warning at call-end, which could result in phantom billable sessions.

## Gaps identified
None