### PR TITLE
docs: update for pipecat PR #4474

### DIFF
--- a/api-reference/server/services/s2s/inworld.mdx
+++ b/api-reference/server/services/s2s/inworld.mdx
@@ -328,6 +328,7 @@ await task.queue_frame(
 - **G.711 support**: PCMU and PCMA formats are supported at a fixed 8000 Hz rate, useful for telephony integrations.
 - **System instruction precedence**: The `system_instruction` from service settings takes precedence over an initial system message in the LLM context. A warning is logged when both are set.
 - **Settings replacement**: When providing `session_properties` in `settings`, it **replaces** all defaults wholesale — provide a complete `SessionProperties` configuration in that case. Use the constructor shortcuts (`llm_model`, `voice`, `tts_model`, `stt_model`) for simpler configuration.
+- **Function calling limitations**: Functions registered with `cancel_on_interruption=False` are not reliably supported by Inworld Realtime as of this writing. The service will emit a warning if async tool messages are detected. Use `cancel_on_interruption=True` (the default) or consider another LLM service if your tool needs async semantics. Streamed intermediate tool results (`FunctionCallResultProperties(is_final=False)`) are also not supported.
 
 ## Event Handlers
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4474](https://github.com/pipecat-ai/pipecat/pull/4474).

## Changes
- **api-reference/server/services/s2s/inworld.mdx** — Added note in Notes section about function calling limitations with `cancel_on_interruption=False` and streamed intermediate results

## Summary
PR #4474 extended the `cancel_on_interruption=False` regression fix to `InworldRealtimeLLMService`, but with important caveats. The service now detects async-tool messages and emits warnings because Inworld's Realtime API doesn't reliably support delayed tool results. The documentation has been updated to note:
- Functions with `cancel_on_interruption=False` are not reliably supported
- Streamed intermediate tool results are not supported
- Users should use `cancel_on_interruption=True` (the default) or consider another service

## Gaps identified
None