### PR TITLE
docs: update for pipecat PR #4501

### DIFF
--- a/api-reference/server/utilities/turn-management/filter-incomplete-turns.mdx
+++ b/api-reference/server/utilities/turn-management/filter-incomplete-turns.mdx
@@ -265,6 +265,41 @@ user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
   for natural conversations.
 </Tip>
 
+### With Function Calling
+
+Turn completion works seamlessly with LLM function calls. When the LLM decides to call a tool, the user turn is automatically finalized before the function executes:
+
+```python
+from pipecat.services.openai.llm import OpenAILLMService
+
+async def get_weather(params: FunctionCallParams, location: str):
+    """Return the current weather for a location."""
+    await params.result_callback({
+        "location": location,
+        "temperature_celsius": 22,
+        "conditions": "partly cloudy",
+    })
+
+llm = OpenAILLMService(
+    api_key=os.environ["OPENAI_API_KEY"],
+    settings=OpenAILLMService.Settings(
+        system_instruction="You are a helpful assistant...",
+    ),
+)
+llm.register_direct_function(get_weather)
+
+user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+    context,
+    user_params=LLMUserAggregatorParams(
+        filter_incomplete_user_turns=True,
+    ),
+)
+```
+
+<Note>
+  Function calls automatically finalize the user turn, so the turn completion logic works correctly whether the LLM responds with text or by calling a tool.
+</Note>
+
 ## Transcripts
 
 Turn completion markers are automatically stripped from assistant transcripts emitted via the `on_assistant_turn_stopped` event. Your transcript handlers will receive clean text without markers:


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4501](https://github.com/pipecat-ai/pipecat/pull/4501).

## Changes

- **filter-incomplete-turns.mdx**: Added usage example showing that turn completion works seamlessly with LLM function calls. Documents that function calls automatically finalize the user turn before execution.

## Gaps identified

None - the PR only modified internal implementation details in `src/pipecat/turns/user_turn_completion_mixin.py` and added example files. The fix ensures function calling now works correctly with the filter incomplete turns feature, which has been documented with a new usage example.