### PR TITLE
docs: update for pipecat PR #4592

### DIFF
--- a/api-reference/server/utilities/turn-management/filter-incomplete-turns.mdx
+++ b/api-reference/server/utilities/turn-management/filter-incomplete-turns.mdx
@@ -101,11 +101,12 @@ The following `LLMUserAggregatorParams` fields predate `FilterIncompleteUserTurn
   default="False"
   deprecated
 >
-  Enable LLM-based turn completion detection. When `True`, the system
-  automatically appends turn completion instructions to the LLM's system prompt
-  and configures the LLM service to process turn markers. *Deprecated in v1.2.0.
-  Use `user_turn_strategies=FilterIncompleteUserTurnStrategies()` instead. Will
-  be removed in v2.0.0.*
+  When enabled, the LLM outputs a turn-completion marker at the start of each
+  response: ✓ (complete), ○ (incomplete short), or ◐ (incomplete long).
+  Incomplete responses are suppressed and timeouts trigger re-prompting.
+  *Deprecated in v1.2.0. Use
+  `user_turn_strategies=FilterIncompleteUserTurnStrategies()` instead. Will be
+  removed in v2.0.0.*
 </ParamField>
 
 <ParamField
@@ -114,10 +115,12 @@ The following `LLMUserAggregatorParams` fields predate `FilterIncompleteUserTurn
   default="None"
   deprecated
 >
-  Optional configuration object for customizing turn completion behavior. If not
-  provided, default values are used. *Deprecated in v1.2.0. Pass the config
-  directly to `FilterIncompleteUserTurnStrategies(config=...)` instead. Will be
-  removed in v2.0.0.*
+  Configuration for turn completion behavior including custom instructions,
+  timeouts, and prompts. Only used when `filter_incomplete_user_turns` is `True`
+  (deprecated path) — for the new strategy-based API, pass the config directly
+  to `FilterIncompleteUserTurnStrategies(config=...)`. *Deprecated in v1.2.0.
+  Pass the config directly to `FilterIncompleteUserTurnStrategies(config=...)`
+  instead. Will be removed in v2.0.0.*
 </ParamField>
 
 ## UserTurnCompletionConfig


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4592](https://github.com/pipecat-ai/pipecat/pull/4592).

## Changes

**api-reference/server/utilities/turn-management/filter-incomplete-turns.mdx**

Updated the deprecated parameter descriptions for `filter_incomplete_user_turns` and `user_turn_completion_config` to align with the source code changes in pipecat PR #4592:

- **filter_incomplete_user_turns**: Updated description to lead with the functional explanation (turn-completion markers: ✓, ○, ◐) instead of generic "Enable LLM-based turn completion detection" text. This matches the source docstring which now presents functionality first, followed by the deprecation directive.

- **user_turn_completion_config**: Enhanced description to clarify that this parameter is only used when `filter_incomplete_user_turns` is `True` (the deprecated path), and that the new strategy-based API should use `FilterIncompleteUserTurnStrategies(config=...)` instead.

Both parameters retain their `deprecated` attribute and deprecation notices, consistent with the Sphinx `.. deprecated::` directive in the source.

## Gaps identified

None