### PR TITLE
docs: add Bandwidth API reference and WebSocket integration guide

### DIFF
--- a/api-reference/server/services/serializers/bandwidth.mdx
+++ b/api-reference/server/services/serializers/bandwidth.mdx
@@ -1,0 +1,207 @@
+---
+title: "BandwidthFrameSerializer"
+description: "Serializer for Bandwidth Programmable Voice WebSocket media streaming protocol"
+---
+
+## Overview
+
+`BandwidthFrameSerializer` enables integration with Bandwidth's bidirectional WebSocket media streaming protocol, established via the BXML `<StartStream>` verb. It converts between Pipecat frames and Bandwidth's wire format with bidirectional audio conversion and optional automatic call termination via the Bandwidth Voice API.
+
+<CardGroup cols={2}>
+  <Card
+    title="Bandwidth Serializer API Reference"
+    icon="code"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.serializers.bandwidth.html"
+  >
+    Pipecat's API methods for Bandwidth WebSocket integration
+  </Card>
+  <Card
+    title="Example Implementation"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/bandwidth-chatbot"
+  >
+    Complete telephony example with Bandwidth
+  </Card>
+  <Card
+    title="Bandwidth StartStream Docs"
+    icon="book"
+    href="https://dev.bandwidth.com/docs/voice/programmable-voice/bxml/startStream/"
+  >
+    Official Bandwidth bidirectional media streaming documentation
+  </Card>
+  <Card
+    title="Bandwidth Dashboard"
+    icon="microphone"
+    href="https://dashboard.bandwidth.com/"
+  >
+    Manage phone numbers, applications, and VCPs
+  </Card>
+</CardGroup>
+
+## Installation
+
+The `BandwidthFrameSerializer` does not require any additional dependencies beyond the core Pipecat library:
+
+```bash
+uv add "pipecat-ai"
+```
+
+## Prerequisites
+
+### Bandwidth Account Setup
+
+Before using BandwidthFrameSerializer, you need:
+
+1. **Bandwidth Account**: A Universal Platform account at [Bandwidth Dashboard](https://dashboard.bandwidth.com/)
+2. **Media Streaming Enabled**: An account-level entitlement; verify with your account rep if unsure
+3. **Phone Number**: A voice-capable Bandwidth number assigned to a Voice Configuration Package (VCP)
+4. **Voice Application**: Pointed at your callback URL that returns `<StartStream>` BXML
+
+### Required Environment Variables
+
+- `BANDWIDTH_CLIENT_ID`: OAuth 2.0 Client ID for Bandwidth API authentication
+- `BANDWIDTH_CLIENT_SECRET`: OAuth 2.0 Client Secret
+
+<Note>
+  Bandwidth deprecated legacy API username/password Basic Auth; use OAuth 2.0
+  client credentials. Tokens are minted via the
+  `client_credentials` grant against
+  `https://api.bandwidth.com/api/v1/oauth2/token` and used as
+  `Authorization: Bearer <token>` on subsequent API requests.
+</Note>
+
+### Required Configuration
+
+- **Stream ID**: Provided by Bandwidth in the WebSocket `start` event metadata
+- **Call ID** and **Account ID**: Required for automatic call termination (also in the `start` event metadata)
+
+### Key Features
+
+- **Bidirectional Audio**: Convert between Pipecat and Bandwidth audio formats
+- **High-Fidelity Outbound**: Optional PCM at 8/16/24 kHz beyond standard PCMU
+- **Auto Hang-up**: Terminate calls via the Bandwidth Voice API
+- **Interruption Handling**: Emits `clear` events to flush buffered outbound audio
+
+## Configuration
+
+<ParamField path="stream_id" type="str" required>
+  The Bandwidth Stream ID, available in the `start` event metadata.
+</ParamField>
+
+<ParamField path="call_id" type="str" default="None">
+  The Bandwidth Call ID. Required when `auto_hang_up` is enabled.
+</ParamField>
+
+<ParamField path="account_id" type="str" default="None">
+  The Bandwidth Account ID. Required when `auto_hang_up` is enabled.
+</ParamField>
+
+<ParamField path="client_id" type="str" default="None">
+  Bandwidth OAuth 2.0 Client ID. Required when `auto_hang_up` is enabled.
+</ParamField>
+
+<ParamField path="client_secret" type="str" default="None">
+  Bandwidth OAuth 2.0 Client Secret. Required when `auto_hang_up` is enabled.
+</ParamField>
+
+<ParamField path="params" type="InputParams" default="None">
+  Configuration parameters for audio and hang-up behavior. See
+  [InputParams](#inputparams) below.
+</ParamField>
+
+### InputParams
+
+| Parameter                   | Type   | Default  | Description                                                                                                              |
+| --------------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `bandwidth_sample_rate`     | `int`  | `8000`   | Sample rate Bandwidth uses on the wire for PCMU (Hz). Always 8000.                                                       |
+| `sample_rate`               | `int`  | `None`   | Optional override for pipeline input sample rate. When `None`, uses the pipeline's configured rate.                      |
+| `outbound_encoding`         | `str`  | `"PCMU"` | Outbound audio encoding: `"PCMU"` (μ-law 8kHz) or `"PCM"` (16-bit signed little-endian linear PCM at higher rates).      |
+| `outbound_pcm_sample_rate`  | `int`  | `24000`  | Sample rate when `outbound_encoding == "PCM"`. One of 8000, 16000, or 24000. Higher values yield better TTS audio quality. |
+| `auto_hang_up`              | `bool` | `True`   | Whether to automatically terminate the call on `EndFrame` or `CancelFrame`.                                              |
+
+## Usage
+
+### Basic Setup
+
+```python
+import os
+from pipecat.serializers.bandwidth import BandwidthFrameSerializer
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
+
+# Read metadata from the first WebSocket message (Bandwidth's "start" event).
+metadata = start_event["metadata"]
+
+serializer = BandwidthFrameSerializer(
+    stream_id=metadata["streamId"],
+    call_id=metadata["callId"],
+    account_id=str(metadata["accountId"]),
+    client_id=os.getenv("BANDWIDTH_CLIENT_ID"),
+    client_secret=os.getenv("BANDWIDTH_CLIENT_SECRET"),
+)
+
+transport = FastAPIWebsocketTransport(
+    websocket=websocket,
+    params=FastAPIWebsocketParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        add_wav_header=False,
+        serializer=serializer,
+    ),
+)
+```
+
+### High-Fidelity Outbound (24 kHz PCM)
+
+Bandwidth supports linear PCM outbound at higher rates than μ-law's 8 kHz, which can noticeably improve TTS quality:
+
+```python
+serializer = BandwidthFrameSerializer(
+    stream_id=metadata["streamId"],
+    call_id=metadata["callId"],
+    account_id=str(metadata["accountId"]),
+    client_id=os.getenv("BANDWIDTH_CLIENT_ID"),
+    client_secret=os.getenv("BANDWIDTH_CLIENT_SECRET"),
+    params=BandwidthFrameSerializer.InputParams(
+        outbound_encoding="PCM",
+        outbound_pcm_sample_rate=24000,
+    ),
+)
+```
+
+### Without Auto Hang-up
+
+```python
+serializer = BandwidthFrameSerializer(
+    stream_id=metadata["streamId"],
+    params=BandwidthFrameSerializer.InputParams(
+        auto_hang_up=False,
+    ),
+)
+```
+
+## BXML Setup
+
+Your voice application's inbound webhook should respond with BXML that opens a bidirectional stream pointing at your WebSocket endpoint:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <StartStream
+    destination="wss://your-server.example.com/ws"
+    mode="bidirectional"
+    tracks="inbound"/>
+  <Pause duration="86400"/>
+</Response>
+```
+
+The `<Pause>` keeps the call alive while the WebSocket runs. `tracks="inbound"` means only the caller's audio is forwarded — the bot's outbound audio is sent back via `playAudio` events on the same WebSocket.
+
+## Notes
+
+- **Auto hang-up requires credentials**: When `auto_hang_up` is enabled (the default), you must provide `call_id`, `account_id`, `client_id`, and `client_secret`. A `ValueError` is raised at initialization if any are missing.
+- **DTMF**: Bandwidth does not deliver DTMF events over the media-stream WebSocket. Touch-tone digits are captured via the BXML `<Gather>` verb and posted to a separate webhook. Handle DTMF in your application's webhook handler.
+- **OAuth tokens are minted per call**: The serializer is per-call and only mints a Bearer token when an `EndFrame` or `CancelFrame` triggers the hang-up REST call. There is no token caching across calls.
+- **Higher-fidelity outbound is opt-in**: The default PCMU 8 kHz matches the parity baseline with Twilio and Telnyx. Switch to `outbound_encoding="PCM"` to take advantage of Bandwidth's higher-rate options.

--- a/api-reference/server/services/serializers/introduction.mdx
+++ b/api-reference/server/services/serializers/introduction.mdx
@@ -21,6 +21,13 @@ Pipecat includes serializers for popular voice and communications platforms:
 
 <CardGroup cols={2}>
   <Card
+    title="Bandwidth Serializer"
+    icon="phone"
+    href="/api-reference/server/services/serializers/bandwidth"
+  >
+    For integrating with Bandwidth Programmable Voice WebSocket media streaming
+  </Card>
+  <Card
     title="Exotel Serializer"
     icon="phone"
     href="/api-reference/server/services/serializers/exotel"

--- a/docs.json
+++ b/docs.json
@@ -337,6 +337,7 @@
                     "group": "Serializers",
                     "pages": [
                       "api-reference/server/services/serializers/introduction",
+                      "api-reference/server/services/serializers/bandwidth",
                       "api-reference/server/services/serializers/exotel",
                       "api-reference/server/services/serializers/genesys",
                       "api-reference/server/services/serializers/plivo",

--- a/docs.json
+++ b/docs.json
@@ -104,6 +104,7 @@
               "pipecat/telephony/daily-phone-numbers",
               "pipecat/telephony/daily-pstn",
               "pipecat/telephony/twilio-daily-sip",
+              "pipecat/telephony/bandwidth-websockets",
               "pipecat/telephony/twilio-websockets",
               "pipecat/telephony/telnyx-websockets",
               "pipecat/telephony/plivo-websockets",

--- a/pipecat/telephony/bandwidth-websockets.mdx
+++ b/pipecat/telephony/bandwidth-websockets.mdx
@@ -1,0 +1,265 @@
+---
+title: "Bandwidth WebSocket Integration"
+sidebarTitle: "Bandwidth WebSocket"
+description: "Complete guide to using Bandwidth Programmable Voice Media Streaming with Pipecat for inbound calls"
+---
+
+## Things you'll need
+
+- A Bandwidth account (see [Account Setup](#account-setup) — Build for indie devs, Enterprise for production scale)
+- A voice-capable Bandwidth phone number
+- Media Streaming enabled on the account (account-level entitlement)
+- A public-facing server or tunneling service like [ngrok](https://ngrok.com/)
+- API keys for speech-to-text, text-to-speech, and LLM services
+
+<CardGroup cols={2}>
+  <Card
+    title="Bandwidth Dial-in Example"
+    icon="phone-arrow-down-left"
+    href="https://github.com/pipecat-ai/pipecat-examples/tree/main/bandwidth-chatbot/inbound"
+  >
+    Complete dial-in implementation using Bandwidth Programmable Voice over WebSocket
+  </Card>
+  <Card
+    title="BandwidthFrameSerializer API"
+    icon="code"
+    href="/api-reference/server/services/serializers/bandwidth"
+  >
+    Serializer reference, parameters, and configuration options
+  </Card>
+</CardGroup>
+
+## Account Setup
+
+Bandwidth offers two paths to an account, and both work with this integration:
+
+### Bandwidth Build — for individual developers
+
+The fastest way to get started. Self-service signup with no credit card and no sales call.
+
+- Sign up at [bandwidth.com/build-sign-up](https://www.bandwidth.com/build-sign-up/)
+- $3,000 in pre-loaded trial credits
+- One US local phone number included with signup
+- Instant flow: sign up → provision a number → place your first call
+- Pay-as-you-go (add a card) once trial credits are used
+
+Bandwidth Build is scoped to the Voice API, which is exactly what this integration needs. If you only want to dial into a Pipecat bot from a US number, Build covers it end-to-end.
+
+### Bandwidth Enterprise — for production scale
+
+For higher-volume production deployments, multiple regions, or when you need products beyond Voice (messaging, emergency services, etc.).
+
+- Contact sales at [bandwidth.com](https://www.bandwidth.com/)
+- Full Bandwidth product portfolio: voice, messaging, emergency services
+- Global phone-number inventory across 65+ countries
+- Dedicated onboarding and support
+- Custom pricing under a master service agreement
+
+The runtime integration is identical in both tiers — same Universal Platform, same Voice API, same Media Streaming protocol. Only the account-management surface differs.
+
+<Note>
+  **Media Streaming** is the feature that powers the bidirectional WebSocket
+  used here. On Build accounts it's available as part of Voice API; on
+  Enterprise accounts it may need to be explicitly enabled by your account
+  rep. If your call connects but the WebSocket never opens, that's the first
+  thing to check.
+</Note>
+
+## Phone Number Setup
+
+You'll need a Bandwidth voice-capable phone number routed to a Voice Configuration Package (VCP) that points at a voice application — your callback URL.
+
+The fastest way to wire this up is the [`band` CLI](https://github.com/Bandwidth/bandwidth-cli):
+
+```bash
+band auth login --client-id $BANDWIDTH_CLIENT_ID --client-secret $BANDWIDTH_CLIENT_SECRET
+
+# Create a voice application that points at your public URL
+band app create --name pipecat-bot --type voice \
+  --callback-url https://your-server.example.com/incoming-call
+
+# Update an existing VCP to use your new app, or create one via the dashboard
+band vcp update <vcp-id> --app-id <app-id-from-previous-step>
+```
+
+You can also do this entirely in the Bandwidth dashboard: create a Voice application, point it at your public callback URL, then assign your phone number to a VCP that references the application.
+
+## Environment Setup
+
+Configure your environment variables for Bandwidth and AI services:
+
+```shell .env
+BANDWIDTH_CLIENT_ID=...
+BANDWIDTH_CLIENT_SECRET=...
+BANDWIDTH_ACCOUNT_ID=...
+
+OPENAI_API_KEY=...
+DEEPGRAM_API_KEY=...
+CARTESIA_API_KEY=...
+
+NGROK_PUBLIC_URL=https://your-subdomain.ngrok-free.dev
+```
+
+<Note>
+  Bandwidth deprecated legacy API username/password Basic Auth (sunset
+  2026-12-02). Use OAuth 2.0 client credentials instead — generate a Client
+  ID and Client Secret pair under **API Credentials** in the Bandwidth
+  dashboard.
+</Note>
+
+## Dial-in
+
+Dial-in lets users call your Bandwidth number and connect to your Pipecat bot via bidirectional WebSocket Media Streaming.
+
+### How It Works
+
+Here's the sequence of events when someone calls your Bandwidth number:
+
+1. **Bandwidth receives an incoming call** to your number.
+2. **Bandwidth POSTs to your voice application's callback URL** with call metadata (caller, callee, callId).
+3. **Your server responds with BXML** containing a `<StartStream>` verb pointing at your WebSocket endpoint.
+4. **Bandwidth opens a bidirectional WebSocket** to your server. The first message is a `start` event with the stream metadata (`streamId`, `callId`, `accountId`, tracks).
+5. **Bandwidth streams the caller's audio** as base64-encoded PCMU `media` events.
+6. **Your bot processes audio** through the Pipecat pipeline.
+7. **Your bot sends audio back** as `playAudio` events on the same WebSocket.
+8. **Bandwidth plays the audio** to the caller in real time, and terminates the WebSocket on hangup.
+
+### Set up your BXML response
+
+Your callback URL responds with BXML that opens a bidirectional stream and parks the call:
+
+```xml BXML for dial-in
+<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <StartStream
+    destination="wss://your-server.example.com/ws"
+    mode="bidirectional"
+    tracks="inbound"/>
+  <Pause duration="86400"/>
+</Response>
+```
+
+`mode="bidirectional"` enables the bot to send audio back over the same WebSocket via `playAudio` events. `tracks="inbound"` means only the caller's audio is forwarded (not the bot's own outbound, which would cause feedback). The `<Pause>` keeps the call alive while the WebSocket runs.
+
+### Configure your Pipecat bot for dial-in
+
+Bandwidth's first WebSocket message is the `start` event, which carries the call metadata you'll need. Read it before instantiating the serializer:
+
+```python bot.py
+import json
+import os
+from fastapi import WebSocket
+from pipecat.serializers.bandwidth import BandwidthFrameSerializer
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
+
+async def run_bot(websocket: WebSocket):
+    # Read Bandwidth's first message — the "start" event.
+    start_event = json.loads(await websocket.receive_text())
+    metadata = start_event["metadata"]
+
+    serializer = BandwidthFrameSerializer(
+        stream_id=metadata["streamId"],
+        call_id=metadata["callId"],
+        account_id=str(metadata["accountId"]),
+        client_id=os.getenv("BANDWIDTH_CLIENT_ID"),
+        client_secret=os.getenv("BANDWIDTH_CLIENT_SECRET"),
+    )
+
+    transport = FastAPIWebsocketTransport(
+        websocket=websocket,
+        params=FastAPIWebsocketParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+            add_wav_header=False,
+            serializer=serializer,
+        ),
+    )
+
+    # Build your pipeline (STT → LLM → TTS) using `transport` and run it.
+```
+
+<Card
+  title="Complete Bot Implementation"
+  icon="code"
+  href="https://github.com/pipecat-ai/pipecat-examples/blob/main/bandwidth-chatbot/inbound/bot.py"
+>
+  See the full bot.py with WebSocket parsing, transport setup, and pipeline configuration
+</Card>
+
+## Key Features
+
+### OAuth 2.0 Authentication
+
+The serializer uses OAuth 2.0 client credentials, not legacy Basic Auth. When `auto_hang_up` is enabled (the default), it mints a short-lived Bearer token from `https://api.bandwidth.com/api/v1/oauth2/token` and uses it to terminate the call when your pipeline ends.
+
+### Audio Format and Sample Rate
+
+Bandwidth Media Streaming uses PCMU at 8 kHz on the wire by default. Set your input rate to match:
+
+```python
+task = PipelineTask(
+    pipeline,
+    params=PipelineParams(
+        audio_in_sample_rate=8000,
+        audio_out_sample_rate=8000,
+    ),
+)
+```
+
+If your TTS provider produces audio at a higher rate (e.g. OpenAI TTS at 24 kHz), set `audio_out_sample_rate` to match the TTS rate — the serializer will resample down to 8 kHz μ-law on the wire.
+
+### Higher-Fidelity Outbound (24 kHz PCM)
+
+Bandwidth supports linear PCM outbound at higher rates than μ-law's 8 kHz. To skip the downsample and send Bandwidth higher-fidelity audio:
+
+```python
+serializer = BandwidthFrameSerializer(
+    stream_id=metadata["streamId"],
+    call_id=metadata["callId"],
+    account_id=str(metadata["accountId"]),
+    client_id=os.getenv("BANDWIDTH_CLIENT_ID"),
+    client_secret=os.getenv("BANDWIDTH_CLIENT_SECRET"),
+    params=BandwidthFrameSerializer.InputParams(
+        outbound_encoding="PCM",
+        outbound_pcm_sample_rate=24000,
+    ),
+)
+```
+
+This is unique to Bandwidth among the WebSocket telephony providers — Twilio and Telnyx are 8 kHz μ-law only.
+
+### Automatic Call Termination
+
+When you pass OAuth credentials to `BandwidthFrameSerializer`, it automatically terminates the call when your pipeline ends:
+
+```python
+serializer = BandwidthFrameSerializer(
+    stream_id=metadata["streamId"],
+    call_id=metadata["callId"],
+    account_id=str(metadata["accountId"]),
+    client_id=os.getenv("BANDWIDTH_CLIENT_ID"),
+    client_secret=os.getenv("BANDWIDTH_CLIENT_SECRET"),
+)
+```
+
+### DTMF
+
+Bandwidth does not deliver DTMF events over the media-stream WebSocket. Touch-tone digits are captured via the BXML `<Gather>` verb and posted to a separate webhook. Handle DTMF in your application's webhook handler, not in the serializer.
+
+## Deployment
+
+For self-hosted production, ensure your servers are:
+
+- Publicly accessible over HTTPS (Bandwidth requires `wss://`)
+- Able to handle concurrent WebSocket connections
+- Configured with valid OAuth credentials in environment variables
+- Implementing proper error handling and structured logging
+
+## Next Steps
+
+- Explore the [complete example](https://github.com/pipecat-ai/pipecat-examples/tree/main/bandwidth-chatbot) for a full implementation
+- Read the [`BandwidthFrameSerializer` API reference](/api-reference/server/services/serializers/bandwidth) for all configuration options
+- Review [Bandwidth's StartStream BXML reference](https://dev.bandwidth.com/docs/voice/programmable-voice/bxml/startStream/) for advanced stream configuration

--- a/pipecat/telephony/bandwidth-websockets.mdx
+++ b/pipecat/telephony/bandwidth-websockets.mdx
@@ -38,7 +38,7 @@ Bandwidth offers two paths to an account, and both work with this integration:
 The fastest way to get started. Self-service signup with no credit card and no sales call.
 
 - Sign up at [bandwidth.com/build-sign-up](https://www.bandwidth.com/build-sign-up/)
-- $3,000 in pre-loaded trial credits
+- 3,000 pre-loaded trial credits
 - One US local phone number included with signup
 - Instant flow: sign up → provision a number → place your first call
 - Pay-as-you-go (add a card) once trial credits are used

--- a/pipecat/telephony/overview.mdx
+++ b/pipecat/telephony/overview.mdx
@@ -21,7 +21,7 @@ You can dial-in to your Pipecat bots, and have them dial-out too, across both PS
 
 - **How it works:** Real-time audio streaming over WebSocket connections
 - **Call control:** Basic, managed by the telephony provider
-- **Supported providers:** Twilio, Telnyx, Plivo, Exotel
+- **Supported providers:** Bandwidth, Twilio, Telnyx, Plivo, Exotel
 - **Limitations:** No advanced call center features like transfers or reconnects
 
 **When to use:**
@@ -94,6 +94,10 @@ Combine Daily's WebRTC transport with SIP-based telephony providers.
 Direct integration with telephony providers using WebSocket connections.
 
 <CardGroup cols={2}>
+  <Card title="Bandwidth WebSocket" icon="phone" href="./bandwidth-websockets">
+    Programmable Voice Media Streaming with Bandwidth's telephony platform
+  </Card>
+
   <Card title="Twilio WebSocket" icon="phone" href="./twilio-websockets">
     Media Streams integration with Twilio's telephony platform
   </Card>


### PR DESCRIPTION
## Summary

Documents the new `BandwidthFrameSerializer` landing in [pipecat-ai/pipecat#4387](https://github.com/pipecat-ai/pipecat/pull/4387) for Bandwidth Programmable Voice WebSocket media streaming. Adds both the API reference page and the step-by-step telephony integration guide for parity with Telnyx, Twilio, etc.

## What's in it

**API reference:**
- `api-reference/server/services/serializers/bandwidth.mdx` — full API reference modeled on the existing `telnyx.mdx`. Documents constructor params, `InputParams`, OAuth 2.0 client-credentials authentication (Bandwidth deprecated legacy Basic Auth), the `<StartStream>` BXML setup, and the higher-fidelity 24kHz PCM outbound option.
- `api-reference/server/services/serializers/introduction.mdx` — adds Bandwidth to the serializers card grid (alphabetical, before Exotel).

**Telephony guide:**
- `pipecat/telephony/bandwidth-websockets.mdx` — step-by-step integration guide modeled on `telnyx-websockets.mdx`. Covers Build (self-service, indie devs) and Enterprise (sales-led) account paths, phone number / VCP / voice-application setup via the `band` CLI or dashboard, the dial-in flow, code samples, and Bandwidth-specific notes (OAuth 2.0, 24kHz PCM outbound option, DTMF via `<Gather>` webhook).
- `pipecat/telephony/overview.mdx` — adds Bandwidth to the WebSocket Providers card grid and supported-providers list.

**Navigation:**
- `docs.json` — registers both new pages.

## Companion PRs

- Serializer: [pipecat-ai/pipecat#4387](https://github.com/pipecat-ai/pipecat/pull/4387)
- Example: [pipecat-ai/pipecat-examples#207](https://github.com/pipecat-ai/pipecat-examples/pull/207) (`bandwidth-chatbot/inbound`)

## Test plan

- [x] All cross-links resolve to existing pages
- [x] Frontmatter, prose, and `<ParamField>` / `<CardGroup>` components match the conventions in sibling pages (Telnyx, Twilio)
- [ ] `mint broken-links` check (will run in CI)