### PR TITLE
docs: update for pipecat PR #4430

### DIFF
--- a/api-reference/server/services/stt/deepgram.mdx
+++ b/api-reference/server/services/stt/deepgram.mdx
@@ -290,6 +290,12 @@ Supports the standard [service connection events](/api-reference/server/events/s
   Whether the bot should be interrupted when Flux detects user speech.
 </ParamField>
 
+<ParamField path="watchdog_min_timeout" type="float" default="0.5">
+  Minimum silence duration in seconds before the watchdog sends silence to
+  prevent dangling turns. The actual threshold is `max(chunk_duration * 2,
+  watchdog_min_timeout)`, adapting automatically to the audio chunk size in use.
+</ParamField>
+
 ### Settings
 
 Runtime-configurable settings passed via the `settings` constructor argument using `DeepgramFluxSTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
@@ -545,6 +551,12 @@ Supports the standard [service connection events](/api-reference/server/events/s
   Whether to interrupt the bot when Flux detects user speech.
 </ParamField>
 
+<ParamField path="watchdog_min_timeout" type="float" default="0.5">
+  Minimum silence duration in seconds before the watchdog sends silence to
+  prevent dangling turns. The actual threshold is `max(chunk_duration * 2,
+  watchdog_min_timeout)`, adapting automatically to the audio chunk size in use.
+</ParamField>
+
 <ParamField
   path="settings"
   type="DeepgramFluxSageMakerSTTService.Settings"
@@ -634,7 +646,7 @@ await task.queue_frame(
 - **EagerEndOfTurn**: Enabling `eager_eot_threshold` provides faster response times by predicting end-of-turn before it is confirmed. EagerEndOfTurn transcripts are pushed as `InterimTranscriptionFrame`s. If the user resumes speaking, a `TurnResumed` event is fired.
 - **Multilingual support**: Use the `flux-general-multi` model with `language_hints` to bias transcription toward specific languages (EN, ES, FR, DE, HI, RU, PT, JA, IT, NL). `TranscriptionFrame.language` reflects the detected language for each turn. Omit hints for auto-detection or pass a subset to bias toward expected languages.
 - **SageMaker deployment**: Requires a Deepgram Flux model deployed to an AWS SageMaker endpoint. Unlike Nova models, Flux provides native turn detection and does not require external VAD.
-- **No KeepAlive needed**: The Flux protocol uses a watchdog mechanism that sends silence when needed to maintain the connection, so manual KeepAlive messages are not required.
+- **No KeepAlive needed**: The Flux protocol uses a dynamic watchdog mechanism that sends silence when needed to maintain the connection (threshold: `max(chunk_duration * 2, watchdog_min_timeout)`), so manual KeepAlive messages are not required.
 
 ### Event Handlers
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4430](https://github.com/pipecat-ai/pipecat/pull/4430).

## Changes

Updated `api-reference/server/services/stt/deepgram.mdx`:
- Added `watchdog_min_timeout` parameter to `DeepgramFluxSTTService` Configuration section (default `0.5` seconds)
- Added `watchdog_min_timeout` parameter to `DeepgramFluxSageMakerSTTService` Configuration section (default `0.5` seconds)
- Updated the watchdog note to reflect the new dynamic threshold behavior: `max(chunk_duration * 2, watchdog_min_timeout)`

This parameter allows users to control the minimum silence duration before the watchdog sends a silence packet to prevent dangling turns. The dynamic threshold adapts automatically to the audio chunk size in use, preventing false silence injections when large audio chunks are sent at lower frequency.

## Gaps identified

None