### PR TITLE
docs: add Synap to memory community integrations

### DIFF
--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -9,6 +9,14 @@ Want to add your integration? See our [Community Integrations Guide](https://git
 
 ---
 
+## Memory
+
+Memory services provide persistent, cross-session user memory for voice agents.
+
+| Service                          | Repository                                                        | Maintainer(s)                                 |
+| -------------------------------- | ----------------------------------------------------------------- | --------------------------------------------- |
+| [Synap](https://maximem.ai)      | https://github.com/maximem-ai/maximem_synap                       | [maximem-ai](https://github.com/maximem-ai)   |
+
 ## Image Generation
 
 Image generation services receive text inputs and output images.

--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -15,7 +15,7 @@ Memory services provide persistent, cross-session user memory for voice agents.
 
 | Service                          | Repository                                                        | Maintainer(s)                                 |
 | -------------------------------- | ----------------------------------------------------------------- | --------------------------------------------- |
-| [Synap](https://maximem.ai)      | https://github.com/maximem-ai/maximem_synap                       | [maximem-ai](https://github.com/maximem-ai)   |
+| [Synap](https://maximem.ai)      | https://github.com/maximem-ai/maximem_synap_sdk/tree/main/packages/integrations                       | [maximem-ai](https://github.com/maximem-ai)   |
 
 ## Image Generation
 


### PR DESCRIPTION
Adds a Memory section to the community integrations page and lists Synap as the first memory community integration.

[Synap](https://maximem.ai) is a managed memory layer for AI agents. The `maximem-synap-pipecat` package provides two `FrameProcessor` nodes:

- **`SynapMemoryProcessor`** (read) — insert before the user context aggregator. On each `TranscriptionFrame`, fetches user-scoped context from Synap and injects it as a system message into the shared `LLMContext` so the LLM sees long-term memory before replying.
- **`SynapRecorder`** (write) — insert after the assistant context aggregator. Records user transcription and assistant tokens to Synap at `LLMFullResponseEndFrame`.

Read failures degrade gracefully (log + skip). Write failures surface as `ErrorFrame` upstream so observability hooks fire, but are swallowed locally — a Synap outage never tears down a live call.

**Install:** `pip install maximem-synap-pipecat`
**PyPI:** https://pypi.org/project/maximem-synap-pipecat/
**Docs:** https://docs.maximem.ai/integrations/pipecat
**Dashboard:** https://synap.maximem.ai
**Open source:** Integration package source at [`maximem-ai/maximem_synap_sdk`](https://github.com/maximem-ai/maximem_synap_sdk/tree/main/packages/integrations) — contributions welcome