### PR TITLE
docs: update for pipecat PR #4424

### DIFF
--- a/api-reference/server/services/tts/elevenlabs.mdx
+++ b/api-reference/server/services/tts/elevenlabs.mdx
@@ -245,7 +245,7 @@ async with aiohttp.ClientSession() as session:
 - **Multilingual models required for `language`**: Setting `language` with a non-multilingual model (e.g. `eleven_turbo_v2_5`) has no effect. Use `eleven_multilingual_v2` or similar.
 - **WebSocket vs HTTP**: The WebSocket service supports word-level timestamps and interruption handling, making it significantly better for interactive conversations. The HTTP service is simpler but lacks these features.
 - **Text aggregation**: Sentence aggregation is enabled by default (`text_aggregation_mode=TextAggregationMode.SENTENCE`). Buffering until sentence boundaries produces more natural speech. Set `text_aggregation_mode=TextAggregationMode.TOKEN` to stream tokens directly for lower latency. The `auto_mode` parameter is automatically configured based on the aggregation mode for optimal quality.
-- **Word timestamp accuracy**: Word timestamps accurately reflect the spoken audio, not just the input text. When using pronunciation dictionaries or text normalization (`apply_text_normalization`), the service consumes ElevenLabs' normalized alignment data to ensure downstream consumers (captions, transcripts, context aggregation) match what the listener actually hears.
+- **Word timestamp accuracy**: Word timestamps reflect the original input text by default, preserving non-Latin scripts in transcripts and LLM context. When pronunciation dictionaries are configured via `pronunciation_dictionary_locators`, the service switches to ElevenLabs' normalized alignment to avoid duplicate words caused by dictionary substitutions. Text normalization (`apply_text_normalization`) does not affect which alignment field is used.
 
 ## Event Handlers
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4424](https://github.com/pipecat-ai/pipecat/pull/4424).

## Changes
- `api-reference/server/services/tts/elevenlabs.mdx` — Updated Notes section ("Word timestamp accuracy") to reflect corrected alignment field selection behavior

## Details
PR #4424 fixed a bug where ElevenLabs TTS was using normalized alignment by default, causing non-Latin scripts (e.g., Chinese) to be romanized (e.g., pinyin) in LLM context. The service now:
- Defaults to `alignment` field (preserves original text including non-Latin scripts)
- Only uses `normalized_alignment` when pronunciation dictionaries are configured
- Text normalization setting no longer affects which alignment field is used

## Gaps identified
None