### PR TITLE
docs: add Pipecat Cloud "Stopping charges" page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -247,7 +247,8 @@
               "pipecat-cloud/fundamentals/secrets",
               "pipecat-cloud/fundamentals/scaling",
               "pipecat-cloud/fundamentals/logging",
-              "pipecat-cloud/fundamentals/error-codes"
+              "pipecat-cloud/fundamentals/error-codes",
+              "pipecat-cloud/fundamentals/stopping-charges"
             ]
           },
           {

--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -60,7 +60,8 @@ pipecat cloud deploy [agent-name] --min-agents 1
 
 <Warning>
   Setting `--min-agents` to 1 or greater will incur charges even when the agent
-  is not in use.
+  is not in use. To stop these charges, see [Stopping
+  charges](./stopping-charges).
 </Warning>
 
 ### Maximum agents

--- a/pipecat-cloud/fundamentals/stopping-charges.mdx
+++ b/pipecat-cloud/fundamentals/stopping-charges.mdx
@@ -8,7 +8,7 @@ description: "Scale reserved agent instances to zero and delete your Pipecat Clo
 Two common sources:
 
 1. **Reserved (warm) agent instances.** When you set `min-agents` to 1 or more on a deployment, Pipecat Cloud keeps that many warm instances running, and you are billed for that time even when no sessions are active. See [Scaling](./scaling) for how reserved instances and billing work.
-2. **Phone numbers attached to your account.** PSTN numbers incur a small monthly charge (around $2 per number) until the account is deleted.
+2. **Phone numbers attached to your account.** PSTN numbers incur a monthly charge until the account is deleted.
 
 If you tested Pipecat Cloud, set reserved instances, and never scaled them back to zero, you'll keep being billed until you do.
 

--- a/pipecat-cloud/fundamentals/stopping-charges.mdx
+++ b/pipecat-cloud/fundamentals/stopping-charges.mdx
@@ -1,0 +1,85 @@
+---
+title: "Stopping charges"
+description: "Scale reserved agent instances to zero and delete your Pipecat Cloud account to stop recurring billing."
+---
+
+## Why am I being charged?
+
+Two common sources:
+
+1. **Reserved (warm) agent instances.** When you set `min-agents` to 1 or more on a deployment, Pipecat Cloud keeps that many warm instances running, and you are billed for that time even when no sessions are active. See [Scaling](./scaling) for how reserved instances and billing work.
+2. **Phone numbers attached to your account.** PSTN numbers incur a small monthly charge (around $2 per number) until the account is deleted.
+
+If you tested Pipecat Cloud, set reserved instances, and never scaled them back to zero, you'll keep being billed until you do.
+
+<Warning>
+  For security and privacy reasons, Daily support cannot modify your deployment
+  configuration. You must scale your agents to zero yourself.
+</Warning>
+
+## Step 1: Scale reserved instances to zero
+
+Do this for **every** deployed agent in your account.
+
+### Option A: REST API (cURL)
+
+If you have a private API key, update each agent directly:
+
+```bash
+curl --request POST \
+  --url https://api.pipecat.daily.co/v1/agents/{agentName} \
+  --header 'Authorization: Bearer YOUR_PRIVATE_API_KEY' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "autoScaling": {
+      "minAgents": 0
+    }
+  }'
+```
+
+Replace `{agentName}` with the agent's name and `YOUR_PRIVATE_API_KEY` with a private API key from the dashboard. See the [agent-update endpoint](/api-reference/pipecat-cloud/rest-reference/endpoint/agent-update) and [agent-list-all](/api-reference/pipecat-cloud/rest-reference/endpoint/agent-list-all) to enumerate every agent in your account.
+
+<Tip>If you've lost your API key, use Option B (dashboard) instead.</Tip>
+
+### Option B: Pipecat Cloud dashboard
+
+<Steps>
+  <Step title="Open the dashboard">
+    Go to [pipecat.daily.co](https://pipecat.daily.co/) and sign in.
+  </Step>
+  <Step title="Open the agent">
+    Click on a deployed agent that has reserved instances.
+  </Step>
+  <Step title="Open Settings">Click "Settings".</Step>
+  <Step title="Set min and max agents to 0">
+    Set both **minimum agents** and **maximum agents** to `0`.
+  </Step>
+  <Step title="Save">Click "Save" at the bottom of the page.</Step>
+</Steps>
+
+Repeat for each agent listed in your account.
+
+## Step 2: Delete your account
+
+Once all agents are scaled to zero, email `delete@daily.co` from the same email address that created the account. The deletion request will:
+
+- Cancel future Stripe billing
+- Release any phone numbers tied to the account
+- Remove your account data
+
+<Note>
+  Account deletion stops future billing. Any usage already incurred during the
+  current billing period will still be invoiced.
+</Note>
+
+<Warning>
+  Deleting the account does not retroactively scale down reserved instances.
+  Step 1 is a required prerequisite. If you skip it, you may continue to accrue
+  reserved-session charges until deletion completes.
+</Warning>
+
+## Related
+
+- [Scaling](./scaling)
+- [Capacity planning](../guides/capacity-planning)
+- [Accounts and organizations](./accounts-and-organizations)


### PR DESCRIPTION
## Summary

- Adds `pipecat-cloud/fundamentals/stopping-charges.mdx` explaining why customers get billed (reserved instances + phone numbers), how to scale `min-agents` to 0 via REST API or dashboard, and the `delete@daily.co` follow-up.
- Registers the page in the Pipecat Cloud → Fundamentals nav group in `docs.json`.
- Cross-links from the existing `--min-agents` warning in `scaling.mdx` so readers landing on the scaling page from search find the fix.

## Why

Every month 1–3 customers write in claiming their account is deleted but they keep getting invoiced. The cause is almost always reserved warm instances they set up while testing and never scaled back. Daily support cannot modify a customer's deployment for them, so the customer has to do it themselves. Today nothing in the docs explains this, and Kapa AI tells them to email `help@daily.co`, which doesn't actually stop the charges. This gives us a single shareable URL to send people to and gives Kapa something correct to ingest.

Source content for the page is the email reply on Plain thread T-1064.

## Test plan

- [ ] `mint dev` renders the new page at `/pipecat-cloud/fundamentals/stopping-charges`
- [ ] Page appears in left nav under Pipecat Cloud → Fundamentals
- [ ] Cross-link from `scaling.mdx` resolves
- [ ] `mint broken-links` reports no new broken links
- [ ] cURL example copy-pastes cleanly (no smart quotes)