### PR TITLE
Add Lokutor TTS community integration

### DIFF
--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -81,6 +81,7 @@ Text-to-Speech services receive text input and output audio streams or chunks.
 | Service                                                          | Repository                                                   | Maintainer(s)                                                       |
 | ---------------------------------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------- |
 | [Deepdub](https://deepdub.ai/)                                   | https://github.com/deepdub-ai/pipecat-deepdub-tts            | [deepdub-ai](https://github.com/deepdub-ai)                         |
+| [Lokutor](https://lokutor.com)                                   | https://github.com/lokutor-ai/pipecat-lokutor                | [danivs10](https://github.com/danivs10)                            |
 | [Murf AI](https://murf.ai/api)                                   | https://github.com/murf-ai/pipecat-murf-tts                  | [murf-ai](https://github.com/murf-ai)                               |
 | [Pipecat TTS Cache](https://pypi.org/project/pipecat-tts-cache/) | https://github.com/omChauhanDev/pipecat-tts-cache            | [omChauhanDev](https://github.com/omChauhanDev)                     |
 | [Respeecher](https://www.respeecher.com/real-time-tts-api)       | https://github.com/respeecher/pipecat-respeecher             | [respeecher](https://github.com/respeecher)                         |


### PR DESCRIPTION
Adds [Lokutor TTS](https://github.com/lokutor-ai/pipecat-lokutor) as a community TTS integration for Pipecat.

**Repository:** https://github.com/lokutor-ai/pipecat-lokutor
**PyPI:** `pip install pipecat-lokutor`
**Maintainer:** danivs10

**Demo:** https://drive.google.com/file/d/1GDdG7_VHgiSO_I7dfF_o46fcHzcvnyEH/view