### PR TITLE
docs: add Roark to Observability community integrations

### DIFF
--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -51,6 +51,7 @@ Observability services enable telemetry and metrics data to be passed to a Open 
 | [OpenInference](https://arize-ai.github.io/openinference/) | [openinference-instrumentation-pipecat](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-pipecat) | [Arize-ai](https://github.com/Arize-ai/openinference/graphs/contributors) |
 | [Finchvox](https://finchvox.dev/)                          | https://github.com/finchvox/finchvox                                                                                                                      | [Finchvox](https://github.com/finchvox)                                   |
 | [Future AGI](https://futureagi.com)                        | [traceAI-pipecat](https://github.com/future-agi/traceAI/tree/main/python/frameworks/pipecat)                                                              | [future-agi](https://github.com/future-agi)                               |
+| [Roark](https://roark.ai)                                  | https://github.com/roarkhq/sdk-roark-analytics-python-pipecat                                                                                             | [roarkhq](https://github.com/roarkhq)                                     |
 
 ## Speech-to-Text
 
@@ -77,17 +78,17 @@ Serializers convert between frames and media streams, enabling real-time communi
 
 Text-to-Speech services receive text input and output audio streams or chunks.
 
-| Service                                                          | Repository                                           | Maintainer(s)                                   |
-| ---------------------------------------------------------------- | ---------------------------------------------------- | ----------------------------------------------- |
-| [Deepdub](https://deepdub.ai/)                                   | https://github.com/deepdub-ai/pipecat-deepdub-tts    | [deepdub-ai](https://github.com/deepdub-ai)     |
-| [Murf AI](https://murf.ai/api)                                   | https://github.com/murf-ai/pipecat-murf-tts          | [murf-ai](https://github.com/murf-ai)           |
-| [Pipecat TTS Cache](https://pypi.org/project/pipecat-tts-cache/) | https://github.com/omChauhanDev/pipecat-tts-cache    | [omChauhanDev](https://github.com/omChauhanDev) |
-| [Respeecher](https://www.respeecher.com/real-time-tts-api)       | https://github.com/respeecher/pipecat-respeecher     | [respeecher](https://github.com/respeecher)     |
-| [Simplismart](https://simplismart.ai)                            | https://github.com/simpli-smart/pipecat-simplismart  | [simpli-smart](https://github.com/simpli-smart) |
+| Service                                                          | Repository                                                   | Maintainer(s)                                                       |
+| ---------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------- |
+| [Deepdub](https://deepdub.ai/)                                   | https://github.com/deepdub-ai/pipecat-deepdub-tts            | [deepdub-ai](https://github.com/deepdub-ai)                         |
+| [Murf AI](https://murf.ai/api)                                   | https://github.com/murf-ai/pipecat-murf-tts                  | [murf-ai](https://github.com/murf-ai)                               |
+| [Pipecat TTS Cache](https://pypi.org/project/pipecat-tts-cache/) | https://github.com/omChauhanDev/pipecat-tts-cache            | [omChauhanDev](https://github.com/omChauhanDev)                     |
+| [Respeecher](https://www.respeecher.com/real-time-tts-api)       | https://github.com/respeecher/pipecat-respeecher             | [respeecher](https://github.com/respeecher)                         |
+| [Simplismart](https://simplismart.ai)                            | https://github.com/simpli-smart/pipecat-simplismart          | [simpli-smart](https://github.com/simpli-smart)                     |
 | [Supertonic](https://github.com/supertone-inc/supertonic)        | https://github.com/architjambhule66-debug/pipecat-supertonic | [architjambhule66-debug](https://github.com/architjambhule66-debug) |
-| [Typecast](https://typecast.ai/)                                 | https://github.com/neosapience/pipecat-typecast      | [neosapience](https://github.com/neosapience)   |
-| [Uplift AI](https://upliftai.org)                                | https://github.com/havkerboi123/pipecat-upliftai-tts | [havkerboi123](https://github.com/havkerboi123) |
-| [Voice.ai](https://voice.ai/)                                    | https://github.com/voice-ai/voice-ai-pipecat-tts     | [voice-ai](https://github.com/voice-ai)         |
+| [Typecast](https://typecast.ai/)                                 | https://github.com/neosapience/pipecat-typecast              | [neosapience](https://github.com/neosapience)                       |
+| [Uplift AI](https://upliftai.org)                                | https://github.com/havkerboi123/pipecat-upliftai-tts         | [havkerboi123](https://github.com/havkerboi123)                     |
+| [Voice.ai](https://voice.ai/)                                    | https://github.com/voice-ai/voice-ai-pipecat-tts             | [voice-ai](https://github.com/voice-ai)                             |
 
 ## Translation
 


### PR DESCRIPTION
## Summary

Adds [Roark](https://roark.ai) to the Observability community integrations, alongside OpenInference, Finchvox, and Future AGI.

- `api-reference/server/services/community-integrations.mdx` — new row in the Observability table.

## What the integration does

[`pipecat-roark`](https://github.com/roarkhq/sdk-roark-analytics-python-pipecat) ([PyPI](https://pypi.org/project/pipecat-roark/)) is a Pipecat `BaseObserver` that captures call lifecycle events, transcripts, tool calls, and recordings from any Pipecat pipeline and ships them to the Roark analytics dashboard via webhook + presigned upload. It is not an OpenTelemetry exporter, so no `opentelemetry.mdx` changes are needed.

Wire-up is a one-liner on `PipelineTask`:

```python
from pipecat_roark import RoarkObserver

task = PipelineTask(pipeline, observers=[RoarkObserver(...)])
```

- Repository: https://github.com/roarkhq/sdk-roark-analytics-python-pipecat
- Maintainer: @roarkhq

## Demo video

https://github.com/user-attachments/assets/b63570d7-f388-4633-8325-b0a8f3df8023




## Test plan

- [x] `npx prettier --write` run on the edited file
- [ ] Maintainer review of placement (Observability table row)