### PR TITLE
Update default Gradium voice ID

### DIFF
--- a/api-reference/server/services/tts/gradium.mdx
+++ b/api-reference/server/services/tts/gradium.mdx
@@ -64,7 +64,7 @@ Before using Gradium TTS services, you need:
   Gradium API key for authentication.
 </ParamField>
 
-<ParamField path="voice_id" type="str" default="YTpq7expH9539ERJ" deprecated>
+<ParamField path="voice_id" type="str" default="_6Aslh2DxfmnRLmP" deprecated>
   Voice identifier. _Deprecated in v0.0.105. Use
   `settings=GradiumTTSService.Settings(voice=...)` instead._
 </ParamField>
@@ -121,7 +121,7 @@ from pipecat.services.gradium import GradiumTTSService
 tts = GradiumTTSService(
     api_key=os.getenv("GRADIUM_API_KEY"),
     settings=GradiumTTSService.Settings(
-        voice="YTpq7expH9539ERJ",
+        voice="_6Aslh2DxfmnRLmP",
     ),
 )
 ```


### PR DESCRIPTION
## Summary
- Update the default voice ID for `GradiumTTSService` in the API reference from `YTpq7expH9539ERJ` to `_6Aslh2DxfmnRLmP` (two occurrences in `api-reference/server/services/tts/gradium.mdx`: the deprecated `voice_id` ParamField default and the example snippet).

## Test plan
- [ ] `mint dev` renders `api-reference/server/services/tts/gradium.mdx` without errors
- [ ] `mint broken-links` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)