### PR TITLE
docs: update for pipecat PR #4507

### DIFF
--- a/api-reference/server/services/stt/elevenlabs.mdx
+++ b/api-reference/server/services/stt/elevenlabs.mdx
@@ -230,15 +230,15 @@ async with aiohttp.ClientSession() as session:
 
 Runtime-configurable settings passed via the `settings` constructor argument using `ElevenLabsRealtimeSTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter                    | Type              | Default       | Description                                                                             |
-| ---------------------------- | ----------------- | ------------- | --------------------------------------------------------------------------------------- |
-| `model`                      | `str`             | `None`        | Model ID for transcription. _(Inherited from base STT settings.)_                       |
-| `language`                   | `Language \| str` | `Language.EN` | Language for speech recognition. _(Inherited from base STT settings.)_                  |
-| `keyterms`                   | `list[str]`       | `None`        | List of key terms or phrases to bias transcription towards.                             |
-| `vad_silence_threshold_secs` | `float`           | `None`        | Seconds of silence before VAD commits (0.3-3.0). Only used with VAD commit strategy.    |
-| `vad_threshold`              | `float`           | `None`        | VAD sensitivity (0.1-0.9, lower is more sensitive). Only used with VAD commit strategy. |
-| `min_speech_duration_ms`     | `int`             | `None`        | Minimum speech duration for VAD (50-2000ms). Only used with VAD commit strategy.        |
-| `min_silence_duration_ms`    | `int`             | `None`        | Minimum silence duration for VAD (50-2000ms). Only used with VAD commit strategy.       |
+| Parameter                    | Type              | Default | Description                                                                             |
+| ---------------------------- | ----------------- | ------- | --------------------------------------------------------------------------------------- |
+| `model`                      | `str`             | `None`  | Model ID for transcription. _(Inherited from base STT settings.)_                       |
+| `language`                   | `Language \| str` | `None`  | Language for speech recognition. _(Inherited from base STT settings.)_                  |
+| `keyterms`                   | `list[str]`       | `None`  | List of key terms or phrases to bias transcription towards.                             |
+| `vad_silence_threshold_secs` | `float`           | `None`  | Seconds of silence before VAD commits (0.3-3.0). Only used with VAD commit strategy.    |
+| `vad_threshold`              | `float`           | `None`  | VAD sensitivity (0.1-0.9, lower is more sensitive). Only used with VAD commit strategy. |
+| `min_speech_duration_ms`     | `int`             | `None`  | Minimum speech duration for VAD (50-2000ms). Only used with VAD commit strategy.        |
+| `min_silence_duration_ms`    | `int`             | `None`  | Minimum silence duration for VAD (50-2000ms). Only used with VAD commit strategy.       |
 
 ### Usage
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4507](https://github.com/pipecat-ai/pipecat/pull/4507).

## Changes

**`api-reference/server/services/stt/elevenlabs.mdx`** — Updated ElevenLabsRealtimeSTTService Settings table:
- Corrected `language` parameter default from `Language.EN` to `None` (matches actual source code behavior)

## Context

PR #4507 fixed a crash in `ElevenLabsSTTService` when `language` was set to `None`. The fix allows both STT services to properly handle `None` for automatic language detection.

While investigating, I discovered that the `ElevenLabsRealtimeSTTService` Settings table had an incorrect default value documented (`Language.EN` instead of `None`). The source code shows the Realtime service defaults to `language=None` for auto-detection, which differs from the HTTP service that defaults to `Language.EN`.

## Gaps identified

None