### PR TITLE
docs: update for pipecat PR #4473

### DIFF
--- a/api-reference/server/services/tts/inworld.mdx
+++ b/api-reference/server/services/tts/inworld.mdx
@@ -137,6 +137,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 | `language`      | `Language \| str` | `None`      | Language for synthesis. _(Inherited.)_ |
 | `speaking_rate` | `float`           | `NOT_GIVEN` | Speaking rate for speech synthesis.    |
 | `temperature`   | `float`           | `NOT_GIVEN` | Temperature for speech synthesis.      |
+| `delivery_mode` | `"STABLE" \| "BALANCED" \| "CREATIVE"` | `NOT_GIVEN` | Controls the stability vs. creativity tradeoff. `"STABLE"` produces reliable, predictable speech. `"BALANCED"` is the default midpoint. `"CREATIVE"` produces more expressive, emotionally varied speech. Only supported by `inworld-tts-2`. |
 
 ### InworldHttpTTSService
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4473](https://github.com/pipecat-ai/pipecat/pull/4473).

## Changes
- **api-reference/server/services/tts/inworld.mdx** — Added `delivery_mode` parameter to InworldTTSService Settings table. This parameter controls the stability vs. creativity tradeoff with three options: `"STABLE"`, `"BALANCED"`, and `"CREATIVE"`. Only supported by `inworld-tts-2`.

## Gaps identified
None