### PR TITLE
docs: update for pipecat-flows PR #277

### DIFF
--- a/api-reference/pipecat-flows/flow-manager.mdx
+++ b/api-reference/pipecat-flows/flow-manager.mdx
@@ -11,8 +11,16 @@ description: "Core orchestration class for managing conversation flows"
 
 All parameters are keyword-only.
 
-<ParamField path="task" type="PipelineWorker" required>
-  Pipeline task instance used for queueing frames into the pipeline.
+<ParamField path="worker" type="PipelineWorker" required>
+  Pipeline worker instance used for queueing frames into the pipeline.
+</ParamField>
+
+<ParamField path="task" type="PipelineWorker" deprecated>
+  **Deprecated:** Use `worker` instead. This parameter is deprecated and will be
+  removed in a future release.
+
+Pipeline worker instance used for queueing frames into the pipeline.
+
 </ParamField>
 
 <ParamField path="llm" type="LLMService | LLMSwitcher" required>
@@ -103,21 +111,34 @@ async def my_handler(args, flow_manager):
         await setup_secure_session(flow_manager)
 ```
 
+### worker
+
+```python
+flow_manager.worker -> PipelineWorker
+```
+
+The pipeline worker instance used for frame queueing. Use this for advanced flow control such as queuing custom frames.
+
+```python
+async def my_handler(args, flow_manager):
+    from pipecat.frames.frames import TTSUpdateSettingsFrame
+    await flow_manager.worker.queue_frame(
+        TTSUpdateSettingsFrame(settings={"voice": "new-voice-id"})
+    )
+```
+
 ### task
+
+<Warning>
+  **Deprecated:** Use `worker` instead. This property is deprecated and will be
+  removed in a future release.
+</Warning>
 
 ```python
 flow_manager.task -> PipelineWorker
 ```
 
-The pipeline task instance used for frame queueing. Use this for advanced flow control such as queuing custom frames.
-
-```python
-async def my_handler(args, flow_manager):
-    from pipecat.frames.frames import TTSUpdateSettingsFrame
-    await flow_manager.task.queue_frame(
-        TTSUpdateSettingsFrame(settings={"voice": "new-voice-id"})
-    )
-```
+Alias for `worker`. Maintained for backward compatibility.
 
 ## Methods
 
@@ -136,7 +157,7 @@ Initialize the flow manager. Must be called before any node transitions can occu
 **Raises:** `FlowInitializationError` if initialization fails.
 
 ```python
-flow_manager = FlowManager(task=task, llm=llm, context_aggregator=context_aggregator)
+flow_manager = FlowManager(worker=worker, llm=llm, context_aggregator=context_aggregator)
 await flow_manager.initialize(initial_node=create_initial_node())
 ```
 
@@ -228,7 +249,7 @@ async def create_initial_node() -> NodeConfig:
     }
 
 flow_manager = FlowManager(
-    task=task,
+    worker=worker,
     llm=llm,
     context_aggregator=context_aggregator,
     transport=transport,
@@ -250,7 +271,7 @@ transfer_function = FlowsFunctionSchema(
 )
 
 flow_manager = FlowManager(
-    task=task,
+    worker=worker,
     llm=llm,
     context_aggregator=context_aggregator,
     global_functions=[transfer_function],

--- a/pipecat-flows/guides/quickstart.mdx
+++ b/pipecat-flows/guides/quickstart.mdx
@@ -132,11 +132,11 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         ]
     )
 
-    task = PipelineWorker(pipeline)
+    worker = PipelineWorker(pipeline)
 
     # Initialize flow manager
     flow_manager = FlowManager(
-        task=task,
+        worker=worker,
         llm=llm,
         context_aggregator=context_aggregator,
         transport=transport,
@@ -147,7 +147,8 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         await flow_manager.initialize(create_initial_node())
 
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-    await runner.run(task)
+    await runner.add_workers(worker)
+    await runner.run()
 ```
 
 That's it! When a user connects, the bot greets them, asks for their favorite color, records the answer, thanks them, and ends the conversation.

--- a/pipecat-flows/guides/state-management.mdx
+++ b/pipecat-flows/guides/state-management.mdx
@@ -11,7 +11,7 @@ First, create the FlowManager:
 
 ```python
 flow_manager = FlowManager(
-    task=task,                              # PipelineWorker
+    worker=worker,                          # PipelineWorker
     llm=llm,                                # LLMService
     context_aggregator=context_aggregator,  # Context aggregator
     transport=transport,                    # Transport
@@ -52,7 +52,7 @@ Pipecat Flows supports defining functions that are available across all nodes in
 
 ```python
 flow_manager = FlowManager(
-    task=task,
+    worker=worker,
     llm=llm,
     context_aggregator=context_aggregator,
     transport=transport,


### PR DESCRIPTION
Automated documentation update for [pipecat-flows PR #277](https://github.com/pipecat-ai/pipecat-flows/pull/277).

## Changes

### API Reference
- **api-reference/pipecat-flows/flow-manager.mdx**
  - Added `worker` parameter (required) to replace deprecated `task` parameter
  - Added deprecation notice for `task` parameter
  - Added new `worker` property documentation
  - Updated `task` property with deprecation warning and backward compatibility note
  - Updated all code examples to use `worker` instead of `task`

### Guides
- **pipecat-flows/guides/state-management.mdx**
  - Updated FlowManager initialization examples to use `worker` parameter
  - Updated variable names from `task` to `worker` for clarity

- **pipecat-flows/guides/quickstart.mdx**
  - Updated variable name from `task` to `worker`
  - Updated FlowManager initialization to use `worker` parameter
  - Updated WorkerRunner usage to use new pattern: `runner.add_workers(worker)` + `runner.run()`

## Gaps identified

None — all documentation changes align with the API migration in PR #277.