### PR TITLE
docs: update for pipecat PR #4549

### DIFF
--- a/api-reference/server/services/tts/azure.mdx
+++ b/api-reference/server/services/tts/azure.mdx
@@ -60,7 +60,7 @@ Before using Azure TTS services, you need:
 ### Required Environment Variables
 
 - `AZURE_SPEECH_API_KEY`: Your Azure Speech service API key
-- `AZURE_SPEECH_REGION`: Your Azure Speech service region (e.g., "eastus")
+- `AZURE_SPEECH_REGION`: Your Azure Speech service region (e.g., "eastus") _or_ a custom endpoint URL when using Private Link
 
 ## Configuration
 
@@ -70,8 +70,16 @@ Before using Azure TTS services, you need:
   Azure Cognitive Services subscription key.
 </ParamField>
 
-<ParamField path="region" type="str" required>
-  Azure region identifier (e.g., `"eastus"`, `"westus2"`).
+<ParamField path="region" type="str">
+  Azure region identifier (e.g., `"eastus"`, `"westus2"`). Required unless
+  `private_endpoint` is provided.
+</ParamField>
+
+<ParamField path="private_endpoint" type="str">
+  Custom endpoint URL for Azure Speech Services (e.g.,
+  `"https://my-resource.cognitiveservices.azure.com/"`). Use this when
+  connecting via Private Link or a custom domain. See [Azure Private Link
+  documentation](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-services-private-link).
 </ParamField>
 
 <ParamField path="voice" type="str" default="en-US-SaraNeural" deprecated>
@@ -116,8 +124,14 @@ The HTTP service accepts the same parameters as the streaming service except `te
   Azure Cognitive Services subscription key.
 </ParamField>
 
-<ParamField path="region" type="str" required>
-  Azure region identifier.
+<ParamField path="region" type="str">
+  Azure region identifier. Required unless `private_endpoint` is provided.
+</ParamField>
+
+<ParamField path="private_endpoint" type="str">
+  Custom endpoint URL for Azure Speech Services. Use this when connecting via
+  Private Link or a custom domain. See [Azure Private Link
+  documentation](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/speech-services-private-link).
 </ParamField>
 
 <ParamField path="voice" type="str" default="en-US-SaraNeural" deprecated>
@@ -198,6 +212,20 @@ tts = AzureHttpTTSService(
     api_key=os.getenv("AZURE_SPEECH_API_KEY"),
     region=os.getenv("AZURE_SPEECH_REGION"),
     voice="en-US-SaraNeural",
+)
+```
+
+### With Private Endpoint
+
+```python
+from pipecat.services.azure import AzureTTSService
+
+tts = AzureTTSService(
+    api_key=os.getenv("AZURE_SPEECH_API_KEY"),
+    private_endpoint="https://my-resource.cognitiveservices.azure.com/",
+    settings=AzureTTSService.Settings(
+        voice="en-US-SaraNeural",
+    ),
 )
 ```
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4549](https://github.com/pipecat-ai/pipecat/pull/4549).

## Changes

Updated `api-reference/server/services/tts/azure.mdx`:
- Added `private_endpoint` parameter documentation for both `AzureTTSService` and `AzureHttpTTSService`
- Updated `region` parameter to indicate it's required only when `private_endpoint` is not provided
- Added usage example demonstrating private endpoint configuration
- Updated Prerequisites section to mention private endpoint as an alternative to region

## Summary

The pipecat PR added support for connecting to Azure Speech Services via Private Link or custom domain endpoints, matching the existing functionality in `AzureSTTService`. The documentation now reflects:
- Both services accept a new `private_endpoint` parameter
- The `region` parameter is now optional when `private_endpoint` is provided
- Either `region` or `private_endpoint` must be specified (validation is enforced)

## Gaps identified

None