### PR TITLE
docs: update subagents docs for PR #20

### DIFF
--- a/subagents/learn/task-coordination.mdx
+++ b/subagents/learn/task-coordination.mdx
@@ -117,10 +117,10 @@ Let's build a debate system where a moderator dispatches a topic to three worker
 Each worker runs its own LLM pipeline. The LLM response arrives asynchronously through an event handler, so the worker tracks the current task ID until it has something to respond with:
 
 ```python
-from pipecat_subagents.agents import LLMAgent
+from pipecat_subagents.agents import LLMContextAgent
 from pipecat_subagents.bus.messages import BusTaskRequestMessage
 
-class DebateWorker(LLMAgent):
+class DebateWorker(LLMContextAgent):
     def __init__(self, name, *, bus, role):
         super().__init__(name, bus=bus)
         self._role = role
@@ -132,20 +132,16 @@ class DebateWorker(LLMAgent):
             settings=OpenAILLMSettings(system_instruction=f"You argue as a {self._role}."),
         )
 
-    async def build_pipeline(self) -> Pipeline:
-        llm = self.build_llm()
-        context = LLMContext()
-        user_agg, assistant_agg = LLMContextAggregatorPair(context)
+    async def on_ready(self) -> None:
+        await super().on_ready()
 
-        @assistant_agg.event_handler("on_assistant_turn_stopped")
+        @self.assistant_aggregator.event_handler("on_assistant_turn_stopped")
         async def on_assistant_turn_stopped(aggregator, message):
             text = message.content
             if self._current_task_id:
                 task_id = self._current_task_id
                 await self.send_task_response(task_id, {"role": self._role, "text": text})
                 self._current_task_id = ""
-
-        return Pipeline([user_agg, llm, assistant_agg])
 
     async def on_task_request(self, message: BusTaskRequestMessage) -> None:
         await super().on_task_request(message)
@@ -157,6 +153,10 @@ class DebateWorker(LLMAgent):
             )
         )
 ```
+
+<Note>
+  `LLMContextAgent` extends `LLMAgent` with a built-in `LLMContext` and aggregator pair. It automatically builds the pipeline as `[user_aggregator, llm, assistant_aggregator]`, so you don't need to wire the context plumbing yourself. Access the aggregators via `self.user_aggregator` and `self.assistant_aggregator` in `on_ready()` or later hooks.
+</Note>
 
 The worker:
 


### PR DESCRIPTION
Automated documentation update for [pipecat-subagents PR #20](https://github.com/pipecat-ai/pipecat-subagents/pull/20).

## Changes

### Updated guides
- **`subagents/learn/task-coordination.mdx`** - Updated the `DebateWorker` example to use the new `LLMContextAgent` class instead of manually creating `LLMContext` and `LLMContextAggregatorPair`. This demonstrates the simplified pattern for worker agents that need their own conversation context. Added an explanatory note about `LLMContextAgent` benefits.

## Gaps identified

### New API requiring documentation
- **`LLMContextAgent`** - New class in `src/pipecat_subagents/agents/llm/llm_context_agent.py` needs its own API reference page at `api-reference/pipecat-subagents/llm-context-agent.mdx`. This is a subclass of `LLMAgent` that includes built-in `LLMContext` and `LLMContextAggregatorPair`, simplifying the pattern for worker agents.

### File renames (no content changes)
- `agents/llm/agent.py` → `agents/llm/llm_agent.py` (content unchanged, mapping updated)
- `agents/flows/agent.py` → `agents/flows/flows_agent.py` (content unchanged, mapping updated)

The source-to-doc mapping file (`.claude/skills/update-docs/SOURCE_DOC_MAPPING.md`) was already updated in PR #20 to reflect the new filenames.

---

🤖 Generated with automated docs sync workflow