### PR TITLE
docs: update for pipecat PR #4482

### DIFF
--- a/api-reference/server/services/stt/soniox.mdx
+++ b/api-reference/server/services/stt/soniox.mdx
@@ -130,7 +130,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 | `language_hints_strict`          | `bool`                       | `None`        | If true, strictly enforce language hints (only transcribe in provided languages).                                                                      |
 | `context`                        | `SonioxContextObject \| str` | `None`        | Customization for transcription. String for models with context_version 1, `SonioxContextObject` for context_version 2 (stt-rt-v3-preview and higher). |
 | `enable_speaker_diarization`     | `bool`                       | `False`       | Enable speaker diarization. Tokens are annotated with speaker IDs.                                                                                     |
-| `enable_language_identification` | `bool`                       | `False`       | Enable language identification. Tokens are annotated with language IDs.                                                                                |
+| `enable_language_identification` | `bool`                       | `False`       | Enable language identification. Tokens are annotated with language IDs, and the detected language is included in the final `TranscriptionFrame`.       |
 | `client_reference_id`            | `str`                        | `None`        | Client reference ID for transcription tracking.                                                                                                        |
 
 ## Usage


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4482](https://github.com/pipecat-ai/pipecat/pull/4482).

## Changes

- **`api-reference/server/services/stt/soniox.mdx`** — Updated Settings table description for `enable_language_identification` parameter to reflect that the detected language is now included in the final `TranscriptionFrame`, not just in token annotations.

## Gaps identified

None