### PR TITLE
docs: update for pipecat PR #4439

### DIFF
--- a/api-reference/server/services/transport/transport-params.mdx
+++ b/api-reference/server/services/transport/transport-params.mdx
@@ -129,9 +129,12 @@ transport = DailyTransport(
   default="None"
   deprecated
 >
-  **[DEPRECATED]** Video output bitrate in bits per second. Use
-  provider-specific settings instead (e.g.,
-  `DailyParams.camera_out_send_settings` for Daily).
+  Video output bitrate in bits per second.
+
+**Deprecated in 1.1.0:** Use provider-specific settings instead (e.g.,
+`DailyParams.camera_out_send_settings` for Daily). This parameter will be
+removed in 2.0.0.
+
 </ParamField>
 
 <ParamField path="video_out_framerate" type="int" default="30">


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4439](https://github.com/pipecat-ai/pipecat/pull/4439).

## Changes

- **api-reference/server/services/transport/transport-params.mdx** — Updated `video_out_bitrate` deprecation notice to include version information (deprecated in 1.1.0, will be removed in 2.0.0)

## Gaps identified

None