### PR TITLE
docs: add Future AGI to Observability community integrations

### DIFF
--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -50,6 +50,7 @@ Observability services enable telemetry and metrics data to be passed to a Open 
 | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | [OpenInference](https://arize-ai.github.io/openinference/) | [openinference-instrumentation-pipecat](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-pipecat) | [Arize-ai](https://github.com/Arize-ai/openinference/graphs/contributors) |
 | [Finchvox](https://finchvox.dev/)                          | https://github.com/finchvox/finchvox                                                                                                                      | [Finchvox](https://github.com/finchvox)                                   |
+| [Future AGI](https://futureagi.com)                        | [traceAI-pipecat](https://github.com/future-agi/traceAI/tree/main/python/frameworks/pipecat)                                                              | [future-agi](https://github.com/future-agi)                               |
 
 ## Speech-to-Text
 

--- a/api-reference/server/utilities/opentelemetry.mdx
+++ b/api-reference/server/utilities/opentelemetry.mdx
@@ -182,6 +182,14 @@ Arize-ai provides OpenInference instrumentation, compatible with OpenTelemetry.
 
 See [Observability community integrations](https://docs.pipecat.ai/server/services/community-integrations#observability) for more details.
 
+### Future AGI
+
+Future AGI provides OpenTelemetry attribute mapping for Pipecat traces, compatible with OpenTelemetry.
+
+- [traceAI-pipecat](https://github.com/future-agi/traceAI/tree/main/python/frameworks/pipecat)
+
+See [Observability community integrations](https://docs.pipecat.ai/server/services/community-integrations#observability) for more details.
+
 ## Span Attributes
 
 Pipecat enriches spans with detailed attributes about service operations:
@@ -422,3 +430,4 @@ If you're having issues with tracing:
 - [OpenTelemetry Tracing Specification](https://opentelemetry.io/docs/reference/specification/trace/api/)
 - [Jaeger Documentation](https://www.jaegertracing.io/docs/latest/)
 - [Langfuse OpenTelemetry Documentation](https://langfuse.com/docs/opentelemetry/get-started)
+- [Future AGI Documentation](https://docs.futureagi.com)


### PR DESCRIPTION
## Summary

Adds [Future AGI](https://futureagi.com) to the Observability community integrations, alongside OpenInference and Finchvox.

- `api-reference/server/services/community-integrations.mdx` — new row in the Observability table.
- `api-reference/server/utilities/opentelemetry.mdx` — new `### Future AGI` subsection parallel to `### OpenInference`, plus a `Future AGI Documentation` entry in the References list at the bottom of the page.

## What the integration does

[`traceAI-pipecat`](https://github.com/future-agi/traceAI/tree/main/python/frameworks/pipecat) is a Pipecat-aware OpenTelemetry span-exporter wrapper that maps Pipecat span attributes onto Future AGI's tracer conventions, so existing Pipecat OTEL setups can route traces to the Future AGI dashboard.

## Test plan

- [x] `npx prettier --check` passes on both edited files
- [ ] Maintainer review of placement (Observability table row + parallel `### Future AGI` subsection in `opentelemetry.mdx`)