### PR TITLE
docs: update for pipecat PR #4270

### DIFF
--- a/api-reference/server/services/llm/nvidia.mdx
+++ b/api-reference/server/services/llm/nvidia.mdx
@@ -52,19 +52,19 @@ uv add "pipecat-ai[nvidia]"
 
 Before using NVIDIA NIM LLM services, you need:
 
-1. **NVIDIA Developer Account**: Sign up at [NVIDIA Developer Portal](https://developer.nvidia.com/)
-2. **API Key**: Generate an NVIDIA API key for NIM services
+1. **NVIDIA Developer Account** (cloud endpoint only): Sign up at [NVIDIA Developer Portal](https://developer.nvidia.com/)
+2. **API Key** (cloud endpoint only): Generate an NVIDIA API key for NIM cloud services
 3. **Model Selection**: Choose from available NIM-hosted models
-4. **Enterprise Setup**: Configure NIM for on-premises deployment if needed
+4. **Local NIM Setup** (optional): For local deployments, configure NIM on-premises and set the `base_url` to your local endpoint
 
-### Required Environment Variables
+### Environment Variables
 
-- `NVIDIA_API_KEY`: Your NVIDIA API key for authentication
+- `NVIDIA_API_KEY`: Your NVIDIA API key for authentication (required for cloud endpoint, not needed for local NIM deployments)
 
 ## Configuration
 
-<ParamField path="api_key" type="str" required>
-  NVIDIA API key for authentication.
+<ParamField path="api_key" type="str | None" default="None">
+  NVIDIA API key for authentication. Required when using the cloud endpoint (`https://integrate.api.nvidia.com/v1`). Not needed for local NIM deployments.
 </ParamField>
 
 <ParamField
@@ -72,7 +72,7 @@ Before using NVIDIA NIM LLM services, you need:
   type="str"
   default="https://integrate.api.nvidia.com/v1"
 >
-  Base URL for NIM API endpoint.
+  Base URL for NIM API endpoint. Defaults to NVIDIA's cloud endpoint. For local deployments, pass the local address (e.g., `http://localhost:8000/v1`).
 </ParamField>
 
 <ParamField
@@ -107,7 +107,9 @@ from pipecat.services.nvidia import NvidiaLLMService
 
 llm = NvidiaLLMService(
     api_key=os.getenv("NVIDIA_API_KEY"),
-    model="nvidia/llama-3.1-nemotron-70b-instruct",
+    settings=NvidiaLLMService.Settings(
+        model="nvidia/nemotron-3-nano-30b-a3b",
+    ),
 )
 ```
 
@@ -119,7 +121,7 @@ from pipecat.services.nvidia import NvidiaLLMService
 llm = NvidiaLLMService(
     api_key=os.getenv("NVIDIA_API_KEY"),
     settings=NvidiaLLMService.Settings(
-        model="nvidia/llama-3.1-nemotron-70b-instruct",
+        model="nvidia/nemotron-3-nano-30b-a3b",
         temperature=0.7,
         top_p=0.9,
         max_completion_tokens=1024,
@@ -129,8 +131,13 @@ llm = NvidiaLLMService(
 
 ## Notes
 
-- NVIDIA NIM uses incremental token reporting. The service accumulates token usage metrics during processing and reports the final totals at the end of each request.
-- NIM supports both cloud-hosted and on-premises deployments. For on-premises, override the `base_url` to point to your local NIM endpoint.
+- **Token reporting**: NVIDIA NIM uses incremental token reporting. The service accumulates token usage metrics during processing and reports the final totals at the end of each request.
+- **Cloud vs. local deployment**: NIM supports both cloud-hosted and on-premises deployments. For on-premises, override the `base_url` to point to your local NIM endpoint. API keys are only required for the cloud endpoint.
+- **Reasoning content**: The service automatically detects and filters reasoning content from model responses, emitting it as `LLMThought*Frame` objects. This applies to:
+  - Models with API-level reasoning separation (e.g., Nemotron Nano models) that include a `reasoning_content` field
+  - Models that emit reasoning inline using `<think>...</think>` tags (e.g., DeepSeek-R1, some Nemotron models)
+  
+  Reasoning frames are accessible to observers and logging but are not sent to TTS, keeping the spoken output clean while preserving visibility into the model's thought process.
 
 <Tip>
   The `InputParams` / `params=` pattern is deprecated as of v0.0.105. Use


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4270](https://github.com/pipecat-ai/pipecat/pull/4270).

## Changes

### Updated reference pages
- `api-reference/server/services/llm/nvidia.mdx`:
  - Made `api_key` parameter optional (not required for local NIM deployments)
  - Updated default model from `nvidia/llama-3.1-nemotron-70b-instruct` to `nvidia/nemotron-3-nano-30b-a3b`
  - Added documentation for reasoning content handling via `LLMThought*Frame` objects
  - Updated Prerequisites section to clarify cloud vs. local deployment requirements
  - Enhanced Notes section with reasoning content behavior details
  - Updated all usage examples with new default model

## Gaps identified
None