### PR TITLE
docs: update for pipecat PR #4512

### DIFF
--- a/api-reference/server/services/stt/nvidia.mdx
+++ b/api-reference/server/services/stt/nvidia.mdx
@@ -183,6 +183,7 @@ stt = NvidiaSTTService(
 
 - **Model cannot be changed after initialization**: Use the `model_function_map` parameter in the constructor to specify the model and function ID.
 - **Streaming**: Provides real-time interim and final results through continuous audio streaming.
+- **Automatic reconnection**: The service automatically reconnects if the gRPC stream drops unexpectedly, maintaining continuous transcription.
 - **Metrics support**: This service supports metrics generation (`can_generate_metrics()` returns `True`).
 
 ## NvidiaSegmentedSTTService


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4512](https://github.com/pipecat-ai/pipecat/pull/4512).

## Changes

- **api-reference/server/services/stt/nvidia.mdx**: Added note about automatic reconnection for `NvidiaSTTService`. The service now automatically reconnects if the gRPC stream drops unexpectedly, maintaining continuous transcription. This aligns with how other STT services document their reconnection behavior.

## Gaps identified

None - the PR only modified internal implementation details of the NVIDIA STT service. The automatic reconnection is a reliability improvement that enhances existing streaming functionality without changing the public API (no new parameters, settings, or event handlers).