### PR TITLE
Add Ringg AI to community Speech-to-Text integrations

### DIFF
--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -57,6 +57,7 @@ Speech-to-Text services receive and audio input and output transcriptions.
 
 | Service                               | Repository                                           | Maintainer(s)                                   |
 | ------------------------------------- | ---------------------------------------------------- | ----------------------------------------------- |
+| [Ringg AI](https://ringg.ai)          | https://github.com/Stonkr/pipecat-ringg              | [Stonkr](https://github.com/Stonkr)             |
 | [Simplismart](https://simplismart.ai) | https://github.com/simpli-smart/pipecat-simplismart  | [simpli-smart](https://github.com/simpli-smart) |
 | [Uplift AI](https://upliftai.org)     | https://github.com/havkerboi123/pipecat-upliftai-stt | [havkerboi123](https://github.com/havkerboi123) |
 


### PR DESCRIPTION
Adds [pipecat-ringg](https://github.com/Stonkr/pipecat-ringg) to the community integrations registry.

**Service included:**
- **STT** — `RinggSTTService`: SDK-based streaming Speech-to-Text backed by the official [`ringglabs`](https://pypi.org/project/ringglabs/) SDK. The SDK manages the WebSocket connection, handshake, and event parsing; the service forwards Pipecat `VADUserStartedSpeakingFrame` / `VADUserStoppedSpeakingFrame` as `start_speaking` / `stop_speaking` cues so the server can endpoint in `on_final` mode.

**Package:** https://github.com/Stonkr/pipecat-ringg
**Maintainer:** [Stonkr](https://github.com/Stonkr)

The repository follows `COMMUNITY_INTEGRATIONS.md`: standalone package (`src/pipecat_ringg/`), foundational example (`example.py`), README with install/usage and "Tested with Pipecat v1.2.1", BSD-2 LICENSE, CHANGELOG, docstrings, and unit tests.