### PR TITLE
docs: update for pipecat PR #4429

### DIFF
--- a/api-reference/server/services/llm/grok.mdx
+++ b/api-reference/server/services/llm/grok.mdx
@@ -93,7 +93,6 @@ from pipecat.services.xai.llm import GrokLLMService
 
 llm = GrokLLMService(
     api_key=os.getenv("XAI_API_KEY"),
-    model="grok-3",
 )
 ```
 
@@ -105,7 +104,7 @@ from pipecat.services.xai.llm import GrokLLMService
 llm = GrokLLMService(
     api_key=os.getenv("XAI_API_KEY"),
     settings=GrokLLMService.Settings(
-        model="grok-3",
+        model="grok-4.20-non-reasoning",
         temperature=0.7,
         top_p=0.9,
         max_completion_tokens=1024,


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4429](https://github.com/pipecat-ai/pipecat/pull/4429).

## Changes
- **`api-reference/server/services/llm/grok.mdx`** — Updated default model from `grok-3` to `grok-4.20-non-reasoning`
  - Removed deprecated `model` parameter from basic setup example (now uses default)
  - Updated custom settings example to show new default model

## Gaps identified
None

## Context
xAI is retiring `grok-3` on May 15, 2026. The pipecat framework has updated its default model to `grok-4.20-non-reasoning` to ensure continued service.