### PR TITLE
docs: update for pipecat PR #4500

### DIFF
--- a/api-reference/server/services/stt/gradium.mdx
+++ b/api-reference/server/services/stt/gradium.mdx
@@ -67,9 +67,10 @@ Before using Gradium STT services, you need:
 <ParamField
   path="api_endpoint_base_url"
   type="str"
-  default="wss://eu.api.gradium.ai/api/speech/asr"
+  default="wss://api.gradium.ai/api/speech/asr"
 >
-  WebSocket endpoint URL. Override for different regions or custom deployments.
+  WebSocket endpoint URL. Gradium automatically routes traffic to the nearest
+  endpoint. Override to pin to a specific region or custom deployment.
 </ParamField>
 
 <ParamField path="encoding" type="str" default="pcm">

--- a/api-reference/server/services/tts/gradium.mdx
+++ b/api-reference/server/services/tts/gradium.mdx
@@ -72,9 +72,10 @@ Before using Gradium TTS services, you need:
 <ParamField
   path="url"
   type="str"
-  default="wss://eu.api.gradium.ai/api/speech/tts"
+  default="wss://api.gradium.ai/api/speech/tts"
 >
-  Gradium WebSocket API endpoint.
+  Gradium WebSocket API endpoint. Gradium automatically routes traffic to the
+  nearest endpoint. Override to pin to a specific region or custom deployment.
 </ParamField>
 
 <ParamField path="model" type="str" default="default" deprecated>


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4500](https://github.com/pipecat-ai/pipecat/pull/4500).

## Changes
- **`api-reference/server/services/stt/gradium.mdx`** — Updated default `api_endpoint_base_url` from `wss://eu.api.gradium.ai/api/speech/asr` to `wss://api.gradium.ai/api/speech/asr`. Updated description to clarify that Gradium automatically routes traffic to the nearest endpoint.
- **`api-reference/server/services/tts/gradium.mdx`** — Updated default `url` from `wss://eu.api.gradium.ai/api/speech/tts` to `wss://api.gradium.ai/api/speech/tts`. Updated description to clarify that Gradium automatically routes traffic to the nearest endpoint.

## Gaps identified
None