### PR TITLE
docs: update for pipecat PR #4400

### DIFF
--- a/api-reference/server/services/tts/deepgram.mdx
+++ b/api-reference/server/services/tts/deepgram.mdx
@@ -116,6 +116,12 @@ Before using `DeepgramSageMakerTTSService`, you need:
   Audio encoding format. Must be one of: `"linear16"`, `"mulaw"`, `"alaw"`.
 </ParamField>
 
+<ParamField path="mip_opt_out" type="bool | None" default="None">
+  Opt out of the Deepgram Model Improvement Program. See
+  [https://dpgr.am/deepgram-mip](https://dpgr.am/deepgram-mip) for pricing
+  impacts before setting to `True`.
+</ParamField>
+
 #### DeepgramTTSService Settings
 
 Runtime-configurable settings passed via the `settings` constructor argument using `DeepgramTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
@@ -161,6 +167,12 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 <ParamField path="encoding" type="str" default="linear16">
   Audio encoding format.
+</ParamField>
+
+<ParamField path="mip_opt_out" type="bool | None" default="None">
+  Opt out of the Deepgram Model Improvement Program. See
+  [https://dpgr.am/deepgram-mip](https://dpgr.am/deepgram-mip) for pricing
+  impacts before setting to `True`.
 </ParamField>
 
 #### DeepgramHttpTTSService Settings


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4400](https://github.com/pipecat-ai/pipecat/pull/4400).

## Changes
- **api-reference/server/services/tts/deepgram.mdx**: Added `mip_opt_out` parameter to both `DeepgramTTSService` and `DeepgramHttpTTSService` Configuration sections. This new optional boolean parameter allows opting out of the Deepgram Model Improvement Program and includes a link to pricing implications.

## Gaps identified
None