### PR TITLE
docs: update for pipecat PR #4620

### DIFF
--- a/api-reference/server/services/stt/azure.mdx
+++ b/api-reference/server/services/stt/azure.mdx
@@ -104,10 +104,11 @@ Before using Azure STT services, you need:
 
 Runtime-configurable settings passed via the `settings` constructor argument using `AzureSTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter  | Type              | Default          | Description                                                            |
-| ---------- | ----------------- | ---------------- | ---------------------------------------------------------------------- |
-| `model`    | `str`             | `None`           | STT model identifier. _(Inherited from base STT settings.)_            |
-| `language` | `Language \| str` | `Language.EN_US` | Language for speech recognition. _(Inherited from base STT settings.)_ |
+| Parameter   | Type                                 | Default          | Description                                                                                                                                                                                                                                                                                                                                                              |
+| ----------- | ------------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `model`     | `str`                                | `None`           | STT model identifier. _(Inherited from base STT settings.)_                                                                                                                                                                                                                                                                                                              |
+| `language`  | `Language \| str`                    | `Language.EN_US` | Language for speech recognition. _(Inherited from base STT settings.)_                                                                                                                                                                                                                                                                                                   |
+| `profanity` | `"raw" \| "masked" \| "removed"`     | `None`           | How Azure handles profanity in transcripts. `"raw"` returns text as recognized with no masking, `"masked"` replaces profane words with `****` (Azure default), `"removed"` drops profane words. Default `None` keeps Azure SDK default (`"masked"`). Use `"raw"` for non-English deployments where Azure's profanity filter over-eagerly masks ordinary words. |
 
 ## Usage
 
@@ -137,6 +138,21 @@ stt = AzureSTTService(
 )
 ```
 
+### With Profanity Filtering
+
+```python
+from pipecat.services.azure.stt import AzureSTTService
+
+# Disable profanity masking for non-English deployments
+stt = AzureSTTService(
+    api_key=os.getenv("AZURE_SPEECH_API_KEY"),
+    region="westus2",
+    settings=AzureSTTService.Settings(
+        profanity="raw",  # No masking
+    ),
+)
+```
+
 <Tip>
   The `InputParams` / `params=` pattern is deprecated as of v0.0.105. Use
   `Settings` / `settings=` instead. See the [Service Settings
@@ -147,5 +163,6 @@ stt = AzureSTTService(
 
 - **SDK-based (not WebSocket)**: Unlike most other STT services in Pipecat, Azure STT uses the Azure Cognitive Services Speech SDK rather than a raw WebSocket connection. Recognition callbacks run on SDK-managed threads and are bridged to asyncio via `asyncio.run_coroutine_threadsafe`.
 - **Continuous recognition**: The service uses Azure's `start_continuous_recognition_async` for always-on transcription. It provides both interim (`recognizing`) and final (`recognized`) results automatically.
+- **Finalized transcripts**: Azure's `RecognizedSpeech` events are marked as finalized (`TranscriptionFrame(finalized=True)`). This enables downstream user-turn stop strategies (e.g., `SpeechTimeoutUserTurnStop`) to take their fast-path instead of waiting for VAD events, which may not arrive on short utterances.
 - **Custom endpoints**: Use the `endpoint_id` parameter to point to a custom speech model deployed in your Azure subscription for domain-specific accuracy improvements.
 - **Region vs private endpoint**: Either `region` or `private_endpoint` must be provided (but not both). If both are specified, `private_endpoint` takes priority and a warning is logged. If neither is provided, a `ValueError` is raised.


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4620](https://github.com/pipecat-ai/pipecat/pull/4620).

## Changes
- **api-reference/server/services/stt/azure.mdx** — Added `profanity` parameter to Settings table, documented finalized transcript behavior, and added usage example for profanity filtering

## Gaps identified
None