### PR TITLE
docs: update for pipecat PR #4621

### DIFF
--- a/api-reference/server/services/tts/cartesia.mdx
+++ b/api-reference/server/services/tts/cartesia.mdx
@@ -159,12 +159,12 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 | `model`                 | `str`              | `None`      | TTS model identifier. Defaults to `sonic-3.5` when not specified. _(Inherited from base settings.)_ |
 | `voice`                 | `str`              | `None`      | Voice identifier. _(Inherited from base settings.)_           |
 | `language`              | `Language \| str`  | `None`      | Language for synthesis. _(Inherited from base settings.)_     |
-| `generation_config`     | `GenerationConfig` | `NOT_GIVEN` | Generation configuration for Sonic-3 models. See below.       |
+| `generation_config`     | `GenerationConfig` | `NOT_GIVEN` | Generation configuration for Cartesia models. See below.       |
 | `pronunciation_dict_id` | `str`              | `NOT_GIVEN` | ID of the pronunciation dictionary for custom pronunciations. |
 
-#### GenerationConfig (Sonic-3)
+#### GenerationConfig
 
-Configuration for Sonic-3 generation parameters:
+Configuration for Cartesia generation parameters. Applicable to sonic-3 and sonic-3.5 models:
 
 | Parameter | Type    | Default | Description                                                                                           |
 | --------- | ------- | ------- | ----------------------------------------------------------------------------------------------------- |
@@ -187,7 +187,7 @@ tts = CartesiaTTSService(
 )
 ```
 
-### With Sonic-3 Generation Config
+### With Generation Config
 
 ```python
 from pipecat.services.cartesia.tts import GenerationConfig


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4621](https://github.com/pipecat-ai/pipecat/pull/4621).

## Changes
- **api-reference/server/services/tts/cartesia.mdx**: Updated Cartesia TTS documentation to reflect that `GenerationConfig` applies to both sonic-3 and sonic-3.5 models:
  - Changed "Generation configuration for Sonic-3 models" to "Generation configuration for Cartesia models" in the Settings table
  - Updated "GenerationConfig (Sonic-3)" section header to "GenerationConfig" with clarification that it applies to sonic-3 and sonic-3.5 models
  - Changed "With Sonic-3 Generation Config" example section to "With Generation Config" to be model-agnostic

## Gaps identified
None