### PR TITLE
docs: update for pipecat PR #4371

### DIFF
--- a/api-reference/server/pipeline/pipeline-task.mdx
+++ b/api-reference/server/pipeline/pipeline-task.mdx
@@ -105,6 +105,14 @@ await runner.run(task)
   for details.
 </ParamField>
 
+<ParamField path="tool_resources" type="Any" default="None">
+  Application-defined bag of resources (database handles, API clients, state,
+  etc.) shared across tool handlers. Passed by reference to every function
+  handler via `FunctionCallParams.tool_resources`. The framework never copies or
+  clears this object; the caller retains their handle and can read mutations
+  after the task finishes.
+</ParamField>
+
 ## Methods
 
 ### Task Lifecycle Management

--- a/pipecat/learn/function-calling.mdx
+++ b/pipecat/learn/function-calling.mdx
@@ -362,6 +362,7 @@ class FunctionCallParams:
     llm: LLMService                             # Reference to the LLM service
     context: LLMContext                         # Current conversation context
     result_callback: FunctionCallResultCallback # Return results here
+    tool_resources: Any                         # Application-defined resources shared across tool calls
 ```
 
 **Using the parameters:**
@@ -377,6 +378,11 @@ async def example_function_handler(params: FunctionCallParams):
 
     # Access LLM context for conversation history
     messages = params.context.messages
+
+    # Access shared resources (database, API clients, etc.)
+    if params.tool_resources:
+        db = params.tool_resources.database
+        user_id = params.tool_resources.current_user_id
 
     # Use LLM service for additional operations
     await params.llm.push_frame(TTSSpeakFrame("Looking up weather data..."))
@@ -450,6 +456,54 @@ async def get_current_weather(params: FunctionCallParams, location: str, format:
 ```
 
 </CodeGroup>
+
+### Sharing Resources with tool_resources
+
+When function handlers need access to shared resources like database connections, API clients, or application state, you can pass them via `tool_resources` when creating the `PipelineTask`. These resources are then accessible in every function handler via `params.tool_resources`.
+
+```python
+from dataclasses import dataclass
+from pipecat.pipeline.task import PipelineTask
+from pipecat.services.llm_service import FunctionCallParams
+
+# Define your application resources
+@dataclass
+class AppResources:
+    database: DatabaseConnection
+    api_client: WeatherAPIClient
+    user_id: str
+
+# Create your resources
+resources = AppResources(
+    database=db_connection,
+    api_client=weather_client,
+    user_id="user-123"
+)
+
+# Pass resources to the pipeline task
+task = PipelineTask(
+    pipeline,
+    tool_resources=resources
+)
+
+# Access resources in function handlers
+async def query_user_preferences(params: FunctionCallParams):
+    # Access shared resources
+    db = params.tool_resources.database
+    user_id = params.tool_resources.user_id
+    
+    # Query database with shared connection
+    prefs = await db.query("SELECT * FROM preferences WHERE user_id = ?", user_id)
+    
+    await params.result_callback(prefs)
+```
+
+**Key points:**
+
+- Resources are **passed by reference** — the caller retains their handle and can read mutations after the task finishes
+- The framework **never copies or clears** the `tool_resources` object
+- All function handlers in the pipeline share the same `tool_resources` instance
+- Useful for database connections, API clients, caches, or any shared state
 
 ## Controlling Function Call Behavior (Advanced)
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4371](https://github.com/pipecat-ai/pipecat/pull/4371).

## Changes

### Updated reference pages
- `api-reference/server/pipeline/pipeline-task.mdx` — Added `tool_resources` parameter documentation
- `pipecat/learn/function-calling.mdx` — Added `tool_resources` field to FunctionCallParams, added usage example showing how to share resources across tool handlers

## Summary

PR #4371 adds a new `tool_resources` parameter to `PipelineTask` that allows passing application-defined resources (database handles, API clients, state, etc.) to function handlers via `FunctionCallParams.tool_resources`.

### PipelineTask
- Added `tool_resources` constructor parameter that accepts any application-defined object
- Resources are passed by reference to all function handlers
- The framework never copies or clears this object

### FunctionCallParams
- Added `tool_resources` field that provides access to the shared resources
- Updated documentation to show how to access resources in function handlers
- Added comprehensive example demonstrating resource sharing pattern

## Gaps identified

None