### PR TITLE
docs: update for pipecat PR #4422

### DIFF
--- a/api-reference/server/services/s2s/inworld.mdx
+++ b/api-reference/server/services/s2s/inworld.mdx
@@ -91,8 +91,8 @@ Before using Inworld Realtime services, you need:
   `session_properties.audio.output.voice`.
 </ParamField>
 
-<ParamField path="tts_model" type="str" default="inworld-tts-1.5-max">
-  TTS model to use (e.g. "inworld-tts-1.5-max"). Shorthand for
+<ParamField path="tts_model" type="str" default="inworld-tts-2">
+  TTS model to use (e.g. "inworld-tts-2"). Shorthand for
   `session_properties.audio.output.model`.
 </ParamField>
 
@@ -217,7 +217,7 @@ llm = InworldRealtimeLLMService(
     api_key=os.getenv("INWORLD_API_KEY"),
     llm_model="openai/gpt-4.1-nano",
     voice="Sarah",
-    tts_model="inworld-tts-1.5-max",
+    tts_model="inworld-tts-2",
     stt_model="assemblyai/universal-streaming-multilingual",
 )
 ```
@@ -255,7 +255,7 @@ session_properties = SessionProperties(
         ),
         output=AudioOutput(
             format=PCMAudioFormat(rate=24000),
-            model="inworld-tts-1.5-max",
+            model="inworld-tts-2",
             voice="Sarah",
         ),
     ),

--- a/api-reference/server/services/tts/inworld.mdx
+++ b/api-reference/server/services/tts/inworld.mdx
@@ -75,7 +75,7 @@ WebSocket-based service for lowest latency streaming.
   `settings=InworldTTSService.Settings(voice=...)` instead._
 </ParamField>
 
-<ParamField path="model" type="str" default="inworld-tts-1.5-max" deprecated>
+<ParamField path="model" type="str" default="inworld-tts-2" deprecated>
   ID of the model to use for synthesis. _Deprecated in v0.0.105. Use
   `settings=InworldTTSService.Settings(model=...)` instead._
 </ParamField>
@@ -155,7 +155,7 @@ HTTP-based service supporting both streaming and non-streaming modes.
   `settings=InworldHttpTTSService.Settings(voice=...)` instead._
 </ParamField>
 
-<ParamField path="model" type="str" default="inworld-tts-1.5-max" deprecated>
+<ParamField path="model" type="str" default="inworld-tts-2" deprecated>
   ID of the model to use for synthesis. _Deprecated in v0.0.105. Use
   `settings=InworldHttpTTSService.Settings(model=...)` instead._
 </ParamField>
@@ -208,7 +208,7 @@ tts = InworldTTSService(
     api_key=os.getenv("INWORLD_API_KEY"),
     settings=InworldTTSService.Settings(
         voice="Ashley",
-        model="inworld-tts-1.5-max",
+        model="inworld-tts-2",
         temperature=0.8,
         speaking_rate=1.1,
     ),


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4422](https://github.com/pipecat-ai/pipecat/pull/4422).

## Changes

### api-reference/server/services/s2s/inworld.mdx
- Updated `tts_model` parameter default from `inworld-tts-1.5-max` to `inworld-tts-2`
- Updated code examples in "With Model and Voice Configuration" section
- Updated code example in "With Full Session Configuration" section

### api-reference/server/services/tts/inworld.mdx
- Updated `model` parameter default from `inworld-tts-1.5-max` to `inworld-tts-2` for both InworldTTSService and InworldHttpTTSService
- Updated code example in "With Custom Settings" section

## Summary

The default TTS model for Inworld services has been updated to `inworld-tts-2` (Realtime TTS-2). The previous models (`inworld-tts-1.5-max` and `inworld-tts-1.5-mini`) remain valid and can be explicitly specified via the `model`/`tts_model` arguments.

## Gaps identified

None