### PR TITLE
docs: update subagents docs for PR #21

### DIFF
--- a/subagents/fundamentals/agent-bus.mdx
+++ b/subagents/fundamentals/agent-bus.mdx
@@ -11,7 +11,7 @@ Think of it as an internal event bus -- agents publish messages and other agents
 
 ## Bus implementations
 
-Pipecat Subagents provides two bus implementations:
+Pipecat Subagents provides three bus implementations:
 
 ### AsyncQueueBus (local)
 
@@ -40,6 +40,31 @@ All processes that share the same Redis channel can exchange messages. The progr
 
 <Info>
   `RedisBus` requires the `redis` extra: `uv add "pipecat-ai-subagents[redis]"`
+</Info>
+
+### PgmqBus (distributed)
+
+An alternative distributed bus backed by PGMQ (PostgreSQL Message Queue). Each instance creates its own queue and broadcasts to peer queues.
+
+```python
+from pgmq.async_queue import PGMQueue
+from pipecat_subagents.bus.network.pgmq import PgmqBus
+
+pgmq = PGMQueue(
+    host="localhost",
+    port="5432",
+    database="postgres",
+    username="postgres",
+    password="...",
+    pool_size=4,
+)
+await pgmq.init()
+bus = PgmqBus(pgmq=pgmq, channel="pipecat:my-app")
+runner = AgentRunner(bus=bus)
+```
+
+<Info>
+  `PgmqBus` requires the `pgmq` extra: `uv add "pipecat-ai-subagents[pgmq]"`
 </Info>
 
 ## Message types

--- a/subagents/learn/distributed-agents.mdx
+++ b/subagents/learn/distributed-agents.mdx
@@ -13,7 +13,11 @@ Distributed agents are agents connected to the **same bus** but running in diffe
   Agents](/subagents/learn/proxy-agents) instead.
 </Note>
 
-## Setting up RedisBus
+## Setting up a distributed bus
+
+Pipecat Subagents provides two distributed bus implementations: RedisBus and PgmqBus. Choose based on your infrastructure.
+
+### RedisBus
 
 Each process creates its own `AgentRunner` with a `RedisBus` connected to the same Redis channel:
 
@@ -30,6 +34,30 @@ runner = AgentRunner(bus=bus, handle_sigint=True)
 All runners sharing the same `channel` can exchange messages. Agents discover each other automatically through registry snapshots.
 
 <Info>Install the Redis extra: `uv add "pipecat-ai-subagents[redis]"`</Info>
+
+### PgmqBus
+
+Alternatively, use `PgmqBus` backed by PostgreSQL Message Queue:
+
+```python
+from pgmq.async_queue import PGMQueue
+from pipecat_subagents.bus.network.pgmq import PgmqBus
+from pipecat_subagents.runner import AgentRunner
+
+pgmq = PGMQueue(
+    host="localhost",
+    port="5432",
+    database="postgres",
+    username="postgres",
+    password="...",
+    pool_size=4,
+)
+await pgmq.init()
+bus = PgmqBus(pgmq=pgmq, channel="pipecat:my-app")
+runner = AgentRunner(bus=bus, handle_sigint=True)
+```
+
+<Info>Install the PGMQ extra: `uv add "pipecat-ai-subagents[pgmq]"`</Info>
 
 ## Example: distributed handoff
 
@@ -157,6 +185,6 @@ Runners exchange registry information automatically over the shared bus. To get 
 
 ## Considerations
 
-- **Latency**: Redis adds network overhead. For latency-sensitive voice applications, keep the main transport agent and its active LLM agent geographically close to each other and the Redis instance.
-- **Serialization**: `RedisBus` serializes messages to JSON. Custom frame types need to be registered with the serializer.
+- **Latency**: Network buses add overhead. For latency-sensitive voice applications, keep the main transport agent and its active LLM agent geographically close to each other and the bus server (Redis or PostgreSQL).
+- **Serialization**: Both `RedisBus` and `PgmqBus` serialize messages to JSON. Custom frame types need to be registered with the serializer.
 - **Single channel**: All agents on the same channel see all messages. Use different channels for different sessions or applications.


### PR DESCRIPTION
Automated documentation update for [pipecat-subagents PR #21](https://github.com/pipecat-ai/pipecat-subagents/pull/21).

## Changes

- **api-reference/pipecat-subagents/bus.mdx** — Added PgmqBus section with configuration parameters (pgmq, serializer, channel, visibility_timeout, batch_size, poll_interval_ms, max_poll_seconds)
- **subagents/fundamentals/agent-bus.mdx** — Updated bus implementations section to include PgmqBus alongside RedisBus and AsyncQueueBus
- **subagents/learn/distributed-agents.mdx** — Added PgmqBus setup instructions as an alternative to RedisBus, updated considerations to cover both distributed bus options

## Gaps identified

None