### PR TITLE
docs: update for pipecat PR #4450

### DIFF
--- a/api-reference/server/services/s2s/openai.mdx
+++ b/api-reference/server/services/s2s/openai.mdx
@@ -164,12 +164,12 @@ The `audio` field in `SessionProperties` accepts an `AudioConfiguration` with `i
 
 **AudioInput** (`audio.input`):
 
-| Parameter         | Type                                             | Default | Description                                                                             |
-| ----------------- | ------------------------------------------------ | ------- | --------------------------------------------------------------------------------------- |
-| `format`          | `AudioFormat`                                    | `None`  | Input audio format (`PCMAudioFormat`, `PCMUAudioFormat`, or `PCMAAudioFormat`).         |
-| `transcription`   | `InputAudioTranscription`                        | `None`  | Transcription settings: `model` (e.g. `"gpt-4o-transcribe"`), `language`, and `prompt`. |
-| `noise_reduction` | `InputAudioNoiseReduction`                       | `None`  | Noise reduction type: `"near_field"` or `"far_field"`.                                  |
-| `turn_detection`  | `TurnDetection \| SemanticTurnDetection \| bool` | `None`  | Turn detection config, or `False` to disable server-side turn detection.                |
+| Parameter         | Type                                             | Default | Description                                                                                                                                           |
+| ----------------- | ------------------------------------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `format`          | `AudioFormat`                                    | `None`  | Input audio format (`PCMAudioFormat`, `PCMUAudioFormat`, or `PCMAAudioFormat`).                                                                       |
+| `transcription`   | `InputAudioTranscription`                        | `None`  | Transcription settings: `model` (e.g. `"gpt-realtime-whisper"`, `"gpt-4o-transcribe"`), `language`, and `prompt` (not supported by `"gpt-realtime-whisper"`). |
+| `noise_reduction` | `InputAudioNoiseReduction`                       | `None`  | Noise reduction type: `"near_field"` or `"far_field"`.                                                                                                |
+| `turn_detection`  | `TurnDetection \| SemanticTurnDetection \| bool` | `None`  | Turn detection config, or `False` to disable server-side turn detection.                                                                              |
 
 **AudioOutput** (`audio.output`):
 
@@ -229,7 +229,7 @@ from pipecat.services.openai.realtime.events import (
 session_properties = SessionProperties(
     audio=AudioConfiguration(
         input=AudioInput(
-            transcription=InputAudioTranscription(model="gpt-4o-transcribe"),
+            transcription=InputAudioTranscription(model="gpt-realtime-whisper"),
             turn_detection=SemanticTurnDetection(eagerness="medium"),
         ),
         output=AudioOutput(

--- a/api-reference/server/services/stt/openai.mdx
+++ b/api-reference/server/services/stt/openai.mdx
@@ -154,10 +154,11 @@ Real-time streaming speech-to-text using OpenAI's Realtime API WebSocket transcr
   OpenAI API key for authentication.
 </ParamField>
 
-<ParamField path="model" type="str" default="gpt-4o-transcribe" deprecated>
-  Transcription model. Supported values are `"gpt-4o-transcribe"` and
-  `"gpt-4o-mini-transcribe"`. *Deprecated in v0.0.105. Use
-  `settings=OpenAIRealtimeSTTService.Settings(...)` instead.*
+<ParamField path="model" type="str" default="gpt-realtime-whisper" deprecated>
+  Transcription model. For low-latency streaming transcription, use
+  `"gpt-realtime-whisper"`. Other supported models include
+  `"gpt-4o-transcribe"` and `"gpt-4o-mini-transcribe"`. *Deprecated in v0.0.105.
+  Use `settings=OpenAIRealtimeSTTService.Settings(...)` instead.*
 </ParamField>
 
 <ParamField
@@ -175,8 +176,8 @@ Real-time streaming speech-to-text using OpenAI's Realtime API WebSocket transcr
 
 <ParamField path="prompt" type="str" default="None" deprecated>
   Optional prompt text to guide transcription style or provide keyword hints.
-  *Deprecated in v0.0.105. Use `settings=OpenAIRealtimeSTTService.Settings(...)`
-  instead.*
+  Not supported by `"gpt-realtime-whisper"`. *Deprecated in v0.0.105. Use
+  `settings=OpenAIRealtimeSTTService.Settings(...)` instead.*
 </ParamField>
 
 <ParamField
@@ -220,11 +221,11 @@ Real-time streaming speech-to-text using OpenAI's Realtime API WebSocket transcr
 
 Runtime-configurable settings passed via the `settings` constructor argument using `OpenAIRealtimeSTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter  | Type              | Default               | Description                                                         |
-| ---------- | ----------------- | --------------------- | ------------------------------------------------------------------- |
-| `model`    | `str`             | `"gpt-4o-transcribe"` | Transcription model to use. _(Inherited from base STT settings.)_   |
-| `language` | `Language \| str` | `Language.EN`         | Language of the audio input. _(Inherited from base STT settings.)_  |
-| `prompt`   | `str`             | `None`                | Optional prompt text to guide transcription style or keyword hints. |
+| Parameter  | Type              | Default                  | Description                                                                                |
+| ---------- | ----------------- | ------------------------ | ------------------------------------------------------------------------------------------ |
+| `model`    | `str`             | `"gpt-realtime-whisper"` | Transcription model to use. _(Inherited from base STT settings.)_                          |
+| `language` | `Language \| str` | `Language.EN`            | Language of the audio input. _(Inherited from base STT settings.)_                         |
+| `prompt`   | `str`             | `None`                   | Optional prompt text to guide transcription style or keyword hints. Not supported by `"gpt-realtime-whisper"`. |
 
 ### Usage
 
@@ -237,7 +238,7 @@ from pipecat.services.openai.stt import OpenAIRealtimeSTTService
 stt = OpenAIRealtimeSTTService(
     api_key=os.getenv("OPENAI_API_KEY"),
     settings=OpenAIRealtimeSTTService.Settings(
-        model="gpt-4o-transcribe",
+        model="gpt-realtime-whisper",
         noise_reduction="near_field",
     ),
 )
@@ -253,7 +254,7 @@ stt = OpenAIRealtimeSTTService(
     api_key=os.getenv("OPENAI_API_KEY"),
     turn_detection=None,  # Enable server-side VAD
     settings=OpenAIRealtimeSTTService.Settings(
-        model="gpt-4o-transcribe",
+        model="gpt-realtime-whisper",
     ),
 )
 ```
@@ -263,6 +264,7 @@ stt = OpenAIRealtimeSTTService(
 - **Local VAD vs Server-side VAD**: Defaults to local VAD mode (`turn_detection=False`), where a local VAD processor in the pipeline controls when audio is committed for transcription. Set `turn_detection=None` for server-side VAD, but do not use a separate VAD processor in the pipeline in that mode.
 - **Automatic resampling**: Automatically resamples audio to 24 kHz as required by the Realtime API, regardless of the pipeline's sample rate.
 - **Interim transcriptions**: Produces interim transcriptions via delta events for real-time feedback.
+- **Model selection**: The default `"gpt-realtime-whisper"` model provides low-latency streaming transcription but does not support the `prompt` parameter. If you need prompt hints for keywords or style guidance, use `"gpt-4o-transcribe"` or `"gpt-4o-mini-transcribe"` instead.
 - **Multilingual support**: GPT-4o transcription models support many languages. The default is `Language.EN` (English). Set `language=None` in settings to enable automatic language detection, which will transcribe whatever language the user speaks.
 
 ### Event Handlers

--- a/pipecat/features/openai-audio-models-and-apis.mdx
+++ b/pipecat/features/openai-audio-models-and-apis.mdx
@@ -57,8 +57,8 @@ Which approach should you choose?
 
 ### Transcription API
 
-- Models: `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`
-- Pipecat service: `OpenAISTTService` ([reference docs](/api-reference/server/services/stt/openai))
+- Models: `gpt-realtime-whisper` (default for streaming), `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`
+- Pipecat services: `OpenAISTTService`, `OpenAIRealtimeSTTService` ([reference docs](/api-reference/server/services/stt/openai))
 - OpenAI endpoint: `/v1/audio/transcriptions` ([docs](https://platform.openai.com/docs/api-reference/audio/createTranscription))
 
 ### Chat Completions API


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4450](https://github.com/pipecat-ai/pipecat/pull/4450).

## Changes

### api-reference/server/services/stt/openai.mdx
- Updated default transcription model from `"gpt-4o-transcribe"` to `"gpt-realtime-whisper"` in parameter documentation and Settings table
- Added note that `"gpt-realtime-whisper"` does not support the `prompt` parameter
- Updated all code examples to use `"gpt-realtime-whisper"` as the model
- Added new note in the Notes section explaining model selection and prompt parameter compatibility

### api-reference/server/services/s2s/openai.mdx
- Updated AudioInput transcription description to list `"gpt-realtime-whisper"` as the primary example and note that it doesn't support the `prompt` parameter
- Updated usage example to use `"gpt-realtime-whisper"` instead of `"gpt-4o-transcribe"`

### pipecat/features/openai-audio-models-and-apis.mdx
- Added `"gpt-realtime-whisper"` to the list of transcription models, noting it as the default for streaming
- Added `OpenAIRealtimeSTTService` to the list of Pipecat services

## Gaps identified

None