### PR TITLE
docs: update subagents docs for PR #22

### DIFF
--- a/api-reference/pipecat-subagents/decorators.mdx
+++ b/api-reference/pipecat-subagents/decorators.mdx
@@ -67,28 +67,32 @@ Decorated methods are automatically collected by [`BaseAgent`](/api-reference/pi
 from pipecat_subagents.agents import task
 ```
 
-Can be used with or without arguments:
+The decorator requires a `name` argument:
 
 ```python
-# Default handler (receives unnamed requests)
-@task
-async def on_task_request(self, message):
-    result = await do_work(message.payload)
-    await self.send_task_response(result)
-
-# Named handler (receives only "research" requests)
 @task(name="research")
 async def on_research(self, message):
     result = await do_research(message.payload)
-    await self.send_task_response(result)
+    await self.send_task_response(message.task_id, result)
+
+@task(name="write", sequential=True)
+async def on_write(self, message):
+    result = await do_write(message.payload)
+    await self.send_task_response(message.task_id, result)
 ```
 
 ### Parameters
 
-<ParamField path="name" type="str | None" default="None">
-  Task name to match. When set, this handler only receives requests with a
-  matching name. When `None`, handles all unnamed requests (or requests with no
-  matching named handler).
+<ParamField path="name" type="str" required>
+  Task name to match. The handler only receives requests with a matching name.
+</ParamField>
+
+<ParamField path="sequential" type="bool" default="False">
+  When `True`, requests with this name run one at a time in FIFO order.
+  Concurrent requests wait for the previous one to finish before running. When
+  `False` (the default), multiple requests run concurrently. The wait time
+  counts against the requester's timeout, so a slow predecessor can cause queued
+  requests to time out before they start.
 </ParamField>
 
 ### Method Signature

--- a/subagents/learn/task-coordination.mdx
+++ b/subagents/learn/task-coordination.mdx
@@ -56,19 +56,19 @@ Workers handle incoming tasks in two ways.
 
 ### The @task decorator
 
-The `@task` decorator marks a method as a task handler. The framework automatically dispatches matching requests to it. The worker passes `message.task_id` when sending the response:
+The `@task` decorator marks a method as a task handler. The framework automatically dispatches matching requests to it. The decorator requires a `name` argument. The worker passes `message.task_id` when sending the response:
 
 ```python
 from pipecat_subagents.agents import task
 
 class MyWorker(BaseAgent):
-    @task
-    async def on_task_handler(self, message: BusTaskRequestMessage):
+    @task(name="process")
+    async def on_process(self, message: BusTaskRequestMessage):
         result = await self._do_work(message.payload)
         await self.send_task_response(message.task_id, result)
 ```
 
-You can use named tasks to route different types of work to different handlers:
+You can use different task names to route work to different handlers:
 
 ```python
 class MyWorker(BaseAgent):


### PR DESCRIPTION
Automated documentation update for [pipecat-subagents PR #22](https://github.com/pipecat-ai/pipecat-subagents/pull/22).

## Changes

### api-reference/pipecat-subagents/decorators.mdx
- Updated @task section to reflect that the `name` parameter is now required (breaking change)
- Removed "Can be used with or without arguments" text
- Updated code examples to show only the keyword form: `@task(name="...")`
- Changed `name` parameter documentation from optional to required
- Added new `sequential` parameter documentation (defaults to False)
- Added example showing `@task(name="write", sequential=True)`

### subagents/learn/task-coordination.mdx
- Updated all @task decorator examples to use required `name` argument
- Changed `@task` to `@task(name="process")` in the basic example
- Updated prose to mention "The decorator requires a `name` argument"
- Changed "You can use named tasks" to "You can use different task names"

## Gaps identified

None. All relevant source changes have been documented. The `base-agent.mdx` file did not require changes because the task requester methods (`task()`, `request_task()`, etc.) still accept an optional `name` parameter, which is used for routing to named handlers.