### PR TITLE
docs: update for pipecat PR #4535

### DIFF
--- a/api-reference/server/services/tts/smallest.mdx
+++ b/api-reference/server/services/tts/smallest.mdx
@@ -57,6 +57,12 @@ export SMALLEST_API_KEY=your_api_key
   sample rate.
 </ParamField>
 
+<ParamField path="output_format" type="str" default="pcm">
+  Audio format returned by the API. One of `pcm`, `mp3`, `wav`, `ulaw`, `alaw`.
+  Defaults to `pcm`, which is what Pipecat expects internally. Fixed at init
+  time.
+</ParamField>
+
 <ParamField path="settings" type="SmallestTTSService.Settings" default="None">
   Runtime-configurable settings. See [Settings](#settings) below.
 </ParamField>
@@ -65,21 +71,13 @@ export SMALLEST_API_KEY=your_api_key
 
 Runtime-configurable settings passed via the `settings` constructor argument using `SmallestTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter     | Type              | Default          | Description                                                                                                               |
-| ------------- | ----------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `model`       | `str`             | `lightning-v3.1` | Model identifier: `lightning-v2` or `lightning-v3.1`. Model changes require WebSocket reconnection. _(Init-only setting)_ |
-| `voice`       | `str`             | `sophia`         | Voice identifier.                                                                                                         |
-| `language`    | `Language \| str` | `Language.EN`    | Language code for synthesis.                                                                                              |
-| `speed`       | `float`           | `None`           | Speech speed multiplier. When `None`, uses API defaults.                                                                  |
-| `consistency` | `float`           | `None`           | Consistency level for voice generation (0-1). Only supported by `lightning-v2`. When `None`, uses API defaults.           |
-| `similarity`  | `float`           | `None`           | Similarity level for voice generation (0-1). Only supported by `lightning-v2`. When `None`, uses API defaults.            |
-| `enhancement` | `int`             | `None`           | Enhancement level for voice generation (0-2). Only supported by `lightning-v2`. When `None`, uses API defaults.           |
+| Parameter  | Type              | Default                | Description                                                    |
+| ---------- | ----------------- | ---------------------- | -------------------------------------------------------------- |
+| `model`    | `str`             | `lightning_v3.1_pro`   | Model identifier: `lightning_v3.1` or `lightning_v3.1_pro`.    |
+| `voice`    | `str`             | `meher`                | Voice identifier. Default is `meher` for `lightning_v3.1_pro`. |
+| `language` | `Language \| str` | `Language.EN`          | Language code for synthesis.                                   |
+| `speed`    | `float`           | `None`                 | Speech speed multiplier (0.5–2.0). When `None`, uses API defaults. |
 
-<Note>
-  `None` values use the Smallest AI API defaults. The `consistency`,
-  `similarity`, and `enhancement` parameters are only supported by the
-  `lightning-v2` model.
-</Note>
 
 ## Usage
 
@@ -111,23 +109,6 @@ tts = SmallestTTSService(
 )
 ```
 
-### Using Lightning V2 Model
-
-```python
-from pipecat.services.smallest.tts import SmallestTTSModel
-
-tts = SmallestTTSService(
-    api_key=os.getenv("SMALLEST_API_KEY"),
-    settings=SmallestTTSService.Settings(
-        model=SmallestTTSModel.LIGHTNING_V2,
-        voice="sophia",
-        consistency=0.7,
-        similarity=0.8,
-        enhancement=1,
-    ),
-)
-```
-
 ### Updating Settings at Runtime
 
 Voice settings can be changed mid-conversation using `TTSUpdateSettingsFrame`:
@@ -146,16 +127,10 @@ await task.queue_frame(
 )
 ```
 
-<Tip>
-  Changing the `model` setting will trigger a WebSocket reconnection, which may
-  cause a brief interruption in service.
-</Tip>
-
 ## Notes
 
 - **WebSocket streaming**: The service uses WebSocket connections for real-time streaming. The connection is automatically managed and will reconnect if interrupted.
 - **Keepalive**: The service sends periodic keepalive messages (every 30 seconds) to prevent idle timeouts on the WebSocket connection.
-- **Model-specific parameters**: The `consistency`, `similarity`, and `enhancement` parameters are only effective when using the `lightning-v2` model. They are ignored by `lightning-v3.1`.
 - **Language support**: Supports multiple languages including Arabic, Bengali, German, English, Spanish, French, Gujarati, Hebrew, Hindi, Italian, Kannada, Marathi, Dutch, Polish, Russian, and Tamil.
 
 ## Event Handlers


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4535](https://github.com/pipecat-ai/pipecat/pull/4535).

## Changes

Updated `api-reference/server/services/tts/smallest.mdx` to reflect Smallest AI TTS Waves v4.0.0 API changes:

- **Configuration**: Added `output_format` parameter supporting `pcm`, `mp3`, `wav`, `ulaw`, `alaw`
- **Model updates**: 
  - Default model changed to `lightning_v3.1_pro` (with underscore, not hyphen)
  - Available models updated to use underscore convention: `lightning_v3.1` and `lightning_v3.1_pro`
  - Removed `lightning-v2` model
- **Voice defaults**: Updated default voice to `meher` (for `lightning_v3.1_pro`)
- **Removed settings**: Deleted `consistency`, `similarity`, and `enhancement` parameters (no longer supported in v4.0.0)
- **Behavioral change**: Removed note about model changes requiring reconnection (model is now sent in payload)
- **Usage examples**: Removed "Using Lightning V2 Model" section

## Gaps identified

None