### PR TITLE
docs: update for pipecat-cli PR #74

### DIFF
--- a/api-reference/cli/init.mdx
+++ b/api-reference/cli/init.mdx
@@ -219,9 +219,9 @@ Output:
     "web": ["daily", "smallwebrtc"],
     "telephony": ["twilio", "twilio_daily_sip_dialin", "twilio_daily_sip_dialout", ...]
   },
-  "stt": ["deepgram_stt", "openai_stt", ...],
+  "stt": ["deepgram_stt", "mistral_stt", "openai_stt", "xai_stt", ...],
   "llm": ["openai_llm", "anthropic_llm", ...],
-  "tts": ["cartesia_tts", "elevenlabs_tts", ...],
+  "tts": ["cartesia_tts", "elevenlabs_tts", "soniox_tts", ...],
   "realtime": ["openai_realtime", "gemini_live_realtime", ...],
   "video": ["heygen_video", "tavus_video", "simli_video"]
 }


### PR DESCRIPTION
Automated documentation update for [pipecat-cli PR #74](https://github.com/pipecat-ai/pipecat-cli/pull/74).

## Changes
- **api-reference/cli/init.mdx**: Updated `--list-options` example JSON to include new services added in pipecat 1.1.0:
  - Added `mistral_stt` and `xai_stt` to STT service list
  - Added `soniox_tts` to TTS service list

## Gaps identified
None. All changes from pipecat-cli PR #74 that affect user-facing CLI documentation have been incorporated.

Note: The XAI TTS class rename (`XAIHttpTTSService` → `XAITTSService`) and React template dependency updates are internal implementation details that don't require CLI reference documentation updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)