### PR TITLE
docs(community): add Bandwidth telephony serializer

### DIFF
--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -62,10 +62,11 @@ Speech-to-Text services receive and audio input and output transcriptions.
 
 Serializers convert between frames and media streams, enabling real-time communication over a websocket.
 
-| Service                          | Repository                                 | Maintainer(s)                         |
-| -------------------------------- | ------------------------------------------ | ------------------------------------- |
-| [AwaazAI](https://www.awaaz.ai/) | https://github.com/awaazde/pipecat-awaazai | [AwaazAI](https://github.com/awaazde) |
-| [Wavix](https://wavix.com/)      | https://github.com/wavix/pipecat-wavix     | [Wavix](https://github.com/wavix)     |
+| Service                                  | Repository                                       | Maintainer(s)                               |
+| ---------------------------------------- | ------------------------------------------------ | ------------------------------------------- |
+| [AwaazAI](https://www.awaaz.ai/)         | https://github.com/awaazde/pipecat-awaazai       | [AwaazAI](https://github.com/awaazde)       |
+| [Bandwidth](https://www.bandwidth.com/)  | https://github.com/Bandwidth/pipecat-bandwidth   | [Bandwidth](https://github.com/Bandwidth)   |
+| [Wavix](https://wavix.com/)              | https://github.com/wavix/pipecat-wavix           | [Wavix](https://github.com/wavix)           |
 
 ## Text-to-Speech
 


### PR DESCRIPTION
## Summary

Adds Bandwidth as a community-maintained Telephony Serializer integration.

- **Repository:** https://github.com/Bandwidth/pipecat-bandwidth
- **Maintainer:** Bandwidth (@Bandwidth) — official integration from the Bandwidth team
- **Demo video (~100s):** https://drive.google.com/file/d/1AjMwF49i-e3FHu_d5rIP91vtK12IoSFL/view?usp=sharing
- **Bandwidth Developer Documentation**: https://dev.bandwidth.com/docs/voice/integrations/pipecat

The repo includes:

- `BandwidthFrameSerializer` — handles Bandwidth Programmable Voice's bidirectional WebSocket protocol
- Inbound μ-law decoding and outbound μ-law or linear PCM at 8/16/24 kHz (PCM at 24 kHz noticeably improves TTS quality)
- Interruption handling via Bandwidth's `clear` event
- Auto hang-up via the Bandwidth Voice API using OAuth 2.0 client_credentials
- 20 unit tests (passing) + a single-file foundational FastAPI example at `examples/bandwidth-chatbot/`

Tested with Pipecat **v1.1.0** and validated end-to-end on a real Bandwidth Programmable Voice call.

## Test plan

- [x] Demo video shows: bot answering an inbound call, multi-turn conversation, mid-response interruption, clean hang-up
- [x] Audio path: inbound μ-law → STT (Deepgram in the example) → LLM → TTS → outbound μ-law over the same WebSocket
- [x] OAuth-based hang-up against the Voice API (REST)

> Note: the linked repo is being made public alongside this listing. If anything 404s, that's the timing window — happy to keep this in draft until everything is reachable.