### PR TITLE
docs: update for pipecat PR #4355

### DIFF
--- a/api-reference/server/services/s2s/gemini-live.mdx
+++ b/api-reference/server/services/s2s/gemini-live.mdx
@@ -325,7 +325,7 @@ llm = GeminiLiveLLMService(
 - **VAD modes**: By default, Gemini Live uses server-side VAD for detecting when the user starts and stops speaking. To use local VAD (e.g., Silero), set `vad=GeminiVADParams(disabled=True)` and configure an external VAD analyzer in your `LLMUserAggregatorParams`. The service will automatically send activity signals to the Gemini API when local VAD detects speech.
 - **Tools precedence**: Similarly, tools provided in the context override tools provided at init time.
 - **Transcription aggregation**: Gemini Live sends user transcriptions in small chunks. The service aggregates them into complete sentences using end-of-sentence detection with a 0.5-second timeout fallback.
-- **Session resumption**: The service automatically handles session resumption on reconnection using session resumption handles.
+- **Session resumption**: The service automatically handles session resumption on reconnection using session resumption handles. In the rare case where reconnection occurs before a resumption handle is received, conversation history is preserved by reseeding it into the new session.
 - **Connection resilience**: The service will attempt up to 3 consecutive reconnections before treating a connection failure as fatal.
 - **Video frame rate**: Video frames are throttled to a maximum of one per second.
 - **Affective dialog and proactivity**: These features require both a supporting model and API version (`v1alpha`).


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4355](https://github.com/pipecat-ai/pipecat/pull/4355).

## Changes
- **api-reference/server/services/s2s/gemini-live.mdx** — Updated the Session resumption note to clarify that conversation history is preserved even when reconnection occurs before a session resumption handle is received (via context reseeding).

## Gaps identified
None