### PR TITLE
docs: update for pipecat PR #4426

### DIFF
--- a/api-reference/server/services/stt/elevenlabs.mdx
+++ b/api-reference/server/services/stt/elevenlabs.mdx
@@ -117,6 +117,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 | `model`            | `str`             | `None`        | Model ID for transcription. _(Inherited from base STT settings.)_        |
 | `language`         | `Language \| str` | `Language.EN` | Target language for transcription. _(Inherited from base STT settings.)_ |
 | `tag_audio_events` | `bool`            | `True`        | Include audio events like (laughter), (coughing) in transcription.       |
+| `keyterms`         | `list[str]`       | `None`        | List of key terms or phrases to bias transcription towards.              |
 
 ### Usage
 
@@ -233,6 +234,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 | ---------------------------- | ----------------- | ------------- | --------------------------------------------------------------------------------------- |
 | `model`                      | `str`             | `None`        | Model ID for transcription. _(Inherited from base STT settings.)_                       |
 | `language`                   | `Language \| str` | `Language.EN` | Language for speech recognition. _(Inherited from base STT settings.)_                  |
+| `keyterms`                   | `list[str]`       | `None`        | List of key terms or phrases to bias transcription towards.                             |
 | `vad_silence_threshold_secs` | `float`           | `None`        | Seconds of silence before VAD commits (0.3-3.0). Only used with VAD commit strategy.    |
 | `vad_threshold`              | `float`           | `None`        | VAD sensitivity (0.1-0.9, lower is more sensitive). Only used with VAD commit strategy. |
 | `min_speech_duration_ms`     | `int`             | `None`        | Minimum speech duration for VAD (50-2000ms). Only used with VAD commit strategy.        |


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4426](https://github.com/pipecat-ai/pipecat/pull/4426).

## Changes
- **api-reference/server/services/stt/elevenlabs.mdx** — Added `keyterms` parameter to both `ElevenLabsSTTService.Settings` and `ElevenLabsRealtimeSTTService.Settings` tables

The `keyterms` parameter allows users to provide a list of key terms or phrases to bias transcription towards, supporting Scribe V2 transcription biasing for both file-based and realtime transcription.

## Gaps identified
None