### PR TITLE
Fix --base64encode flag drift in image pull secret docs

### DIFF
--- a/pipecat-cloud/fundamentals/secrets.mdx
+++ b/pipecat-cloud/fundamentals/secrets.mdx
@@ -146,7 +146,7 @@ pipecat cloud secrets image-pull-secret <secret-name> <registry-url>
 ```
 
 Running this command will prompt you for account credentials.
-You can optionally encode your credentials in base64 with the `--base64encode` flag.
+Credentials are base64-encoded by default; pass `--encode=false` to skip encoding if your credentials are already encoded.
 
 Like regular secret sets, image pull secrets are region-specific. Specify the region with the `--region` flag:
 

--- a/pipecat-cloud/fundamentals/secrets.mdx
+++ b/pipecat-cloud/fundamentals/secrets.mdx
@@ -146,7 +146,7 @@ pipecat cloud secrets image-pull-secret <secret-name> <registry-url>
 ```
 
 Running this command will prompt you for account credentials.
-Credentials are base64-encoded by default; pass `--encode=false` to skip encoding if your credentials are already encoded.
+Credentials are base64-encoded by default; pass `--encode=false` to store them without base64 encoding.
 
 Like regular secret sets, image pull secrets are region-specific. Specify the region with the `--region` flag:
 

--- a/pipecat-cloud/guides/container-registries/docker-hub.mdx
+++ b/pipecat-cloud/guides/container-registries/docker-hub.mdx
@@ -31,7 +31,7 @@ When prompted, enter:
 - **Username:** Your Docker Hub username
 - **Password:** Your access token (not your account password)
 
-Credentials are base64-encoded by default; pass `--encode=false` to skip encoding if your credentials are already encoded.
+Credentials are base64-encoded by default; pass `--encode=false` to store them without base64 encoding.
 
 Image pull secrets are region-specific. If you're deploying to a non-default region, specify it when creating the secret:
 

--- a/pipecat-cloud/guides/container-registries/docker-hub.mdx
+++ b/pipecat-cloud/guides/container-registries/docker-hub.mdx
@@ -31,7 +31,7 @@ When prompted, enter:
 - **Username:** Your Docker Hub username
 - **Password:** Your access token (not your account password)
 
-You can optionally encode your credentials in base64 with the `--base64encode` flag.
+Credentials are base64-encoded by default; pass `--encode=false` to skip encoding if your credentials are already encoded.
 
 Image pull secrets are region-specific. If you're deploying to a non-default region, specify it when creating the secret:
 

--- a/pipecat-cloud/security/security-and-compliance.mdx
+++ b/pipecat-cloud/security/security-and-compliance.mdx
@@ -100,8 +100,8 @@ If you use private container registries, Pipecat Cloud supports secure image pul
 # Create an image pull secret for private registry
 pipecat cloud secrets image-pull-secret dockerhub https://index.docker.io/v1/
 
-# Alternatively, use base64 encoding for credentials
-pipecat cloud secrets image-pull-secret dockerhub https://index.docker.io/v1/ --base64encode
+# Skip the default base64 encoding (e.g., if credentials are already encoded)
+pipecat cloud secrets image-pull-secret dockerhub https://index.docker.io/v1/ --encode=false
 
 # Use it during deployment
 pipecat cloud deploy my-agent my-private-repo/image:latest --credentials dockerhub
@@ -110,9 +110,10 @@ pipecat cloud deploy my-agent my-private-repo/image:latest --credentials dockerh
 Credentials are securely stored and only used during image pulls.
 
 <Tip>
-  The optional `--base64encode` flag provides an additional layer of obfuscation
-  when entering credentials in environments where terminal history or session
-  logging might be a concern.
+  Credentials passed via `image-pull-secret` are base64-encoded by default,
+  which provides a layer of obfuscation in environments where terminal history
+  or session logging might be a concern. Pass `--encode=false` only when your
+  credentials are already encoded.
 </Tip>
 
 ### How does Pipecat Cloud protect my agent code?

--- a/pipecat-cloud/security/security-and-compliance.mdx
+++ b/pipecat-cloud/security/security-and-compliance.mdx
@@ -100,7 +100,7 @@ If you use private container registries, Pipecat Cloud supports secure image pul
 # Create an image pull secret for private registry
 pipecat cloud secrets image-pull-secret dockerhub https://index.docker.io/v1/
 
-# Skip the default base64 encoding (e.g., if credentials are already encoded)
+# Store credentials without base64 encoding (encoding is on by default)
 pipecat cloud secrets image-pull-secret dockerhub https://index.docker.io/v1/ --encode=false
 
 # Use it during deployment
@@ -112,8 +112,8 @@ Credentials are securely stored and only used during image pulls.
 <Tip>
   Credentials passed via `image-pull-secret` are base64-encoded by default,
   which provides a layer of obfuscation in environments where terminal history
-  or session logging might be a concern. Pass `--encode=false` only when your
-  credentials are already encoded.
+  or session logging might be a concern. Pass `--encode=false` to store
+  credentials without base64 encoding.
 </Tip>
 
 ### How does Pipecat Cloud protect my agent code?


### PR DESCRIPTION
## Summary

The CLI flag for `pipecat cloud secrets image-pull-secret` is `--encode` (default `true`), not `--base64encode`. Three pages referenced the wrong flag name and framed encoding as opt-in when it's actually the default.

Updates the wording on all three to match the CLI reference: encoding happens by default; pass `--encode=false` to opt out.

## Files changed

- `pipecat-cloud/fundamentals/secrets.mdx`
- `pipecat-cloud/guides/container-registries/docker-hub.mdx`
- `pipecat-cloud/security/security-and-compliance.mdx` (two occurrences)

## Test plan

- [x] `grep -rn base64encode docs` returns 0 hits (verified locally)
- [x] Mintlify build of the three pages renders the corrected wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)