### PR TITLE
docs: update for pipecat PR #4573

### DIFF
--- a/api-reference/server/services/s2s/inworld.mdx
+++ b/api-reference/server/services/s2s/inworld.mdx
@@ -99,9 +99,9 @@ Before using Inworld Realtime services, you need:
   (`inworld-tts-1.5-mini`). Shorthand for `session_properties.audio.output.model`.
 </ParamField>
 
-<ParamField path="stt_model" type="str" default="assemblyai/u3-rt-pro">
-  STT model for input transcription (e.g.
-  "assemblyai/universal-streaming-multilingual"). Shorthand for
+<ParamField path="stt_model" type="str" default="inworld/inworld-stt-1">
+  STT model for input transcription (e.g. "inworld/inworld-stt-1"). Defaults to
+  `"inworld/inworld-stt-1"`; pass `stt_model=` to override. Shorthand for
   `session_properties.audio.input.transcription.model`.
 </ParamField>
 
@@ -221,7 +221,7 @@ llm = InworldRealtimeLLMService(
     llm_model="openai/gpt-4.1-nano",
     voice="Sarah",
     tts_model="inworld-tts-2",
-    stt_model="assemblyai/universal-streaming-multilingual",
+    stt_model="inworld/inworld-stt-1",
 )
 ```
 
@@ -247,7 +247,7 @@ session_properties = SessionProperties(
         input=AudioInput(
             format=PCMAudioFormat(rate=24000),
             transcription=InputTranscription(
-                model="assemblyai/u3-rt-pro"
+                model="inworld/inworld-stt-1"
             ),
             turn_detection=TurnDetection(
                 type="semantic_vad",


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4573](https://github.com/pipecat-ai/pipecat/pull/4573).

## Changes
- `api-reference/server/services/s2s/inworld.mdx` — Updated default STT model from `assemblyai/u3-rt-pro` to `inworld/inworld-stt-1` in Configuration section and all code examples

## Gaps identified
None