### PR TITLE
docs: update for pipecat PR #4401

### DIFF
--- a/api-reference/server/services/s2s/grok.mdx
+++ b/api-reference/server/services/s2s/grok.mdx
@@ -103,11 +103,11 @@ _Deprecated in v0.0.105. Use `settings=GrokRealtimeLLMService.Settings(session_p
 
 Runtime-configurable settings passed via the `settings` constructor argument using `GrokRealtimeLLMService.Settings(...)`. These can be updated mid-conversation with `LLMUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter            | Type                | Default     | Description                                                     |
-| -------------------- | ------------------- | ----------- | --------------------------------------------------------------- |
-| `model`              | `str`               | `NOT_GIVEN` | Model identifier. _(Inherited from base settings.)_             |
-| `system_instruction` | `str`               | `NOT_GIVEN` | System instruction/prompt. _(Inherited from base settings.)_    |
-| `session_properties` | `SessionProperties` | `NOT_GIVEN` | Session-level configuration (voice, audio config, tools, etc.). |
+| Parameter            | Type                | Default                        | Description                                                     |
+| -------------------- | ------------------- | ------------------------------ | --------------------------------------------------------------- |
+| `model`              | `str`               | `"grok-voice-think-fast-1.0"` | Model identifier. Defaults to xAI's recommended Voice Agent model. _(Inherited from base settings.)_ |
+| `system_instruction` | `str`               | `NOT_GIVEN`                    | System instruction/prompt. _(Inherited from base settings.)_    |
+| `session_properties` | `SessionProperties` | `NOT_GIVEN`                    | Session-level configuration (voice, audio config, tools, etc.). |
 
 <Note>
   `NOT_GIVEN` values are omitted, letting the service use its own defaults. Only


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4401](https://github.com/pipecat-ai/pipecat/pull/4401).

## Changes

- **api-reference/server/services/s2s/grok.mdx**: Updated Settings table to reflect new default model `"grok-voice-think-fast-1.0"` (previously had no default). This is xAI's recommended Voice Agent model.

## Summary

PR #4401 changed the default model for `GrokRealtimeLLMService` from `None` to `"grok-voice-think-fast-1.0"` and fixed a bug where the configured model was being ignored. The documentation now accurately reflects the service's default model value.

## Gaps identified

None