### PR TITLE
docs: update for pipecat PR #4472

### DIFF
--- a/api-reference/server/services/s2s/openai.mdx
+++ b/api-reference/server/services/s2s/openai.mdx
@@ -77,7 +77,7 @@ Before using OpenAI Realtime services, you need:
   OpenAI API key for authentication.
 </ParamField>
 
-<ParamField path="model" type="str" default="gpt-realtime-1.5" deprecated>
+<ParamField path="model" type="str" default="gpt-realtime-2" deprecated>
   OpenAI Realtime model name. This is a connection-level parameter set via the
   WebSocket URL and cannot be changed during the session.
 
@@ -142,7 +142,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 <Note>
   `NOT_GIVEN` values are omitted, letting the service use its own defaults
-  (`"gpt-realtime-1.5"` for model). Only parameters that are explicitly set are
+  (`"gpt-realtime-2"` for model). Only parameters that are explicitly set are
   included.
 </Note>
 
@@ -209,7 +209,7 @@ from pipecat.services.openai.realtime import OpenAIRealtimeLLMService
 
 llm = OpenAIRealtimeLLMService(
     api_key=os.getenv("OPENAI_API_KEY"),
-    model="gpt-realtime-1.5",
+    model="gpt-realtime-2",
 )
 ```
 
@@ -243,7 +243,7 @@ session_properties = SessionProperties(
 llm = OpenAIRealtimeLLMService(
     api_key=os.getenv("OPENAI_API_KEY"),
     settings=OpenAIRealtimeLLMService.Settings(
-        model="gpt-realtime-1.5",
+        model="gpt-realtime-2",
         session_properties=session_properties,
         system_instruction="You are a helpful assistant.",
     ),
@@ -264,7 +264,7 @@ session_properties = SessionProperties(
 llm = OpenAIRealtimeLLMService(
     api_key=os.getenv("OPENAI_API_KEY"),
     settings=OpenAIRealtimeLLMService.Settings(
-        model="gpt-realtime-1.5",
+        model="gpt-realtime-2",
         session_properties=session_properties,
         system_instruction="You are a helpful assistant.",
     ),

--- a/pipecat/features/openai-audio-models-and-apis.mdx
+++ b/pipecat/features/openai-audio-models-and-apis.mdx
@@ -69,7 +69,7 @@ Which approach should you choose?
 
 ### Realtime API
 
-- Models: `gpt-realtime-1.5`, `gpt-realtime`
+- Models: `gpt-realtime-2`, `gpt-realtime-1.5`, `gpt-realtime`
 - Pipecat service: `OpenAIRealtimeLLMService` ([reference docs](/api-reference/server/services/s2s/openai))
 - OpenAI docs ([overview](https://platform.openai.com/docs/guides/realtime))
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4472](https://github.com/pipecat-ai/pipecat/pull/4472).

## Changes

- **api-reference/server/services/s2s/openai.mdx** — Updated default model from `gpt-realtime-1.5` to `gpt-realtime-2` in:
  - Configuration section (deprecated `model` parameter default)
  - Settings section note about default values
  - All code examples (Basic Setup, With Session Configuration, With Disabled Turn Detection)

- **pipecat/features/openai-audio-models-and-apis.mdx** — Added `gpt-realtime-2` to the list of available Realtime API models

## Gaps identified

None