### PR TITLE
docs: update for pipecat PR #4370

### DIFF
--- a/api-reference/server/services/transport/daily.mdx
+++ b/api-reference/server/services/transport/daily.mdx
@@ -64,7 +64,7 @@ Before using DailyTransport, you need:
 
 - **Hosted WebRTC**: No infrastructure setup required - Daily handles all WebRTC complexity
 - **Multi-participant Support**: Handle multiple participants with individual audio/video tracks
-- **Multi-track Audio/Video**: Publish multiple custom audio and video tracks simultaneously with per-track configuration
+- **Multi-track Audio/Video**: Publish multiple custom audio and video tracks simultaneously with per-track configuration, including built-in support for Daily's `screenVideo` destination
 - **Built-in Transcription**: Real-time speech-to-text with Deepgram integration
 - **Telephony Integration**: [Dial-in/dial-out support for phone numbers via [SIP](/pipecat/telephony/twilio-daily-sip)/[PSTN](/pipecat/telephony/daily-pstn)
 - **Recording & Streaming**: Built-in call recording and live streaming capabilities
@@ -125,6 +125,17 @@ Inherits all parameters from [TransportParams](/api-reference/server/services/tr
 
 <ParamField path="camera_out_enabled" type="bool" default="True">
   Whether to enable the main camera output track.
+</ParamField>
+
+<ParamField
+  path="camera_out_send_settings"
+  type="Dict[str, Any]"
+  default="None"
+>
+  Camera output track publishing settings. This dict is passed verbatim to the
+  Daily client's camera publishing settings, allowing full control over
+  encoding, codec, bitrate, and framerate. See [Daily
+  VideoPublishingSettings](https://reference-python.daily.co/types.html#videopublishingsettings).
 </ParamField>
 
 <ParamField
@@ -264,6 +275,47 @@ See the [complete example](https://github.com/pipecat-ai/pipecat/blob/main/examp
 - Transport configuration with transcription and VAD
 - Pipeline integration with participant event handling
 - Advanced features like recording and dial-out
+
+## Notes
+
+### Screen Video Destination
+
+DailyTransport includes built-in support for Daily's `screenVideo` destination. When `"screenVideo"` is included in the `video_out_destinations` parameter, a dedicated screen video track is automatically created at join time:
+
+```python
+params = DailyParams(
+    video_out_enabled=True,
+    video_out_is_live=True,
+    video_out_width=1280,
+    video_out_height=720,
+    video_out_destinations=["screenVideo"]
+)
+
+# Route frames to the screen video track
+frame = OutputImageRawFrame(...)
+frame.transport_destination = "screenVideo"
+```
+
+### Camera Publishing Settings
+
+The `camera_out_send_settings` parameter provides full control over the camera track's publishing configuration:
+
+```python
+params = DailyParams(
+    camera_out_send_settings={
+        "maxQuality": "high",
+        "encodings": {
+            "high": {"maxBitrate": 2_000_000, "maxFramerate": 30}
+        },
+    },
+)
+```
+
+<Warning>
+  The `TransportParams.video_out_bitrate` parameter is deprecated for Daily. Use
+  `DailyParams.camera_out_send_settings` instead to configure camera publishing
+  encodings (bitrate, framerate, codec, etc.).
+</Warning>
 
 ## Event Handlers
 

--- a/api-reference/server/services/transport/transport-params.mdx
+++ b/api-reference/server/services/transport/transport-params.mdx
@@ -123,8 +123,15 @@ transport = DailyTransport(
   Video output height in pixels.
 </ParamField>
 
-<ParamField path="video_out_bitrate" type="int" default="800000">
-  Video output bitrate in bits per second.
+<ParamField
+  path="video_out_bitrate"
+  type="int | None"
+  default="None"
+  deprecated
+>
+  **[DEPRECATED]** Video output bitrate in bits per second. Use
+  provider-specific settings instead (e.g.,
+  `DailyParams.camera_out_send_settings` for Daily).
 </ParamField>
 
 <ParamField path="video_out_framerate" type="int" default="30">


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4370](https://github.com/pipecat-ai/pipecat/pull/4370).

## Changes

**api-reference/server/services/transport/transport-params.mdx**
- Marked `video_out_bitrate` parameter as **DEPRECATED**
- Updated type from `int` to `int | None` and default from `800000` to `None`
- Added note to use provider-specific settings instead (e.g., `DailyParams.camera_out_send_settings`)

**api-reference/server/services/transport/daily.mdx**
- Added new `camera_out_send_settings` parameter to DailyParams configuration
- Updated Key Features to mention built-in `screenVideo` destination support
- Added new Notes section documenting:
  - Screen Video Destination usage with example
  - Camera Publishing Settings usage with example
  - Deprecation warning for `video_out_bitrate` with migration guidance

## Gaps identified

None

## Related

- [Pipecat PR #4370](https://github.com/pipecat-ai/pipecat/pull/4370) - Added `camera_out_send_settings` and `screenVideo` destination support