### PR TITLE
docs: update for pipecat PR #4513

### DIFF
--- a/api-reference/server/services/llm/openrouter.mdx
+++ b/api-reference/server/services/llm/openrouter.mdx
@@ -97,7 +97,9 @@ from pipecat.services.openrouter import OpenRouterLLMService
 
 llm = OpenRouterLLMService(
     api_key=os.getenv("OPENROUTER_API_KEY"),
-    model="openai/gpt-4o-2024-11-20",
+    settings=OpenRouterLLMService.Settings(
+        model="openai/gpt-4.1",  # Default model
+    ),
 )
 ```
 
@@ -119,6 +121,8 @@ llm = OpenRouterLLMService(
 ## Notes
 
 - OpenRouter model identifiers use the `provider/model` format (e.g., `openai/gpt-4o`, `anthropic/claude-sonnet-4-20250514`, `google/gemini-pro`).
+- The default model is `openai/gpt-4.1`.
+- **Developer message conversion**: OpenRouter requests now convert `developer` messages to `user` messages by default for broader model compatibility. To use models that support the `developer` role, set `llm.supports_developer_role = True` after instantiation or subclass `OpenRouterLLMService` to override this behavior.
 - When using Gemini models through OpenRouter, the service automatically handles the constraint that only one system message is allowed by converting additional system messages to user messages.
 
 <Tip>


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4513](https://github.com/pipecat-ai/pipecat/pull/4513).

## Changes
- **`api-reference/server/services/llm/openrouter.mdx`**: Updated default model to `openai/gpt-4.1`, added note about developer message conversion behavior, and updated usage example to reflect new defaults

## Gaps identified
None