### PR TITLE
docs(pipecat-cloud): document /start body delivery for websocket tran…

### DIFF
--- a/api-reference/pipecat-cloud/rest-reference/openapi-start.json
+++ b/api-reference/pipecat-cloud/rest-reference/openapi-start.json
@@ -109,7 +109,7 @@
           },
           "body": {
             "type": "object",
-            "description": "Arbitrary user data / configuration object to pass to the service instance. Accessible as the first parameter of the `bot` method or custom entry point.\n\nSee the [`Starting Sessions` docs](../../fundamentals/active-sessions#passing-data) for more information.",
+            "description": "Arbitrary user data / configuration object to pass to the service instance. Accessible as the first parameter of the `bot` method or custom entry point. Maximum size 1 MB. For `transport: \"websocket\"`, the service must be deployed with `websocket_auth = \"token\"`. See the [`Starting Sessions` docs](/pipecat-cloud/fundamentals/active-sessions#passing-data) for details.",
             "example": { "foo": "bar" }
           }
         }

--- a/api-reference/pipecat-cloud/rest-reference/openapi-start.json
+++ b/api-reference/pipecat-cloud/rest-reference/openapi-start.json
@@ -109,7 +109,7 @@
           },
           "body": {
             "type": "object",
-            "description": "Arbitrary user data / configuration object to pass to the service instance. Accessible as the first parameter of the `bot` method or custom entry point. Maximum size 1 MB. For `transport: \"websocket\"`, the service must be deployed with `websocket_auth = \"token\"`. See the [`Starting Sessions` docs](/pipecat-cloud/fundamentals/active-sessions#passing-data) for details.",
+            "description": "Arbitrary user data / configuration object to pass to the service instance. Accessible as the first parameter of the `bot` method or custom entry point. Maximum size: 1 MB for `transport: \"daily\"` or `\"webrtc\"`, 4 KB for `\"websocket\"`. For `transport: \"websocket\"`, the body is returned in the response's `body` field base64-encoded; the service must be deployed with `websocket_auth = \"token\"` to use this encoding convenience. See the [`Starting Sessions` docs](/pipecat-cloud/fundamentals/active-sessions#passing-data) for details.",
             "example": { "foo": "bar" }
           }
         }
@@ -126,6 +126,11 @@
             "type": "string",
             "description": "WebSocket URL to connect to (only when transport is \"websocket\")",
             "example": "wss://us-west.api.pipecat.daily.co/ws/generic/my-agent.my-org"
+          },
+          "body": {
+            "type": "string",
+            "description": "Base64-encoded JSON body for the bot (only when transport is \"websocket\" and the request included a `body`). Append to `wsUrl` as a `?body=` query parameter when connecting.",
+            "example": "eyJjYWxsZXJfaWQiOiJhYmMxMjMifQ=="
           },
           "dailyRoom": {
             "type": "string",

--- a/pipecat-cloud/fundamentals/active-sessions.mdx
+++ b/pipecat-cloud/fundamentals/active-sessions.mdx
@@ -218,6 +218,16 @@ For more advanced data requirements, your application should run its own data fe
 
 If you require your agent to fetch it's own data, be mindful of any blocking requests that could slow down the start process.
 
+### Size limits
+
+The maximum body size is **1 MB of JSON** across all transports. Requests exceeding this limit are rejected with `413 Payload Too Large` before any bot is started.
+
+<Note>
+  For `transport: "websocket"`, passing a `body` requires the service to be deployed with `websocket_auth = "token"` (see [WebSocket Authentication](/pipecat-cloud/guides/websocket-authentication)). The body is delivered to the bot through the authenticated session, not encoded into the WebSocket URL — so the returned `wsUrl` stays compact and there are no URL-construction concerns on your client side.
+
+  A `/start` call with a `body` and `websocket_auth = "none"` is rejected with `400 Bad Request`.
+</Note>
+
 ## Agent capacity
 
 Deployments have an upper limit for the number of sessions that can be started concurrently.

--- a/pipecat-cloud/fundamentals/active-sessions.mdx
+++ b/pipecat-cloud/fundamentals/active-sessions.mdx
@@ -220,12 +220,17 @@ If you require your agent to fetch it's own data, be mindful of any blocking req
 
 ### Size limits
 
-The maximum body size is **1 MB of JSON** across all transports. Requests exceeding this limit are rejected with `413 Payload Too Large` before any bot is started.
+The maximum body size depends on the transport:
+
+- `transport: "daily"` or `"webrtc"` — **1 MB of JSON**
+- `transport: "websocket"` — **4 KB of JSON**
+
+Requests exceeding the per-transport limit are rejected with `413 Payload Too Large` before any bot is started.
 
 <Note>
-  For `transport: "websocket"`, passing a `body` requires the service to be deployed with `websocket_auth = "token"` (see [WebSocket Authentication](/pipecat-cloud/guides/websocket-authentication)). The body is delivered to the bot through the authenticated session, not encoded into the WebSocket URL — so the returned `wsUrl` stays compact and there are no URL-construction concerns on your client side.
+  For `transport: "websocket"`, the smaller 4 KB cap reflects the URL length constraint on the WebSocket upgrade — the body travels as a base64-encoded `?body=` query parameter that your client appends to the returned `wsUrl`. See [Passing parameters to the bot](/pipecat-cloud/guides/generic-websocket#passing-parameters-to-the-bot) for the client-side construction.
 
-  A `/start` call with a `body` and `websocket_auth = "none"` is rejected with `400 Bad Request`.
+  Sending a `body` also requires the service to be deployed with `websocket_auth = "token"` (see [WebSocket Authentication](/pipecat-cloud/guides/websocket-authentication)). A `/start` call with a `body` and `websocket_auth = "none"` is rejected with `400 Bad Request`.
 </Note>
 
 ## Agent capacity

--- a/pipecat-cloud/guides/generic-websocket.mdx
+++ b/pipecat-cloud/guides/generic-websocket.mdx
@@ -47,3 +47,22 @@ wscat -c "wss://us-west.api.pipecat.daily.co/ws/generic/my-agent.my-org"
 The generic endpoint supports both text and binary WebSocket frames. Your bot receives messages exactly as sent by the client — no protocol-specific parsing or transformation is applied.
 
 Your bot code is responsible for handling the client's message format. Use the appropriate [serializer](/api-reference/server/services/serializers/introduction) for your client's protocol, or implement custom message handling for non-standard clients.
+
+## Passing parameters to the bot
+
+When your service is deployed with `websocket_auth = "token"`, you can pass arbitrary JSON data to your bot at session start by including a `body` in the `/start` request:
+
+```bash
+curl -X POST "https://api.pipecat.daily.co/v1/public/my-agent/start" \
+  -H "Authorization: Bearer pk_your_public_key" \
+  -H "Content-Type: application/json" \
+  -d '{"transport": "websocket", "body": {"caller_id": "abc123"}}'
+```
+
+The body is delivered to your bot as `args.body` — the same way it works for `daily` and `webrtc` transports. See [Passing data](/pipecat-cloud/fundamentals/active-sessions#passing-data) for examples in your bot code.
+
+<Note>
+  Body delivery for `transport: "websocket"` requires `websocket_auth = "token"`. The body is held server-side and handed to the bot once the WebSocket upgrade authenticates the session token — the returned `wsUrl` itself is unchanged regardless of body size. Maximum body size is **1 MB of JSON**, matching the other transports.
+
+  A `/start` call with a `body` against a service that has `websocket_auth = "none"` is rejected with `400 Bad Request`.
+</Note>

--- a/pipecat-cloud/guides/generic-websocket.mdx
+++ b/pipecat-cloud/guides/generic-websocket.mdx
@@ -50,19 +50,54 @@ Your bot code is responsible for handling the client's message format. Use the a
 
 ## Passing parameters to the bot
 
-When your service is deployed with `websocket_auth = "token"`, you can pass arbitrary JSON data to your bot at session start by including a `body` in the `/start` request:
+You can pass arbitrary JSON to your bot at session start via a `?body=` query parameter on the WebSocket URL. The value must be base64-encoded JSON. Your bot receives the decoded original through `args.body` — the same way it works for `daily` and `webrtc` transports. See [Passing data](/pipecat-cloud/fundamentals/active-sessions#passing-data) for examples in your bot code.
 
-```bash
-curl -X POST "https://api.pipecat.daily.co/v1/public/my-agent/start" \
-  -H "Authorization: Bearer pk_your_public_key" \
-  -H "Content-Type: application/json" \
-  -d '{"transport": "websocket", "body": {"caller_id": "abc123"}}'
+How you assemble the URL depends on your service's `websocket_auth` setting.
+
+### With `websocket_auth = "token"`
+
+The `/start` call returns your body pre-encoded as a convenience, alongside the token and `wsUrl`. Append the encoded body to the URL when you connect:
+
+```python
+import requests
+import websockets
+
+resp = requests.post(
+    "https://api.pipecat.daily.co/v1/public/my-agent/start",
+    headers={"Authorization": "Bearer pk_your_public_key"},
+    json={"transport": "websocket", "body": {"caller_id": "abc123"}},
+).json()
+
+ws_url = resp["wsUrl"]
+if resp.get("body"):
+    ws_url = f"{ws_url}?body={resp['body']}"
+
+async with websockets.connect(
+    ws_url,
+    additional_headers={"Authorization": f"Bearer {resp['token']}"},
+) as ws:
+    ...
 ```
 
-The body is delivered to your bot as `args.body` — the same way it works for `daily` and `webrtc` transports. See [Passing data](/pipecat-cloud/fundamentals/active-sessions#passing-data) for examples in your bot code.
+### With `websocket_auth = "none"`
+
+There's no `/start` call in this mode — base64-encode the JSON yourself and connect directly to the WebSocket endpoint:
+
+```python
+import base64
+import json
+import websockets
+
+body = {"caller_id": "abc123"}
+encoded = base64.b64encode(json.dumps(body).encode()).decode()
+url = f"wss://us-west.api.pipecat.daily.co/ws/generic/my-agent.my-org?body={encoded}"
+
+async with websockets.connect(url) as ws:
+    ...
+```
 
 <Note>
-  Body delivery for `transport: "websocket"` requires `websocket_auth = "token"`. The body is held server-side and handed to the bot once the WebSocket upgrade authenticates the session token — the returned `wsUrl` itself is unchanged regardless of body size. Maximum body size is **1 MB of JSON**, matching the other transports.
+  Maximum body size is **4 KB of JSON** — smaller than the 1 MB cap for `daily` and `webrtc` transports because the body travels as a URL query parameter on the WebSocket upgrade, which is bounded by the receiving server's URL-length limit. The same cap applies whether the body is encoded by `/start` or by your own client code.
 
-  A `/start` call with a `body` against a service that has `websocket_auth = "none"` is rejected with `400 Bad Request`.
+  Including a `body` on a `/start` call against a service that has `websocket_auth = "none"` is rejected with `400 Bad Request` — the `/start` body-encoding convenience is only available for token-authed services. Encode the body yourself instead.
 </Note>


### PR DESCRIPTION
…sport (PCC-830)

Documents the changes in https://github.com/daily-co/pipecat-cloud-sandbox/pull/476

- active-sessions.mdx: add 1 MB body size limit and call out the websocket_auth = "token" requirement for transport: "websocket".
- generic-websocket.mdx: add a "Passing parameters to the bot" section explaining that /start body is delivered server-side once the WS session token is validated; clarify there's no URL impact.
- openapi-start.json: fix the broken relative link to /pipecat-cloud/fundamentals/active-sessions#passing-data, and add a one-line size + wsAuth=token note in the body parameter description.