### PR TITLE
docs: update for pipecat PR #4446

### DIFF
--- a/api-reference/server/services/tts/inworld.mdx
+++ b/api-reference/server/services/tts/inworld.mdx
@@ -93,7 +93,7 @@ WebSocket-based service for lowest latency streaming.
   rate.
 </ParamField>
 
-<ParamField path="encoding" type="str" default="LINEAR16">
+<ParamField path="encoding" type="str" default="PCM">
   Audio encoding format.
 </ParamField>
 
@@ -168,7 +168,7 @@ HTTP-based service supporting both streaming and non-streaming modes.
   Audio sample rate in Hz.
 </ParamField>
 
-<ParamField path="encoding" type="str" default="LINEAR16">
+<ParamField path="encoding" type="str" default="PCM">
   Audio encoding format.
 </ParamField>
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4446](https://github.com/pipecat-ai/pipecat/pull/4446).

## Changes
- **api-reference/server/services/tts/inworld.mdx** — Updated the `encoding` parameter default from `"LINEAR16"` to `"PCM"` for both `InworldTTSService` and `InworldHttpTTSService` to match the source code changes

## Gaps identified
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)