### PR TITLE
docs: update for pipecat PR #4390

### DIFF
--- a/api-reference/server/services/tts/cartesia.mdx
+++ b/api-reference/server/services/tts/cartesia.mdx
@@ -78,7 +78,7 @@ Before using Cartesia TTS services, you need:
   `settings=CartesiaTTSService.Settings(model=...)` instead._
 </ParamField>
 
-<ParamField path="cartesia_version" type="str" default="2025-04-16">
+<ParamField path="cartesia_version" type="str" default="2026-03-01">
   API version string for Cartesia service.
 </ParamField>
 
@@ -97,6 +97,14 @@ Before using Cartesia TTS services, you need:
 
 <ParamField path="container" type="str" default="raw">
   Audio container format.
+</ParamField>
+
+<ParamField path="max_buffer_delay_ms" type="int" default="None">
+  Server-side buffering window (in milliseconds) before generation starts. `0`
+  disables server buffering (custom buffering); values in (0, 5000] enable
+  managed buffering. When `None`, automatically derived from
+  `text_aggregation_mode`: `0` for `SENTENCE` mode (avoids stacking client and
+  server buffering), unset for `TOKEN` mode (uses Cartesia's 3000ms default).
 </ParamField>
 
 <ParamField
@@ -131,7 +139,7 @@ The HTTP service accepts similar parameters to the WebSocket service, with these
   HTTP API base URL (instead of `url` for WebSocket).
 </ParamField>
 
-<ParamField path="cartesia_version" type="str" default="2024-11-13">
+<ParamField path="cartesia_version" type="str" default="2026-03-01">
   API version for HTTP service.
 </ParamField>
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4390](https://github.com/pipecat-ai/pipecat/pull/4390).

## Changes

**api-reference/server/services/tts/cartesia.mdx**:
- Updated `cartesia_version` default from `"2025-04-16"` to `"2026-03-01"` for `CartesiaTTSService`
- Updated `cartesia_version` default from `"2024-11-13"` to `"2026-03-01"` for `CartesiaHttpTTSService`
- Added `max_buffer_delay_ms` constructor parameter documentation with description of server-side buffering behavior

## Gaps identified

None