### PR TITLE
docs: update for pipecat PR #4464

### DIFF
--- a/api-reference/server/services/stt/nvidia.mdx
+++ b/api-reference/server/services/stt/nvidia.mdx
@@ -5,10 +5,11 @@ description: "Speech-to-text service implementation using NVIDIA Nemotron Speech
 
 ## Overview
 
-NVIDIA Nemotron Speech provides two STT service implementations:
+NVIDIA Nemotron Speech provides three STT service implementations:
 
 - **`NvidiaSTTService`** -- Real-time streaming transcription using Nemotron ASR Streaming models with interim results and continuous audio processing.
 - **`NvidiaSegmentedSTTService`** -- Segmented transcription using Canary models with advanced language support, word boosting, and enterprise-grade accuracy.
+- **`NvidiaSageMakerSTTService`** -- Streaming transcription using NVIDIA Nemotron ASR via an AWS SageMaker bidirectional-stream endpoint with automatic reconnection on error.
 
 <CardGroup cols={2}>
   <Card
@@ -289,3 +290,61 @@ stt = NvidiaSegmentedSTTService(
   `Settings` / `settings=` instead. See the [Service Settings
   guide](/pipecat/fundamentals/service-settings) for migration details.
 </Tip>
+
+## NvidiaSageMakerSTTService
+
+Streaming speech recognition using NVIDIA Nemotron ASR via an AWS SageMaker bidirectional-stream endpoint. This service maintains a persistent HTTP/2 bidi-stream connection to a deployed SageMaker endpoint that proxies to NVIDIA NIM's realtime WebSocket API.
+
+<ParamField path="endpoint_name" type="str" required>
+  Name of the deployed SageMaker endpoint.
+</ParamField>
+
+<ParamField path="region" type="str" default="us-west-2">
+  AWS region where the endpoint is deployed.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="None">
+  Audio sample rate in Hz. When `None`, uses the pipeline's configured sample
+  rate.
+</ParamField>
+
+<ParamField path="settings" type="NvidiaSageMakerSTTService.Settings" default="None">
+  Runtime-configurable settings. See [Settings](#settings-3) below.
+</ParamField>
+
+<ParamField path="ttfs_p99_latency" type="float" default="1.5">
+  P99 latency from speech end to final transcript in seconds. Override for your
+  deployment.
+</ParamField>
+
+### Settings
+
+Runtime-configurable settings passed via the `settings` constructor argument using `NvidiaSageMakerSTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
+
+| Parameter  | Type              | Default                                                        | Description                                                              |
+| ---------- | ----------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `model`    | `str`             | `cache-aware-parakeet-rnnt-en-US-asr-streaming-sortformer`     | STT model identifier.                                                    |
+| `language` | `Language \| str` | `en-US`                                                        | ISO-639-1 language code passed to NIM.                                   |
+
+### Usage
+
+```python
+from pipecat.services.nvidia.sagemaker.stt import NvidiaSageMakerSTTService
+
+stt = NvidiaSageMakerSTTService(
+    endpoint_name=os.getenv("SAGEMAKER_ASR_ENDPOINT_NAME"),
+    region=os.getenv("AWS_REGION", "us-west-2"),
+    settings=NvidiaSageMakerSTTService.Settings(
+        language="en-US",
+    ),
+)
+```
+
+### Notes
+
+- **AWS SageMaker deployment required**: This service requires a deployed SageMaker endpoint running NVIDIA Nemotron ASR NIM. See the [deployment example](https://github.com/pipecat-ai/pipecat-examples/tree/main/nvidia_sagemaker_example/deployment/aws-sagemaker-nvidia) for setup instructions.
+- **AWS credentials**: Requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables for SageMaker authentication.
+- **Environment variables**: `SAGEMAKER_ASR_ENDPOINT_NAME` for the endpoint name.
+- **Automatic reconnection**: The service automatically reconnects on error to maintain continuous transcription.
+- **VAD-aware**: Produces interim results during speech and commits final transcriptions when VAD detects the user has stopped speaking.
+- **Metrics support**: This service supports metrics generation (`can_generate_metrics()` returns `True`).

--- a/api-reference/server/services/tts/nvidia.mdx
+++ b/api-reference/server/services/tts/nvidia.mdx
@@ -5,7 +5,11 @@ description: "Text-to-speech service implementation using NVIDIA Nemotron Speech
 
 ## Overview
 
-`NvidiaTTSService` provides high-quality text-to-speech synthesis through NVIDIA Nemotron Speech's cloud-based AI models accessible via gRPC API. The service offers multilingual support, configurable quality settings, cross-sentence audio stitching, and streaming audio generation optimized for real-time applications.
+NVIDIA Nemotron Speech provides three TTS service implementations:
+
+- **`NvidiaTTSService`** -- High-quality TTS via NVIDIA's cloud-based gRPC API with multilingual support, configurable quality settings, and cross-sentence audio stitching.
+- **`NvidiaSageMakerHTTPTTSService`** -- Single HTTP invocation to an AWS SageMaker endpoint, streaming raw PCM audio back for each text segment.
+- **`NvidiaSageMakerTTSService`** -- Persistent HTTP/2 bidi-stream to an AWS SageMaker endpoint with full interruption support via `InterruptibleTTSService`.
 
 <CardGroup cols={2}>
   <Card
@@ -186,3 +190,116 @@ tts = NvidiaTTSService(
 - **Model cannot be changed after initialization**: The model and function ID must be set during construction via `model_function_map`. Calling `set_model()` after initialization will log a warning and have no effect.
 - **SSL enabled by default**: The service connects to NVIDIA's cloud endpoint with SSL. Set `use_ssl=False` only for local or custom Nemotron Speech deployments.
 - **Metrics generation**: This service supports metric generation via `can_generate_metrics()`. Metrics are automatically stopped when an audio context is interrupted.
+
+## NvidiaSageMakerHTTPTTSService
+
+NVIDIA Magpie TTS service that calls a SageMaker HTTP endpoint for each text segment. Sends JSON to the endpoint's `/invocations` path and streams raw PCM audio back.
+
+### Configuration
+
+<ParamField path="endpoint_name" type="str" required>
+  Name of the deployed SageMaker endpoint.
+</ParamField>
+
+<ParamField path="region" type="str" default="us-west-2">
+  AWS region where the endpoint is deployed.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="None">
+  Audio sample rate in Hz. When `None`, uses the pipeline's configured sample
+  rate.
+</ParamField>
+
+<ParamField path="settings" type="NvidiaSageMakerHTTPTTSService.Settings" default="None">
+  Runtime-configurable settings. See [Settings](#settings-2) below.
+</ParamField>
+
+### Settings
+
+Runtime-configurable settings passed via the `settings` constructor argument using `NvidiaSageMakerHTTPTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
+
+| Parameter  | Type              | Default                            | Description                            |
+| ---------- | ----------------- | ---------------------------------- | -------------------------------------- |
+| `model`    | `str`             | `magpie`                           | Model identifier. _(Inherited.)_       |
+| `voice`    | `str`             | `Magpie-Multilingual.EN-US.Aria`   | Voice identifier. _(Inherited.)_       |
+| `language` | `Language \| str` | `en-US`                            | BCP-47 language code for synthesis.    |
+
+### Usage
+
+```python
+from pipecat.services.nvidia.sagemaker.tts import NvidiaSageMakerHTTPTTSService
+
+tts = NvidiaSageMakerHTTPTTSService(
+    endpoint_name=os.getenv("SAGEMAKER_MAGPIE_ENDPOINT_NAME"),
+    region=os.getenv("AWS_REGION", "us-west-2"),
+    settings=NvidiaSageMakerHTTPTTSService.Settings(
+        voice="Magpie-Multilingual.EN-US.Aria",
+        language="en-US",
+    ),
+)
+```
+
+### Notes
+
+- **AWS SageMaker deployment required**: This service requires a deployed SageMaker endpoint running NVIDIA Magpie TTS NIM. See the [deployment example](https://github.com/pipecat-ai/pipecat-examples/tree/main/nvidia_sagemaker_example/deployment/aws-sagemaker-nvidia) for setup instructions.
+- **AWS credentials**: Requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables for SageMaker authentication.
+- **Environment variables**: `SAGEMAKER_MAGPIE_ENDPOINT_NAME` for the endpoint name.
+- **HTTP-based**: Each text segment triggers a new HTTP POST request to the SageMaker endpoint.
+- **Metrics support**: This service supports metrics generation (`can_generate_metrics()` returns `True`).
+
+## NvidiaSageMakerTTSService
+
+NVIDIA Magpie TTS service using SageMaker bidirectional streaming. Maintains a persistent HTTP/2 bidi-stream connection for the lifetime of the pipeline with full interruption support.
+
+### Configuration
+
+<ParamField path="endpoint_name" type="str" required>
+  Name of the deployed SageMaker endpoint.
+</ParamField>
+
+<ParamField path="region" type="str" default="us-west-2">
+  AWS region where the endpoint is deployed.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="None">
+  Audio sample rate in Hz. When `None`, uses the pipeline's configured sample
+  rate.
+</ParamField>
+
+<ParamField path="settings" type="NvidiaSageMakerTTSService.Settings" default="None">
+  Runtime-configurable settings. See [Settings](#settings-3) below.
+</ParamField>
+
+### Settings
+
+Runtime-configurable settings passed via the `settings` constructor argument using `NvidiaSageMakerTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
+
+| Parameter  | Type              | Default                            | Description                            |
+| ---------- | ----------------- | ---------------------------------- | -------------------------------------- |
+| `model`    | `str`             | `magpie`                           | Model identifier. _(Inherited.)_       |
+| `voice`    | `str`             | `Magpie-Multilingual.EN-US.Aria`   | Voice identifier. _(Inherited.)_       |
+| `language` | `Language \| str` | `en-US`                            | BCP-47 language code for synthesis.    |
+
+### Usage
+
+```python
+from pipecat.services.nvidia.sagemaker.tts import NvidiaSageMakerTTSService
+
+tts = NvidiaSageMakerTTSService(
+    endpoint_name=os.getenv("SAGEMAKER_MAGPIE_ENDPOINT_NAME"),
+    region=os.getenv("AWS_REGION", "us-west-2"),
+    settings=NvidiaSageMakerTTSService.Settings(
+        voice="Magpie-Multilingual.EN-US.Aria",
+        language="en-US",
+    ),
+)
+```
+
+### Notes
+
+- **AWS SageMaker deployment required**: This service requires a deployed SageMaker endpoint running NVIDIA Magpie TTS NIM. See the [deployment example](https://github.com/pipecat-ai/pipecat-examples/tree/main/nvidia_sagemaker_example/deployment/aws-sagemaker-nvidia) for setup instructions.
+- **AWS credentials**: Requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables for SageMaker authentication.
+- **Environment variables**: `SAGEMAKER_MAGPIE_ENDPOINT_NAME` for the endpoint name.
+- **Persistent connection**: Maintains a single HTTP/2 bidi-stream session for the pipeline's lifetime, reconnecting automatically on error.
+- **Interruption support**: Extends `InterruptibleTTSService` for proper handling of user interruptions.
+- **Metrics support**: This service supports metrics generation (`can_generate_metrics()` returns `True`).


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4464](https://github.com/pipecat-ai/pipecat/pull/4464).

## Changes

### Updated api-reference/server/services/stt/nvidia.mdx
- Added `NvidiaSageMakerSTTService` to the overview
- Added complete documentation section for `NvidiaSageMakerSTTService` including:
  - Configuration parameters (endpoint_name, region, sample_rate, settings, ttfs_p99_latency)
  - Settings table (model, language)
  - Usage example
  - Notes about AWS SageMaker deployment, AWS credentials, automatic reconnection, and VAD awareness

### Updated api-reference/server/services/tts/nvidia.mdx
- Updated overview to list all three TTS service implementations
- Added complete documentation section for `NvidiaSageMakerHTTPTTSService` including:
  - Configuration parameters (endpoint_name, region, sample_rate, settings)
  - Settings table (model, voice, language)
  - Usage example
  - Notes about AWS SageMaker deployment, AWS credentials, and HTTP-based operation
- Added complete documentation section for `NvidiaSageMakerTTSService` including:
  - Configuration parameters (endpoint_name, region, sample_rate, settings)
  - Settings table (model, voice, language)
  - Usage example
  - Notes about AWS SageMaker deployment, persistent connection, and interruption support

## Gaps identified

None