### PR TITLE
Add Supertonic community integration

### DIFF
--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -84,6 +84,7 @@ Text-to-Speech services receive text input and output audio streams or chunks.
 | [Pipecat TTS Cache](https://pypi.org/project/pipecat-tts-cache/) | https://github.com/omChauhanDev/pipecat-tts-cache    | [omChauhanDev](https://github.com/omChauhanDev) |
 | [Respeecher](https://www.respeecher.com/real-time-tts-api)       | https://github.com/respeecher/pipecat-respeecher     | [respeecher](https://github.com/respeecher)     |
 | [Simplismart](https://simplismart.ai)                            | https://github.com/simpli-smart/pipecat-simplismart  | [simpli-smart](https://github.com/simpli-smart) |
+| [Supertonic](https://github.com/supertone-inc/supertonic)        | https://github.com/architjambhule66-debug/pipecat-supertonic | [architjambhule66-debug](https://github.com/architjambhule66-debug) |
 | [Typecast](https://typecast.ai/)                                 | https://github.com/neosapience/pipecat-typecast      | [neosapience](https://github.com/neosapience)   |
 | [Uplift AI](https://upliftai.org)                                | https://github.com/havkerboi123/pipecat-upliftai-tts | [havkerboi123](https://github.com/havkerboi123) |
 | [Voice.ai](https://voice.ai/)                                    | https://github.com/voice-ai/voice-ai-pipecat-tts     | [voice-ai](https://github.com/voice-ai)         |


### PR DESCRIPTION
## Summary
Add `pipecat-supertonic` to the Community Integrations page under Text-to-Speech.
- Repository: https://github.com/architjambhule66-debug/pipecat-supertonic
- PyPI: https://pypi.org/project/pipecat-supertonic/

https://github.com/user-attachments/assets/c7d3415a-315e-4a54-b949-abe2dfc55147

- Maintainer: @architjambhule66-debug

This is a community-maintained Pipecat TTS integration for the official Supertonic Python SDK. The first request takes time since it downloads and caches the model. 
Tested with Pipecat v1.2.x.