### PR TITLE
docs: update for pipecat PR #4462

### DIFF
--- a/api-reference/server/services/tts/cartesia.mdx
+++ b/api-reference/server/services/tts/cartesia.mdx
@@ -73,7 +73,7 @@ Before using Cartesia TTS services, you need:
   `settings=CartesiaTTSService.Settings(voice=...)` instead._
 </ParamField>
 
-<ParamField path="model" type="str" default="sonic-3" deprecated>
+<ParamField path="model" type="str" default="sonic-3.5" deprecated>
   TTS model to use. _Deprecated in v0.0.105. Use
   `settings=CartesiaTTSService.Settings(model=...)` instead._
 </ParamField>
@@ -148,7 +148,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 | Parameter               | Type               | Default     | Description                                                   |
 | ----------------------- | ------------------ | ----------- | ------------------------------------------------------------- |
-| `model`                 | `str`              | `None`      | TTS model identifier. _(Inherited from base settings.)_       |
+| `model`                 | `str`              | `None`      | TTS model identifier. Defaults to `sonic-3.5` when not specified. _(Inherited from base settings.)_ |
 | `voice`                 | `str`              | `None`      | Voice identifier. _(Inherited from base settings.)_           |
 | `language`              | `Language \| str`  | `None`      | Language for synthesis. _(Inherited from base settings.)_     |
 | `generation_config`     | `GenerationConfig` | `NOT_GIVEN` | Generation configuration for Sonic-3 models. See below.       |

--- a/pipecat/learn/text-to-speech.mdx
+++ b/pipecat/learn/text-to-speech.mdx
@@ -99,7 +99,7 @@ from pipecat.transcriptions.language import Language
 tts = CartesiaTTSService(
     api_key=os.getenv("CARTESIA_API_KEY"),
     settings=CartesiaTTSService.Settings(
-        model="sonic-3",
+        model="sonic-3.5",
         voice="voice-id-here",
         language=Language.EN,     # Speech language
     ),


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4462](https://github.com/pipecat-ai/pipecat/pull/4462).

## Changes

**api-reference/server/services/tts/cartesia.mdx**
- Updated deprecated `model` parameter default from `sonic-3` to `sonic-3.5`
- Clarified in Settings table that `model` defaults to `sonic-3.5` when not specified

**pipecat/learn/text-to-speech.mdx**
- Updated Cartesia TTS code example to use `sonic-3.5` instead of `sonic-3`

## Gaps identified

None