### PR TITLE
docs: update for pipecat PR #4386

### DIFF
--- a/api-reference/server/services/tts/soniox.mdx
+++ b/api-reference/server/services/tts/soniox.mdx
@@ -103,7 +103,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 | Parameter  | Type              | Default             | Description                                                                                                                  |
 | ---------- | ----------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `model`    | `str`             | `tts-rt-v1-preview` | TTS model identifier. _(Inherited from base settings.)_                                                                      |
+| `model`    | `str`             | `tts-rt-v1`         | TTS model identifier. _(Inherited from base settings.)_                                                                      |
 | `voice`    | `str`             | `Adrian`            | Voice identifier. _(Inherited from base settings.)_                                                                          |
 | `language` | `Language \| str` | `Language.EN`       | Language for synthesis. _(Inherited from base settings.)_ See [supported languages](https://soniox.com/docs/tts/concepts/languages). |
 
@@ -129,7 +129,7 @@ tts = SonioxTTSService(
 tts = SonioxTTSService(
     api_key=os.getenv("SONIOX_API_KEY"),
     settings=SonioxTTSService.Settings(
-        model="tts-rt-v1-preview",
+        model="tts-rt-v1",
         voice="Adrian",
         language="en",
     ),


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4386](https://github.com/pipecat-ai/pipecat/pull/4386).

## Changes
- **api-reference/server/services/tts/soniox.mdx** — Updated default model from `tts-rt-v1-preview` to `tts-rt-v1` in:
  - Settings table (default value column)
  - "With Custom Voice and Model" code example

## Gaps identified
None