### PR TITLE
docs: update for pipecat PR #4612

### DIFF
--- a/api-reference/server/services/tts/smallest.mdx
+++ b/api-reference/server/services/tts/smallest.mdx
@@ -63,6 +63,15 @@ export SMALLEST_API_KEY=your_api_key
   time.
 </ParamField>
 
+<ParamField path="word_timestamps" type="bool" default="True">
+  Whether to request per-word timing events. When `True`, the server interleaves
+  word timestamp messages and the service emits aligned per-word `TTSTextFrame`s
+  for downstream consumers (captions, lip-sync, RTVI). Supported on base-queue
+  English and Hindi voices (`meher`, `devansh`, `kartik`, `maithili`, `liam`,
+  `avery`); other voices silently emit no word events, so leaving this on is
+  safe regardless of voice. Fixed at init time.
+</ParamField>
+
 <ParamField path="settings" type="SmallestTTSService.Settings" default="None">
   Runtime-configurable settings. See [Settings](#settings) below.
 </ParamField>
@@ -71,13 +80,12 @@ export SMALLEST_API_KEY=your_api_key
 
 Runtime-configurable settings passed via the `settings` constructor argument using `SmallestTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter  | Type              | Default                | Description                                                    |
-| ---------- | ----------------- | ---------------------- | -------------------------------------------------------------- |
-| `model`    | `str`             | `lightning_v3.1_pro`   | Model identifier: `lightning_v3.1` or `lightning_v3.1_pro`.    |
-| `voice`    | `str`             | `meher`                | Voice identifier. Default is `meher` for `lightning_v3.1_pro`. |
-| `language` | `Language \| str` | `Language.EN`          | Language code for synthesis.                                   |
-| `speed`    | `float`           | `None`                 | Speech speed multiplier (0.5–2.0). When `None`, uses API defaults. |
-
+| Parameter  | Type              | Default              | Description                                                        |
+| ---------- | ----------------- | -------------------- | ------------------------------------------------------------------ |
+| `model`    | `str`             | `lightning_v3.1_pro` | Model identifier: `lightning_v3.1` or `lightning_v3.1_pro`.        |
+| `voice`    | `str`             | `meher`              | Voice identifier. Default is `meher` for `lightning_v3.1_pro`.     |
+| `language` | `Language \| str` | `Language.EN`        | Language code for synthesis.                                       |
+| `speed`    | `float`           | `None`               | Speech speed multiplier (0.5–2.0). When `None`, uses API defaults. |
 
 ## Usage
 
@@ -131,6 +139,7 @@ await task.queue_frame(
 
 - **WebSocket streaming**: The service uses WebSocket connections for real-time streaming. The connection is automatically managed and will reconnect if interrupted.
 - **Keepalive**: The service sends periodic keepalive messages (every 30 seconds) to prevent idle timeouts on the WebSocket connection.
+- **Word timestamps**: When enabled (the default), word-level timing events are emitted as per-word `TTSTextFrame`s aligned to audio playback. Multiple TTS requests within a turn are automatically offset onto a continuous timeline. Supported on specific voices (`meher`, `devansh`, `kartik`, `maithili`, `liam`, `avery`); other voices produce no word events but function normally.
 - **Language support**: Supports multiple languages including Arabic, Bengali, German, English, Spanish, French, Gujarati, Hebrew, Hindi, Italian, Kannada, Marathi, Dutch, Polish, Russian, and Tamil.
 
 ## Event Handlers

--- a/api-reference/server/services/tts/smallest.mdx
+++ b/api-reference/server/services/tts/smallest.mdx
@@ -57,6 +57,15 @@ export SMALLEST_API_KEY=your_api_key
   sample rate.
 </ParamField>
 
+<ParamField path="word_timestamps" type="bool" default="True">
+  Whether to request per-word timing events. When `True`, the server interleaves
+  word timestamp messages and the service emits aligned per-word `TTSTextFrame`s
+  for downstream consumers (captions, lip-sync, RTVI). Supported on base-queue
+  English and Hindi voices (`meher`, `devansh`, `kartik`, `maithili`, `liam`,
+  `avery`); other voices silently emit no word events, so leaving this on is safe
+  regardless of voice. Fixed at init time.
+</ParamField>
+
 <ParamField path="settings" type="SmallestTTSService.Settings" default="None">
   Runtime-configurable settings. See [Settings](#settings) below.
 </ParamField>
@@ -155,6 +164,7 @@ await task.queue_frame(
 
 - **WebSocket streaming**: The service uses WebSocket connections for real-time streaming. The connection is automatically managed and will reconnect if interrupted.
 - **Keepalive**: The service sends periodic keepalive messages (every 30 seconds) to prevent idle timeouts on the WebSocket connection.
+- **Word timestamps**: When enabled (the default), word-level timing events are emitted as per-word `TTSTextFrame`s aligned to audio playback. Multiple TTS requests within a turn are automatically offset onto a continuous timeline. Supported on specific voices (`meher`, `devansh`, `kartik`, `maithili`, `liam`, `avery`); other voices produce no word events but function normally.
 - **Model-specific parameters**: The `consistency`, `similarity`, and `enhancement` parameters are only effective when using the `lightning-v2` model. They are ignored by `lightning-v3.1`.
 - **Language support**: Supports multiple languages including Arabic, Bengali, German, English, Spanish, French, Gujarati, Hebrew, Hindi, Italian, Kannada, Marathi, Dutch, Polish, Russian, and Tamil.
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4612](https://github.com/pipecat-ai/pipecat/pull/4612).

## Changes

**api-reference/server/services/tts/smallest.mdx**:
- Added `word_timestamps` configuration parameter documentation (defaults to `True`)
- Added note explaining word timestamp behavior: emits per-word `TTSTextFrame`s aligned to audio playback, supports specific voices (meher, devansh, kartik, maithili, liam, avery)

## Gaps identified

None