### PR TITLE
docs: update for pipecat PR #4337

### DIFF
--- a/api-reference/server/utilities/turn-management/user-turn-strategies.mdx
+++ b/api-reference/server/utilities/turn-management/user-turn-strategies.mdx
@@ -235,11 +235,16 @@ All stop strategies inherit these parameters:
 
 ### SpeechTimeoutUserTurnStopStrategy
 
-Signals the end of a user turn when transcription is received and VAD indicates silence. Waits for a configurable timeout after VAD detects silence before finalizing the turn, and supports finalized transcripts for earlier triggering.
+Signals the end of a user turn using two independent timers after VAD detects silence. The user turn stop is triggered only when both timers have finished and at least one transcript has been received:
+
+- **user_speech_timeout**: Policy floor — the window in which the user may resume speaking after a pause. Always runs to completion.
+- **stt_timeout**: Safety net for STT latency — the P99 time for the STT service to return a final transcript after VAD stop. Short-circuited when the STT service emits a finalized transcript (`TranscriptionFrame.finalized=True`), since finalization means STT has nothing more to send.
+
+For STT services that support finalization (Speechmatics, Soniox, Deepgram Flux, AssemblyAI), user turns now end as soon as `user_speech_timeout` elapses after VAD stop, rather than waiting for both timers.
 
 <ParamField path="user_speech_timeout" type="float" default="0.6">
   How long to wait (in seconds) after VAD detects silence before finalizing the
-  user turn.
+  user turn. This is the minimum wait time and always runs to completion.
 </ParamField>
 
 ```python

--- a/pipecat/learn/speech-input.mdx
+++ b/pipecat/learn/speech-input.mdx
@@ -118,7 +118,7 @@ stop_strategy = TurnAnalyzerUserTurnStopStrategy(
 )
 ```
 
-**Speech Timeout**: Waits for silence after receiving a transcription. Useful as a simpler alternative to Smart Turn.
+**Speech Timeout**: Waits for a configurable timeout after VAD detects silence and a transcript is received. Useful as a simpler alternative to Smart Turn.
 
 ```python
 from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4337](https://github.com/pipecat-ai/pipecat/pull/4337).

## Changes

- **`api-reference/server/utilities/turn-management/user-turn-strategies.mdx`** — Updated `SpeechTimeoutUserTurnStopStrategy` description to explain the new dual-timer behavior: strategy now uses two independent timers (`user_speech_timeout` and `stt_timeout`), with finalized transcripts short-circuiting the STT safety net for faster turn detection.
- **`pipecat/learn/speech-input.mdx`** — Updated brief description of Speech Timeout strategy to clarify it waits after VAD detects silence (not just after transcription).

## Gaps identified

None