### PR TITLE
docs: add Future AGI to Observability integrations

### DIFF
--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -49,6 +49,7 @@ Observability services enable telemetry and metrics data to be passed to a Open 
 | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | [OpenInference](https://arize-ai.github.io/openinference/) | [openinference-instrumentation-pipecat](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-pipecat) | [Arize-ai](https://github.com/Arize-ai/openinference/graphs/contributors) |
 | [Finchvox](https://finchvox.dev/)                          | https://github.com/finchvox/finchvox                                                                                                                      | [Finchvox](https://github.com/finchvox)                                   |
+| [Future AGI](https://futureagi.com)                        | [traceAI-pipecat](https://github.com/future-agi/traceAI/tree/main/python/frameworks/pipecat)                                                              | [future-agi](https://github.com/future-agi)                               |
 
 ## Speech-to-Text
 

--- a/api-reference/server/utilities/opentelemetry.mdx
+++ b/api-reference/server/utilities/opentelemetry.mdx
@@ -182,6 +182,14 @@ Arize-ai provides OpenInference instrumentation, compatible with OpenTelemetry.
 
 See [Observability community integrations](https://docs.pipecat.ai/server/services/community-integrations#observability) for more details.
 
+### Future AGI
+
+Future AGI provides OpenTelemetry attribute mapping for Pipecat, converting Pipecat span attributes (e.g., `gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.*`) into Future AGI conventions so existing Pipecat OTEL setups can route traces to the Future AGI dashboard.
+
+- [traceAI-pipecat](https://github.com/future-agi/traceAI/tree/main/python/frameworks/pipecat)
+
+See [Observability community integrations](https://docs.pipecat.ai/server/services/community-integrations#observability) for more details.
+
 ## Span Attributes
 
 Pipecat enriches spans with detailed attributes about service operations:


### PR DESCRIPTION
## Summary

Adds [Future AGI](https://futureagi.com) to the Observability category in two places, mirroring how OpenInference and Langfuse are documented:

1. **`api-reference/server/services/community-integrations.mdx`** — a new row in the Observability table, alongside OpenInference and Finchvox.
2. **`api-reference/server/utilities/opentelemetry.mdx`** — a `### Future AGI` subsection right after the existing `### OpenInference` block, with the same shape (one paragraph + a single repository bullet + a pointer back to the community-integrations page).

## What the integration does

Future AGI is an open-source e2e agent engineering and optimization platform that helps you ship self-improving AI agents. The [`traceAI-pipecat`](https://github.com/future-agi/traceAI/tree/main/python/frameworks/pipecat) package converts Pipecat span attributes (`gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.*`, `transcript`, `input/output`) into Future AGI conventions, so an existing Pipecat OTEL setup routes traces to the Future AGI dashboard with one extra call to `enable_http_attribute_mapping()`.

## Smoke test

Verified end-to-end against the Future AGI tracer endpoint with `traceai-pipecat` 0.1.1:

- `register(project_type=OBSERVE, project_name='pipecat-doc-smoke', transport=HTTP)` → OK
- `enable_http_attribute_mapping()` → returned `True`
- A manual span carrying Pipecat-shaped attributes (`gen_ai.system`, `gen_ai.request.model`, `input`, `output`) flushed via `trace_provider.force_flush()` → `HTTP 200 OK` to `https://api.futureagi.com/tracer/v1/traces`
- The `pipecat-doc-smoke` project surfaced in the Future AGI dashboard

## Note on the demo-video requirement

The `COMMUNITY_INTEGRATIONS.md` submission process mentions a 30-60s demo video showing core functionality and interruption handling. This is a community **observability** integration (an OTel attribute mapper), not a service integration on the audio path — there's no audio interaction or interruption to demo. Happy to record a short clip showing traces flowing into the dashboard if maintainers prefer.

## Test plan

- [x] `npx prettier --check` passes on both edited files
- [x] `npx mint broken-links` passes
- [ ] Maintainer review of placement (Observability row + parallel `### Future AGI` subsection in `opentelemetry.mdx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)