### PR TITLE
docs: update for pipecat-cli PR #89

### DIFF
--- a/api-reference/cli/init.mdx
+++ b/api-reference/cli/init.mdx
@@ -27,8 +27,8 @@ pipecat init [OPTIONS]
 
 <ParamField path="--transport / -t" type="string">
   Transport provider. Repeatable for multiple transports (e.g. `-t daily -t
-  smallwebrtc`). Valid values: `daily`, `smallwebrtc`, `twilio`, `telnyx`,
-  `plivo`, `exotel`, `daily_pstn`, `twilio_daily_sip`.
+  smallwebrtc`). Valid values: `daily`, `smallwebrtc`, `websocket`, `twilio`,
+  `telnyx`, `plivo`, `exotel`, `daily_pstn`, `twilio_daily_sip`.
 </ParamField>
 
 <ParamField path="--mode / -m" type="string">
@@ -216,7 +216,7 @@ Output:
 {
   "bot_type": ["web", "telephony"],
   "transports": {
-    "web": ["daily", "smallwebrtc"],
+    "web": ["daily", "smallwebrtc", "websocket"],
     "telephony": ["twilio", "twilio_daily_sip_dialin", "twilio_daily_sip_dialout", ...]
   },
   "stt": ["deepgram_stt", "mistral_stt", "openai_stt", "xai_stt", ...],


### PR DESCRIPTION
Automated documentation update for [pipecat-cli PR #89](https://github.com/pipecat-ai/pipecat-cli/pull/89).

## Changes

**`api-reference/cli/init.mdx`** — Added `websocket` as a valid transport option:
- Updated `--transport` parameter description to include `websocket` in the list of valid values
- Updated `--list-options` JSON output example to show `websocket` in the web transports list

## Gaps identified

None — all relevant changes from PR #89 have been documented.