### PR TITLE
docs: update for pipecat PR #4470

### DIFF
--- a/api-reference/server/services/s2s/openai.mdx
+++ b/api-reference/server/services/s2s/openai.mdx
@@ -157,6 +157,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 | `tool_choice`       | `Literal["auto", "none", "required"]` | `None`  | Tool usage strategy.                                                                                                 |
 | `max_output_tokens` | `int \| Literal["inf"]`               | `None`  | Maximum tokens in response, or `"inf"` for unlimited.                                                                |
 | `tracing`           | `Literal["auto"] \| Dict`             | `None`  | Configuration options for tracing.                                                                                   |
+| `reasoning`         | `Reasoning`                           | `None`  | Reasoning configuration. Only supported by reasoning-capable models such as `gpt-realtime-2`.                        |
 
 ### AudioConfiguration
 
@@ -199,6 +200,20 @@ Alternatively, use `SemanticTurnDetection` for semantic-based detection:
 | `create_response`    | `bool`                                     | `None`           | Whether to automatically create responses on turn detection. |
 | `interrupt_response` | `bool`                                     | `None`           | Whether to interrupt ongoing responses on turn detection.    |
 
+### Reasoning
+
+Reasoning configuration for reasoning-capable Realtime models (e.g. `gpt-realtime-2`):
+
+| Parameter | Type                                                   | Default | Description                                                                                              |
+| --------- | ------------------------------------------------------ | ------- | -------------------------------------------------------------------------------------------------------- |
+| `effort`  | `Literal["minimal", "low", "medium", "high", "xhigh"]` | `None`  | How much reasoning effort the model should apply. Omit to let the server pick the default for the model. |
+
+<Note>
+  Reasoning configuration is automatically filtered out when used with
+  non-reasoning models (e.g. `gpt-realtime-1.5`) to prevent session errors. A
+  warning is logged when this filtering occurs.
+</Note>
+
 ## Usage
 
 ### Basic Setup
@@ -224,6 +239,7 @@ from pipecat.services.openai.realtime.events import (
     AudioOutput,
     InputAudioTranscription,
     SemanticTurnDetection,
+    Reasoning,
 )
 
 session_properties = SessionProperties(
@@ -271,19 +287,51 @@ llm = OpenAIRealtimeLLMService(
 )
 ```
 
+### With Reasoning Configuration (gpt-realtime-2)
+
+```python
+from pipecat.services.openai.realtime import OpenAIRealtimeLLMService
+from pipecat.services.openai.realtime.events import SessionProperties, Reasoning
+
+session_properties = SessionProperties(
+    reasoning=Reasoning(effort="high"),
+)
+
+llm = OpenAIRealtimeLLMService(
+    api_key=os.getenv("OPENAI_API_KEY"),
+    settings=OpenAIRealtimeLLMService.Settings(
+        model="gpt-realtime-2",
+        session_properties=session_properties,
+        system_instruction="You are a helpful assistant.",
+    ),
+)
+```
+
 ### Updating Settings at Runtime
 
 ```python
 from pipecat.frames.frames import LLMUpdateSettingsFrame
 from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
-from pipecat.services.openai.realtime.events import SessionProperties
+from pipecat.services.openai.realtime.events import SessionProperties, Reasoning
 
+# Update system instruction and max tokens
 await task.queue_frame(
     LLMUpdateSettingsFrame(
         delta=OpenAIRealtimeLLMService.Settings(
             system_instruction="Now speak in Spanish.",
             session_properties=SessionProperties(
                 max_output_tokens=2048,
+            ),
+        )
+    )
+)
+
+# Update reasoning effort (gpt-realtime-2 only)
+await task.queue_frame(
+    LLMUpdateSettingsFrame(
+        delta=OpenAIRealtimeLLMService.Settings(
+            session_properties=SessionProperties(
+                reasoning=Reasoning(effort="xhigh"),
             ),
         )
     )
@@ -306,6 +354,7 @@ await task.queue_frame(
 - **Video support**: Video frames can be sent to the model for multimodal input. Control the detail level with `video_frame_detail` and pause/resume with `set_video_input_paused()`.
 - **Transcription frames**: User speech transcription frames are always emitted upstream when input audio transcription is configured.
 - **System instruction precedence**: The `system_instruction` from service settings takes precedence over an initial system message in the LLM context. A warning is logged when both are set.
+- **Reasoning support**: The `reasoning` configuration is only supported by reasoning-capable models such as `gpt-realtime-2`. When used with non-supporting models, the reasoning configuration is automatically filtered out to prevent session errors, and a warning is logged.
 
 ## Event Handlers
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4470](https://github.com/pipecat-ai/pipecat/pull/4470).

## Changes

Updated `api-reference/server/services/s2s/openai.mdx` to document reasoning support for OpenAI Realtime:
- Added `reasoning` parameter to SessionProperties configuration table
- Added new Reasoning configuration section with effort level options (minimal, low, medium, high, xhigh)
- Added usage example showing how to configure reasoning with gpt-realtime-2
- Updated runtime settings example to demonstrate reasoning effort updates
- Added note about automatic filtering of reasoning config for non-supporting models
- Updated imports in usage examples to include Reasoning

## Gaps identified

None