### PR TITLE
docs: update for pipecat PR #4626

### DIFF
--- a/api-reference/server/services/memory/mem0.mdx
+++ b/api-reference/server/services/memory/mem0.mdx
@@ -101,14 +101,14 @@ Before using Mem0 memory services, you need:
 
 ### InputParams
 
-| Parameter               | Type    | Default                                             | Description                                                                      |
-| ----------------------- | ------- | --------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `search_limit`          | `int`   | `10`                                                | Maximum number of memories to retrieve per query (min: 1).                       |
-| `search_threshold`      | `float` | `0.1`                                               | Minimum similarity threshold for memory retrieval (0.0-1.0).                     |
-| `api_version`           | `str`   | `"v2"`                                              | API version to use for Mem0 client operations.                                   |
-| `system_prompt`         | `str`   | `"Based on previous conversations, I recall: \n\n"` | Prefix text for memory context messages.                                         |
-| `add_as_system_message` | `bool`  | `True`                                              | Whether to add memories as system messages. When `False`, adds as user messages. |
-| `position`              | `int`   | `1`                                                 | Position to insert memory messages in context.                                   |
+| Parameter               | Type         | Default                                             | Description                                                                                                                                                  |
+| ----------------------- | ------------ | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `search_limit`          | `int`        | `10`                                                | Maximum number of memories to retrieve per query (min: 1).                                                                                                   |
+| `search_threshold`      | `float`      | `0.1`                                               | Minimum similarity threshold for memory retrieval (0.0-1.0).                                                                                                 |
+| `api_version`           | `str \| None` | `None`                                              | **Deprecated in 1.4.0**. No longer used. Mem0 2.0.0 removed the `api_version`/`output_format` parameters from the client. Will be removed in a future release. |
+| `system_prompt`         | `str`        | `"Based on previous conversations, I recall: \n\n"` | Prefix text for memory context messages.                                                                                                                     |
+| `add_as_system_message` | `bool`       | `True`                                              | Whether to add memories as system messages. When `False`, adds as user messages.                                                                             |
+| `position`              | `int`        | `1`                                                 | Position to insert memory messages in context.                                                                                                               |
 
 ## Usage
 
@@ -171,6 +171,7 @@ else:
 
 ## Notes
 
+- **Mem0 2.0.0 upgrade**: Pipecat 1.4.0 upgraded to `mem0ai>=2,<3` to support Mem0 2.0.0. The `api_version` parameter is deprecated and no longer used. Additionally, `add()` operations are now async server-side, meaning newly stored memories are only queryable once processed by Mem0.
 - **At least one ID required**: You must provide at least one of `user_id`, `agent_id`, or `run_id`. A `ValueError` is raised if none are provided.
 - **Cloud vs local**: Use `api_key` for Mem0's cloud API, or `local_config` for a self-hosted Mem0 instance using `Memory.from_config()`.
 - **Pipeline placement**: Place the `Mem0MemoryService` before your LLM service in the pipeline. It intercepts `LLMContextFrame` and `LLMMessagesFrame` to enhance context with relevant memories before passing them downstream.


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4626](https://github.com/pipecat-ai/pipecat/pull/4626).

## Changes

**Updated `api-reference/server/services/memory/mem0.mdx`**:
- Marked `api_version` parameter as deprecated in InputParams table (default changed from `"v2"` to `None`)
- Added note about mem0 2.0.0 upgrade and breaking changes (async `add()` operations, deprecated `api_version`/`output_format` parameters)
- Updated parameter type from `str` to `str | None` in table

## Gaps identified

None