### PR TITLE
docs: update for pipecat PR #4447

### DIFF
--- a/api-reference/server/services/s2s/grok.mdx
+++ b/api-reference/server/services/s2s/grok.mdx
@@ -23,6 +23,13 @@ description: "Real-time speech-to-speech service implementation using xAI's Grok
     Complete Grok Realtime conversation example
   </Card>
   <Card
+    title="Async Tool Example"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/realtime/realtime-grok-async-tool.py"
+  >
+    Grok with async function calling (cancel_on_interruption=False)
+  </Card>
+  <Card
     title="Grok Voice Documentation"
     icon="book"
     href="https://docs.x.ai/docs/guides/voice/agent"
@@ -255,6 +262,7 @@ await task.queue_frame(
 - **Available voices**: Ara (default), Rex, Sal, Eve, and Leo.
 - **G.711 support**: PCMU and PCMA formats are supported at a fixed 8000 Hz rate, useful for telephony integrations.
 - **System instruction precedence**: The `system_instruction` from service settings takes precedence over an initial system message in the LLM context. A warning is logged when both are set.
+- **Async tool support**: Functions registered with `cancel_on_interruption=False` are supported. The final tool result is delivered via the formal tool-result channel once the async function completes. Streamed intermediate results (`is_final=False`) are not supported.
 
 ## Event Handlers
 

--- a/api-reference/server/services/s2s/ultravox.mdx
+++ b/api-reference/server/services/s2s/ultravox.mdx
@@ -23,6 +23,13 @@ description: "Real-time speech-to-speech service implementation using Ultravox's
     Complete Ultravox Realtime conversation example
   </Card>
   <Card
+    title="Async Tool Example"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/realtime/realtime-ultravox-async-tool.py"
+  >
+    Ultravox with async function calling (cancel_on_interruption=False)
+  </Card>
+  <Card
     title="Ultravox Documentation"
     icon="book"
     href="https://docs.ultravox.ai/overview"
@@ -247,3 +254,4 @@ await task.queue_frame(
 - **Output medium**: The service supports both `"voice"` and `"text"` output modes, switchable at runtime using `LLMUpdateSettingsFrame`.
 - **Call duration limits**: When using `AgentInputParams` or `OneShotInputParams`, you can set a maximum call duration between 10 seconds and 1 hour.
 - **Tools with agents**: When using `AgentInputParams`, tools are configured on the agent itself. Use `one_shot_selected_tools` only with `OneShotInputParams`.
+- **Async tool support**: Functions registered with `cancel_on_interruption=False` are supported. When an async function is invoked, Ultravox ships a placeholder `client_tool_result` immediately to unfreeze the conversation (since Ultravox's API freezes between tool invocation and result). The actual result is injected as user-side text once the tool completes. Streamed intermediate results (`is_final=False`) are not supported.


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4447](https://github.com/pipecat-ai/pipecat/pull/4447).

## Changes

### Grok Realtime (`api-reference/server/services/s2s/grok.mdx`)
- Added note about async tool support (functions registered with `cancel_on_interruption=False`)
- Documented that final tool results are delivered via the formal tool-result channel
- Added note that streamed intermediate results (`is_final=False`) are not supported
- Added link to new async tool example: `realtime-grok-async-tool.py`

### Ultravox Realtime (`api-reference/server/services/s2s/ultravox.mdx`)
- Added note about async tool support (functions registered with `cancel_on_interruption=False`)
- Documented Ultravox's special placeholder behavior: ships placeholder `client_tool_result` immediately to unfreeze the conversation, then injects actual result as user-side text
- Added note that streamed intermediate results (`is_final=False`) are not supported
- Added link to new async tool example: `realtime-ultravox-async-tool.py`

## Gaps identified

### Missing doc page: Azure Realtime S2S
The PR also extends async tool support to `AzureRealtimeLLMService` (at `src/pipecat/services/azure/realtime/llm.py`), but there is no corresponding documentation page at `api-reference/server/services/s2s/azure.mdx`. 

Azure Realtime inherits from OpenAI Realtime and uses the same async tool handling approach as Grok. A new doc page should be created for this service.

Related source file: `src/pipecat/services/azure/realtime/llm.py`
Example file: `examples/realtime/realtime-azure-async-tool.py`