### PR TITLE
Add Simplismart.ai to community integrations docs (STT, TTS, LLM)

### DIFF
--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -29,9 +29,10 @@ Semantic retrieval services enable context-aware search and retrieval of relevan
 
 LLMs receive text or audio based input and output a streaming text response.
 
-| Service                          | Repository                                                | Maintainer(s)                           |
-| -------------------------------- | --------------------------------------------------------- | --------------------------------------- |
-| [Anannas AI](https://anannas.ai) | https://github.com/Anannas-AI/anannas-pipecat-integration | [Haleshot](https://github.com/Haleshot) |
+| Service                                       | Repository                                                | Maintainer(s)                                   |
+| --------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------- |
+| [Anannas AI](https://anannas.ai)              | https://github.com/Anannas-AI/anannas-pipecat-integration | [Haleshot](https://github.com/Haleshot)         |
+| [Simplismart](https://simplismart.ai)         | https://github.com/simpli-smart/pipecat-simplismart       | [simpli-smart](https://github.com/simpli-smart) |
 
 ## Observability
 
@@ -46,9 +47,10 @@ Observability services enable telemetry and metrics data to be passed to a Open 
 
 Speech-to-Text services receive and audio input and output transcriptions.
 
-| Service                           | Repository                                           | Maintainer(s)                                   |
-| --------------------------------- | ---------------------------------------------------- | ----------------------------------------------- |
-| [Uplift AI](https://upliftai.org) | https://github.com/havkerboi123/pipecat-upliftai-stt | [havkerboi123](https://github.com/havkerboi123) |
+| Service                                   | Repository                                                                         | Maintainer(s)                                   |
+| ----------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------- |
+| [Simplismart](https://simplismart.ai)     | https://github.com/simpli-smart/pipecat-simplismart                               | [simpli-smart](https://github.com/simpli-smart) |
+| [Uplift AI](https://upliftai.org)         | https://github.com/havkerboi123/pipecat-upliftai-stt                              | [havkerboi123](https://github.com/havkerboi123) |
 
 ## Translation
 
@@ -76,8 +78,9 @@ Text-to-Speech services receive text input and output audio streams or chunks.
 | [Deepdub](https://deepdub.ai/)                                   | https://github.com/deepdub-ai/pipecat-deepdub-tts    | [deepdub-ai](https://github.com/deepdub-ai)     |
 | [Murf AI](https://murf.ai/api)                                   | https://github.com/murf-ai/pipecat-murf-tts          | [murf-ai](https://github.com/murf-ai)           |
 | [Pipecat TTS Cache](https://pypi.org/project/pipecat-tts-cache/) | https://github.com/omChauhanDev/pipecat-tts-cache    | [omChauhanDev](https://github.com/omChauhanDev) |
-| [Respeecher](https://www.respeecher.com/real-time-tts-api)       | https://github.com/respeecher/pipecat-respeecher     | [respeecher](https://github.com/respeecher)     |
-| [Typecast](https://typecast.ai/)                                 | https://github.com/neosapience/pipecat-typecast      | [neosapience](https://github.com/neosapience)   |
+| [Respeecher](https://www.respeecher.com/real-time-tts-api)       | https://github.com/respeecher/pipecat-respeecher                                   | [respeecher](https://github.com/respeecher)     |
+| [Simplismart](https://simplismart.ai)                            | https://github.com/simpli-smart/pipecat-simplismart                               | [simpli-smart](https://github.com/simpli-smart) |
+| [Typecast](https://typecast.ai/)                                 | https://github.com/neosapience/pipecat-typecast                                    | [neosapience](https://github.com/neosapience)   |
 | [Uplift AI](https://upliftai.org)                                | https://github.com/havkerboi123/pipecat-upliftai-tts | [havkerboi123](https://github.com/havkerboi123) |
 | [Voice.ai](https://voice.ai/)                                    | https://github.com/voice-ai/voice-ai-pipecat-tts     | [voice-ai](https://github.com/voice-ai)         |
 


### PR DESCRIPTION
Adds [pipecat-simplismart](https://github.com/simpli-smart/pipecat-simplismart) to the community integrations registry.

**Services included:**
- **STT** - `SimplismartSTTService`: Whisper-based transcription via Simplismart's `/predict` endpoint
- **TTS** - `SimplismartHttpTTSService`: Orpheus-based streaming TTS via `/tts` endpoint  
- **LLM** - `SimplismartLLMService`: OpenAI-compatible inference endpoint wrapper

**Package:** https://github.com/simpli-smart/pipecat-simplismart  
**Maintainer:** [simpli-smart](https://github.com/simpli-smart)