### PR TITLE
docs: update for pipecat PR #4632

### DIFF
--- a/api-reference/server/services/stt/gradium.mdx
+++ b/api-reference/server/services/stt/gradium.mdx
@@ -116,7 +116,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 | ----------------- | ----------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `model`           | `str`             | `"default"` | STT model identifier. _(Inherited from base STT settings.)_                                                                                                                                                                                      |
 | `language`        | `Language \| str` | `None`      | Expected language of the audio. _(Inherited from base STT settings.)_ Helps ground the model to a specific language and improve transcription quality.                                                                                           |
-| `delay_in_frames` | `int`             | `None`      | Server-side delay in audio frames (80ms each) before text is generated. Higher delays allow more context but increase latency. Allowed values: 7, 8, 10, 12, 14, 16, 20, 24, 36, 48. Default is 10 (800ms). Sent to Gradium API via json_config. |
+| `delay_in_frames` | `int`             | `12`        | Server-side delay in audio frames (80ms each) before text is generated. Higher delays allow more context but increase latency. Allowed values: 7, 8, 10, 12, 14, 16, 20, 24, 36, 48. Default is 12 (960ms). Sent to Gradium API via json_config. |
 
 ## Usage
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4632](https://github.com/pipecat-ai/pipecat/pull/4632).

## Changes

- **api-reference/server/services/stt/gradium.mdx** — Updated Settings table: changed `delay_in_frames` default from `None` to `12`, updated description from "Default is 10 (800ms)" to "Default is 12 (960ms)"

## Gaps identified

None