### PR TITLE
docs: update for pipecat PR #4414

### DIFF
--- a/api-reference/server/utilities/turn-management/turn-events.mdx
+++ b/api-reference/server/utilities/turn-management/turn-events.mdx
@@ -193,10 +193,11 @@ async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMes
 | `message`    | `AssistantTurnStoppedMessage` | Contains the assistant's transcript and metadata |
 
 <Note>
-  This event fires when the LLM response completes, when the user interrupts, or
-  when a user image is appended to context. The event always fires when a turn
-  ends, even if `content` is empty (e.g., the turn was interrupted before any
-  tokens were generated).
+  This event fires when the LLM response completes, when the user interrupts,
+  when a user image is appended to context, or when a
+  `TTSSpeakFrame(append_to_context=True)` greeting finishes. The event always
+  fires when a turn ends, even if `content` is empty (e.g., the turn was
+  interrupted before any tokens were generated).
 </Note>
 
 ### on_assistant_thought

--- a/pipecat/learn/text-to-speech.mdx
+++ b/pipecat/learn/text-to-speech.mdx
@@ -330,6 +330,13 @@ await tts.queue_frame(
 
 The `append_to_context` parameter controls whether the spoken text is added to the conversation history. When `append_to_context=True`, the text is automatically committed to the context after being spoken, making it useful for bot greetings and injected speech that should be part of the conversation flow.
 
+<Note>
+  When using `append_to_context=True`, the assistant aggregator's
+  `on_assistant_turn_started` and `on_assistant_turn_stopped` events will fire,
+  allowing you to capture the greeting text in your turn event handlers just like
+  LLM-generated responses. See [Turn Events](/api-reference/server/utilities/turn-management/turn-events) for details.
+</Note>
+
 ### Dynamic Settings Updates
 
 Update TTS settings during conversation using typed settings objects:


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4414](https://github.com/pipecat-ai/pipecat/pull/4414).

## Changes

### api-reference/server/utilities/turn-management/turn-events.mdx
Updated the `on_assistant_turn_stopped` event note to clarify that this event now fires for `TTSSpeakFrame(append_to_context=True)` greetings, not just LLM-generated responses or user interruptions.

### pipecat/learn/text-to-speech.mdx
Added a note in the "Direct Speech Commands" section explaining that when using `append_to_context=True`, the assistant aggregator's turn events (`on_assistant_turn_started` and `on_assistant_turn_stopped`) will fire, allowing users to capture greeting text in their turn event handlers.

## Gaps identified
None. The PR only modified internal implementation details of the turn management system (`LLMAssistantAggregator._handle_push_aggregation()` and TTS service PTS handling). These changes don't introduce new public APIs or configuration options—they fix a bug where greetings weren't properly triggering turn events.