### PR TITLE
docs: update for pipecat PR #4360

### DIFF
--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -118,6 +118,7 @@ Text-to-Speech services receive text input and output audio streams or chunks.
 | [Rime](/api-reference/server/services/tts/rime)                 | `uv add "pipecat-ai[rime]"`         |
 | [Sarvam](/api-reference/server/services/tts/sarvam)             | No dependencies required            |
 | [Smallest AI](/api-reference/server/services/tts/smallest)      | `uv add "pipecat-ai[smallest]"`     |
+| [Soniox](/api-reference/server/services/tts/soniox)             | `uv add "pipecat-ai[soniox]"`       |
 | [Speechmatics](/api-reference/server/services/tts/speechmatics) | `uv add "pipecat-ai[speechmatics]"` |
 | [xAI](/api-reference/server/services/tts/xai)                   | `uv add "pipecat-ai[xai]"`          |
 | [XTTS](/api-reference/server/services/tts/xtts)                 | `uv add "pipecat-ai[xtts]"`         |

--- a/api-reference/server/services/tts/soniox.mdx
+++ b/api-reference/server/services/tts/soniox.mdx
@@ -1,0 +1,174 @@
+---
+title: "Soniox"
+description: "Real-time WebSocket text-to-speech service using Soniox's streaming TTS API"
+---
+
+## Overview
+
+Soniox provides real-time text-to-speech synthesis using a WebSocket-based streaming API. `SonioxTTSService` streams text incrementally to the Soniox TTS endpoint and receives audio back as base64-encoded chunks. Multiple concurrent streams (up to 5) are multiplexed over a single WebSocket connection, making it efficient for interactive voice applications.
+
+<CardGroup cols={2}>
+  <Card
+    title="Soniox TTS API Reference"
+    icon="code"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.soniox.tts.html"
+  >
+    Pipecat's API methods for Soniox TTS integration
+  </Card>
+  <Card
+    title="Example Implementation"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-soniox.py"
+  >
+    Complete example with Soniox STT and TTS
+  </Card>
+  <Card
+    title="Soniox Documentation"
+    icon="book"
+    href="https://soniox.com/docs/tts/api-reference/websocket-api"
+  >
+    Official Soniox TTS WebSocket API documentation
+  </Card>
+  <Card
+    title="Supported Languages"
+    icon="globe"
+    href="https://soniox.com/docs/tts/concepts/languages"
+  >
+    Browse supported languages (60+)
+  </Card>
+</CardGroup>
+
+## Installation
+
+To use Soniox TTS, install the required dependencies:
+
+```bash
+uv add "pipecat-ai[soniox]"
+```
+
+## Prerequisites
+
+### Soniox Account Setup
+
+Before using Soniox TTS, you need:
+
+1. **Soniox Account**: Sign up at [Soniox Console](https://console.soniox.com)
+2. **API Key**: Generate an API key from your console dashboard
+3. **Voice Selection**: Choose from available voices
+
+### Required Environment Variables
+
+- `SONIOX_API_KEY`: Your Soniox API key for authentication
+
+## Configuration
+
+<ParamField path="api_key" type="str" required>
+  Soniox API key for authentication. Create API keys at
+  [Soniox Console](https://console.soniox.com).
+</ParamField>
+
+<ParamField path="url" type="str" default="wss://tts-rt.soniox.com/tts-websocket">
+  WebSocket endpoint URL for Soniox TTS.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="None">
+  Output sample rate in Hz. Must be one of `{8000, 16000, 24000, 44100, 48000}`
+  when using a raw PCM audio format. When `None`, inherits from the pipeline's
+  configured sample rate.
+</ParamField>
+
+<ParamField path="audio_format" type="str" default="pcm_s16le">
+  Output audio format. Defaults to `"pcm_s16le"`, which matches Pipecat's
+  downstream audio pipeline.
+</ParamField>
+
+<ParamField
+  path="text_aggregation_mode"
+  type="TextAggregationMode"
+  default="TextAggregationMode.SENTENCE"
+>
+  Controls how incoming text is aggregated before synthesis. `SENTENCE`
+  (default) buffers text until sentence boundaries, producing more natural
+  speech. `TOKEN` streams tokens directly for lower latency. Import from
+  `pipecat.services.tts_service`.
+</ParamField>
+
+<ParamField path="settings" type="SonioxTTSService.Settings" default="None">
+  Runtime-configurable settings. See [Settings](#settings) below.
+</ParamField>
+
+### Settings
+
+Runtime-configurable settings passed via the `settings` constructor argument using `SonioxTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
+
+| Parameter  | Type              | Default             | Description                                                                                                                  |
+| ---------- | ----------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `model`    | `str`             | `tts-rt-v1-preview` | TTS model identifier. _(Inherited from base settings.)_                                                                      |
+| `voice`    | `str`             | `Adrian`            | Voice identifier. _(Inherited from base settings.)_                                                                          |
+| `language` | `Language \| str` | `Language.EN`       | Language for synthesis. _(Inherited from base settings.)_ See [supported languages](https://soniox.com/docs/tts/concepts/languages). |
+
+## Usage
+
+### Basic Setup
+
+```python
+import os
+from pipecat.services.soniox.tts import SonioxTTSService
+
+tts = SonioxTTSService(
+    api_key=os.getenv("SONIOX_API_KEY"),
+    settings=SonioxTTSService.Settings(
+        voice="Maya",
+    ),
+)
+```
+
+### With Custom Voice and Model
+
+```python
+tts = SonioxTTSService(
+    api_key=os.getenv("SONIOX_API_KEY"),
+    settings=SonioxTTSService.Settings(
+        model="tts-rt-v1-preview",
+        voice="Adrian",
+        language="en",
+    ),
+)
+```
+
+### With Custom Sample Rate
+
+```python
+tts = SonioxTTSService(
+    api_key=os.getenv("SONIOX_API_KEY"),
+    sample_rate=16000,
+    settings=SonioxTTSService.Settings(
+        voice="Maya",
+    ),
+)
+```
+
+## Notes
+
+- **WebSocket streaming**: Soniox uses a persistent WebSocket connection for streaming text-in and audio-out, enabling low-latency real-time synthesis.
+- **Concurrent streams**: The service supports up to 5 concurrent streams multiplexed over a single WebSocket connection via Pipecat's audio-context mechanism.
+- **Sample rates**: When using raw PCM audio formats, the sample rate must be one of `{8000, 16000, 24000, 44100, 48000}`.
+- **Keepalive**: The service automatically sends keepalive messages every 20 seconds to prevent Soniox's idle timeout (20-30s).
+- **Text aggregation**: Sentence aggregation is enabled by default (`text_aggregation_mode=TextAggregationMode.SENTENCE`). Buffering until sentence boundaries produces more natural speech. Set `text_aggregation_mode=TextAggregationMode.TOKEN` to stream tokens directly for lower latency.
+- **Language support**: Soniox supports 60+ languages. See the [language documentation](https://soniox.com/docs/tts/concepts/languages) for the complete list.
+
+## Event Handlers
+
+Soniox TTS supports the standard [service connection events](/api-reference/server/events/service-events):
+
+| Event                 | Description                       |
+| --------------------- | --------------------------------- |
+| `on_connected`        | Connected to Soniox WebSocket     |
+| `on_disconnected`     | Disconnected from Soniox WebSocket|
+| `on_connection_error` | WebSocket connection error occurred|
+
+```python
+@tts.event_handler("on_connected")
+async def on_connected(service):
+    print("Connected to Soniox TTS")
+```

--- a/docs.json
+++ b/docs.json
@@ -423,6 +423,7 @@
                       "api-reference/server/services/tts/rime",
                       "api-reference/server/services/tts/sarvam",
                       "api-reference/server/services/tts/smallest",
+                      "api-reference/server/services/tts/soniox",
                       "api-reference/server/services/tts/speechmatics",
                       "api-reference/server/services/tts/xai",
                       "api-reference/server/services/tts/xtts",


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4360](https://github.com/pipecat-ai/pipecat/pull/4360).

## Changes

- **Created `api-reference/server/services/tts/soniox.mdx`**: Complete documentation for the new `SonioxTTSService`, including:
  - Overview and key features (WebSocket-based real-time TTS with up to 5 concurrent streams)
  - Installation instructions
  - Prerequisites and account setup
  - Configuration parameters (api_key, url, sample_rate, audio_format, text_aggregation_mode, settings)
  - Settings table (model, voice, language)
  - Usage examples (basic setup, custom voice/model, custom sample rate)
  - Notes on WebSocket streaming, concurrent streams, sample rates, keepalive, and language support (60+)
  - Event handlers documentation (on_connected, on_disconnected, on_connection_error)
- **Updated `docs.json`**: Added `soniox` to the Text-to-Speech services navigation (alphabetically between smallest and speechmatics)
- **Updated `supported-services.mdx`**: Added Soniox TTS to the Text-to-Speech table with installation command `uv add "pipecat-ai[soniox]"` (alphabetically between Smallest AI and Speechmatics)

## Gaps identified

None