### PR TITLE
docs: update for pipecat PR #4269

### DIFF
--- a/api-reference/server/services/stt/nvidia.mdx
+++ b/api-reference/server/services/stt/nvidia.mdx
@@ -1,22 +1,22 @@
 ---
-title: "NVIDIA Riva"
-description: "Speech-to-text service implementation using NVIDIA Riva"
+title: "NVIDIA Nemotron Speech"
+description: "Speech-to-text service implementation using NVIDIA Nemotron Speech"
 ---
 
 ## Overview
 
-NVIDIA Riva provides two STT service implementations:
+NVIDIA Nemotron Speech provides two STT service implementations:
 
-- **`NvidiaSTTService`** -- Real-time streaming transcription using Parakeet models with interim results and continuous audio processing.
+- **`NvidiaSTTService`** -- Real-time streaming transcription using Nemotron ASR Streaming models with interim results and continuous audio processing.
 - **`NvidiaSegmentedSTTService`** -- Segmented transcription using Canary models with advanced language support, word boosting, and enterprise-grade accuracy.
 
 <CardGroup cols={2}>
   <Card
-    title="NVIDIA Riva STT API Reference"
+    title="NVIDIA Nemotron Speech STT API Reference"
     icon="code"
     href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.nvidia.stt.html"
   >
-    Pipecat's API methods for NVIDIA Riva STT integration
+    Pipecat's API methods for NVIDIA Nemotron Speech STT integration
   </Card>
   <Card
     title="Example Implementation"
@@ -26,24 +26,24 @@ NVIDIA Riva provides two STT service implementations:
     Complete example with NVIDIA services integration
   </Card>
   <Card
-    title="NVIDIA Riva Documentation"
+    title="NVIDIA ASR NIM Documentation"
     icon="book"
-    href="https://docs.nvidia.com/deeplearning/riva/user-guide/docs/asr/asr-overview.html"
+    href="https://docs.nvidia.com/nim/speech/latest/asr/"
   >
-    Official NVIDIA Riva ASR documentation
+    Official NVIDIA ASR NIM documentation
   </Card>
   <Card
     title="NVIDIA Developer Portal"
     icon="microphone"
     href="https://developer.nvidia.com"
   >
-    Access API keys and Riva services
+    Access API keys and Nemotron Speech services
   </Card>
 </CardGroup>
 
 ## Installation
 
-To use NVIDIA Riva services, install the required dependency:
+To use NVIDIA Nemotron Speech services, install the required dependency:
 
 ```bash
 uv add "pipecat-ai[nvidia]"
@@ -51,34 +51,38 @@ uv add "pipecat-ai[nvidia]"
 
 ## Prerequisites
 
-### NVIDIA Riva Setup
+### NVIDIA Nemotron Speech Setup
 
-Before using NVIDIA Riva STT services, you need:
+Before using NVIDIA Nemotron Speech STT services, you need:
 
-1. **NVIDIA Developer Account**: Sign up at [NVIDIA Developer Portal](https://developer.nvidia.com)
-2. **API Key**: Generate an NVIDIA API key for Riva services
-3. **Model Selection**: Choose between Parakeet (streaming) and Canary (segmented) models
+1. **NVIDIA Developer Account** (for cloud deployments): Sign up at [NVIDIA Developer Portal](https://developer.nvidia.com)
+2. **API Key** (for cloud deployments): Generate an NVIDIA API key for Nemotron Speech services
+3. **Model Selection**: Choose between Nemotron ASR Streaming (streaming) and Canary (segmented) models
 
-### Required Environment Variables
+For local deployments, you can run NVIDIA ASR NIM locally without an API key. See the [NVIDIA ASR NIM documentation](https://docs.nvidia.com/nim/speech/latest/asr/) for deployment instructions.
 
-- `NVIDIA_API_KEY`: Your NVIDIA API key for authentication
+### Environment Variables
+
+- `NVIDIA_API_KEY`: Your NVIDIA API key for authentication (required for cloud endpoint, not needed for local deployments)
 
 ## NvidiaSTTService
 
-Real-time streaming transcription using NVIDIA Riva's Parakeet models.
+Real-time streaming transcription using NVIDIA Nemotron Speech's streaming ASR models.
 
-<ParamField path="api_key" type="str" required>
-  NVIDIA API key for authentication.
+<ParamField path="api_key" type="str | None" default="None">
+  NVIDIA API key for authentication. Required when using the cloud endpoint. Not
+  needed for local deployments.
 </ParamField>
 
 <ParamField path="server" type="str" default="grpc.nvcf.nvidia.com:443">
-  NVIDIA Riva server address.
+  NVIDIA Nemotron Speech server address. For local deployments, pass the local
+  address (e.g. `localhost:50051`).
 </ParamField>
 
 <ParamField
   path="model_function_map"
   type="Mapping[str, str]"
-  default='{"function_id": "1598d209-5e27-4d3c-8079-4751568b1081", "model_name": "parakeet-ctc-1.1b-asr"}'
+  default='{"function_id": "bb0837de-8c7b-481f-9ec8-ef5663e9c1fa", "model_name": "nemotron-asr-streaming"}'
 >
   Mapping containing `function_id` and `model_name` for the ASR model.
 </ParamField>
@@ -103,7 +107,41 @@ Real-time streaming transcription using NVIDIA Riva's Parakeet models.
 </ParamField>
 
 <ParamField path="use_ssl" type="bool" default="True">
-  Whether to use SSL for the gRPC connection.
+  Whether to use SSL for the gRPC connection. Defaults to `True` for the NVIDIA
+  cloud endpoint. Set to `False` for local deployments.
+</ParamField>
+
+<ParamField path="audio_channel_count" type="int" default="1">
+  Number of audio channels.
+</ParamField>
+
+<ParamField path="start_history" type="int" default="-1">
+  VAD start history in frames. Use `-1` for Nemotron Speech default.
+</ParamField>
+
+<ParamField path="start_threshold" type="float" default="-1.0">
+  VAD start threshold. Use `-1.0` for Nemotron Speech default.
+</ParamField>
+
+<ParamField path="stop_history" type="int" default="320">
+  VAD stop history in frames. Use `-1` for Nemotron Speech default.
+</ParamField>
+
+<ParamField path="stop_threshold" type="float" default="-1.0">
+  VAD stop threshold. Use `-1.0` for Nemotron Speech default.
+</ParamField>
+
+<ParamField path="stop_history_eou" type="int" default="-1">
+  End-of-utterance stop history in frames. Use `-1` for Nemotron Speech default.
+</ParamField>
+
+<ParamField path="stop_threshold_eou" type="float" default="-1.0">
+  End-of-utterance stop threshold. Use `-1.0` for Nemotron Speech default.
+</ParamField>
+
+<ParamField path="custom_configuration" type="str" default='""'>
+  Custom Nemotron Speech configuration string (e.g.
+  `"enable_vad_endpointing:true,neural_vad.onset:0.65"`).
 </ParamField>
 
 <ParamField path="ttfs_p99_latency" type="float" default="1.0">
@@ -115,10 +153,20 @@ Real-time streaming transcription using NVIDIA Riva's Parakeet models.
 
 Runtime-configurable settings passed via the `settings` constructor argument using `NvidiaSTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter  | Type              | Default          | Description                                                              |
-| ---------- | ----------------- | ---------------- | ------------------------------------------------------------------------ |
-| `model`    | `str`             | `None`           | STT model identifier. _(Inherited from base STT settings.)_              |
-| `language` | `Language \| str` | `Language.EN_US` | Target language for transcription. _(Inherited from base STT settings.)_ |
+| Parameter                 | Type              | Default          | Description                                                                   |
+| ------------------------- | ----------------- | ---------------- | ----------------------------------------------------------------------------- |
+| `model`                   | `str`             | `None`           | STT model identifier. _(Inherited from base STT settings.)_                   |
+| `language`                | `Language \| str` | `Language.EN_US` | Target language for transcription. _(Inherited from base STT settings.)_      |
+| `profanity_filter`        | `bool`            | `False`          | Whether to filter profanity from results.                                     |
+| `automatic_punctuation`   | `bool`            | `True`           | Whether to add automatic punctuation.                                         |
+| `verbatim_transcripts`    | `bool`            | `True`           | Whether to return verbatim transcripts.                                       |
+| `boosted_lm_words`        | `list[str]`       | `None`           | List of words to boost in the language model.                                 |
+| `boosted_lm_score`        | `float`           | `4.0`            | Score boost for specified words.                                              |
+| `max_alternatives`        | `int`             | `1`              | Maximum number of recognition alternatives.                                   |
+| `interim_results`         | `bool`            | `True`           | Whether to return interim (partial) results.                                  |
+| `word_time_offsets`       | `bool`            | `False`          | Whether to include word-level time offsets.                                   |
+| `speaker_diarization`     | `bool`            | `False`          | Whether to enable speaker diarization.                                        |
+| `diarization_max_speakers`| `int`             | `0`              | Maximum number of speakers for diarization.                                   |
 
 ### Usage
 
@@ -134,17 +182,20 @@ stt = NvidiaSTTService(
 
 - **Model cannot be changed after initialization**: Use the `model_function_map` parameter in the constructor to specify the model and function ID.
 - **Streaming**: Provides real-time interim and final results through continuous audio streaming.
+- **Metrics support**: This service supports metrics generation (`can_generate_metrics()` returns `True`).
 
 ## NvidiaSegmentedSTTService
 
-Batch/segmented transcription using NVIDIA Riva's Canary models. Processes complete audio segments after VAD detects speech boundaries.
+Batch/segmented transcription using NVIDIA Nemotron Speech's Canary models. Processes complete audio segments after VAD detects speech boundaries.
 
-<ParamField path="api_key" type="str" required>
-  NVIDIA API key for authentication.
+<ParamField path="api_key" type="str | None" default="None">
+  NVIDIA API key for authentication. Required when using the cloud endpoint. Not
+  needed for local deployments.
 </ParamField>
 
 <ParamField path="server" type="str" default="grpc.nvcf.nvidia.com:443">
-  NVIDIA Riva server address.
+  NVIDIA Nemotron Speech server address. For local deployments, pass the local
+  address (e.g. `localhost:50051`).
 </ParamField>
 
 <ParamField
@@ -179,7 +230,13 @@ Batch/segmented transcription using NVIDIA Riva's Canary models. Processes compl
 </ParamField>
 
 <ParamField path="use_ssl" type="bool" default="True">
-  Whether to use SSL for the gRPC connection.
+  Whether to use SSL for the gRPC connection. Defaults to `True` for the NVIDIA
+  cloud endpoint. Set to `False` for local deployments.
+</ParamField>
+
+<ParamField path="custom_configuration" type="str" default='""'>
+  Custom Nemotron Speech configuration string (e.g.
+  `"enable_vad_endpointing:true,neural_vad.onset:0.65"`).
 </ParamField>
 
 <ParamField path="ttfs_p99_latency" type="float" default="1.0">
@@ -200,6 +257,8 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 | `verbatim_transcripts`  | `bool`            | `False`          | Whether to return verbatim transcripts.                                  |
 | `boosted_lm_words`      | `list[str]`       | `None`           | List of words to boost in the language model.                            |
 | `boosted_lm_score`      | `float`           | `4.0`            | Score boost for specified words.                                         |
+| `max_alternatives`      | `int`             | `1`              | Maximum number of recognition alternatives.                              |
+| `word_time_offsets`     | `bool`            | `False`          | Whether to include word-level time offsets.                              |
 
 ### Usage
 
@@ -222,7 +281,7 @@ stt = NvidiaSegmentedSTTService(
 
 - **Model cannot be changed after initialization**: Use the `model_function_map` parameter in the constructor to specify the model and function ID.
 - **Segmented processing**: Processes complete audio segments for higher accuracy compared to streaming.
-- **Language support**: Supports Arabic, English (US/GB), French, German, Hindi, Italian, Japanese, Korean, Portuguese (BR), Russian, and Spanish (ES/US).
+- **Language support**: Supports Arabic, English (US/GB), French, German, Hindi, Italian, Japanese, Korean, Portuguese (BR), Russian, and Spanish (ES/US). See the [NVIDIA ASR NIM documentation](https://docs.nvidia.com/nim/speech/latest/reference/support-matrix/asr.html#supported-languages-by-model-type) for the complete list.
 - **Word boosting**: Use `boosted_lm_words` and `boosted_lm_score` to improve recognition of domain-specific terms.
 
 <Tip>


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4269](https://github.com/pipecat-ai/pipecat/pull/4269).

## Changes

**api-reference/server/services/stt/nvidia.mdx** — Updated NVIDIA STT documentation to reflect Nemotron Speech branding and new configuration options:
- Rebranded from "NVIDIA Riva" to "NVIDIA Nemotron Speech" throughout
- Updated model references (Parakeet → Nemotron ASR Streaming)
- Updated documentation links to point to NVIDIA ASR NIM docs
- Made `api_key` optional (None default) for local deployments
- Added new `NvidiaSTTService` configuration parameters: `audio_channel_count`, `start_history`, `start_threshold`, `stop_history`, `stop_threshold`, `stop_history_eou`, `stop_threshold_eou`, `custom_configuration`
- Added new `NvidiaSTTService.Settings` fields: `profanity_filter`, `automatic_punctuation`, `verbatim_transcripts`, `boosted_lm_words`, `boosted_lm_score`, `max_alternatives`, `interim_results`, `word_time_offsets`, `speaker_diarization`, `diarization_max_speakers`
- Added `custom_configuration` parameter to `NvidiaSegmentedSTTService`
- Added `max_alternatives` and `word_time_offsets` to `NvidiaSegmentedSTTService.Settings`
- Updated Prerequisites section to mention local deployment support (API key not required for local deployments)
- Added note about metrics support (`can_generate_metrics()` now returns `True`)
- Updated default `model_function_map` to use new function ID and model name for streaming service

## Gaps identified

None