### PR TITLE
docs: update for pipecat PR #4521

### DIFF
--- a/api-reference/server/services/stt/soniox.mdx
+++ b/api-reference/server/services/stt/soniox.mdx
@@ -131,6 +131,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 | `context`                        | `SonioxContextObject \| str` | `None`        | Customization for transcription. String for models with context_version 1, `SonioxContextObject` for context_version 2 (stt-rt-v3-preview and higher). |
 | `enable_speaker_diarization`     | `bool`                       | `False`       | Enable speaker diarization. Tokens are annotated with speaker IDs.                                                                                     |
 | `enable_language_identification` | `bool`                       | `False`       | Enable language identification. Tokens are annotated with language IDs, and the detected language is included in the final `TranscriptionFrame`.       |
+| `max_endpoint_delay_ms`          | `int`                        | `None`        | Maximum delay in milliseconds before endpoint detection finalizes the turn. Valid range: 500-3000.                                                     |
 | `client_reference_id`            | `str`                        | `None`        | Client reference ID for transcription tracking.                                                                                                        |
 
 ## Usage


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4521](https://github.com/pipecat-ai/pipecat/pull/4521).

## Changes
- **api-reference/server/services/stt/soniox.mdx**: Added `max_endpoint_delay_ms` parameter to the Settings table. This new parameter allows controlling the maximum delay (in milliseconds, range 500-3000) before endpoint detection finalizes a user turn.

## Gaps identified
None