### PR TITLE
docs: update for pipecat-cli PR #88

### DIFF
--- a/api-reference/cli/init.mdx
+++ b/api-reference/cli/init.mdx
@@ -36,11 +36,13 @@ pipecat init [OPTIONS]
 </ParamField>
 
 <ParamField path="--stt" type="string">
-  Speech-to-Text service (cascade mode). e.g. `deepgram_stt`, `openai_stt`.
+  Speech-to-Text service (cascade mode). e.g. `deepgram_stt`, `openai_stt`,
+  `cartesia_turns_stt`.
 </ParamField>
 
 <ParamField path="--llm" type="string">
-  Language model service (cascade mode). e.g. `openai_llm`, `anthropic_llm`.
+  Language model service (cascade mode). e.g. `openai_llm`, `anthropic_llm`,
+  `inception_llm`.
 </ParamField>
 
 <ParamField path="--tts" type="string">
@@ -219,8 +221,8 @@ Output:
     "web": ["daily", "smallwebrtc"],
     "telephony": ["twilio", "twilio_daily_sip_dialin", "twilio_daily_sip_dialout", ...]
   },
-  "stt": ["deepgram_stt", "mistral_stt", "openai_stt", "xai_stt", ...],
-  "llm": ["openai_llm", "anthropic_llm", ...],
+  "stt": ["deepgram_stt", "mistral_stt", "openai_stt", "cartesia_turns_stt", "xai_stt", ...],
+  "llm": ["openai_llm", "anthropic_llm", "inception_llm", ...],
   "tts": ["cartesia_tts", "elevenlabs_tts", "soniox_tts", ...],
   "realtime": ["openai_realtime", "gemini_live_realtime", ...],
   "video": ["heygen_video", "tavus_video", "simli_video"]


### PR DESCRIPTION
Automated documentation update for [pipecat-cli PR #88](https://github.com/pipecat-ai/pipecat-cli/pull/88).

## Changes

**api-reference/cli/init.mdx:**
- Added `cartesia_turns_stt` to STT service examples (new Cartesia Turns STT service added in pipecat 1.3.0)
- Added `inception_llm` to LLM service examples (new Inception LLM service added in pipecat 1.3.0)
- Updated `--list-options` JSON output example to include both new services

## Gaps identified

None - all relevant changes have been documented. The PR also updated generated project templates to use the new Worker API (PipelineWorker/WorkerRunner instead of PipelineTask/PipelineRunner), but this is an internal implementation detail that doesn't affect the CLI documentation.