### PR TITLE
docs: update for pipecat-cli PR #95

### DIFF
--- a/api-reference/cli/init.mdx
+++ b/api-reference/cli/init.mdx
@@ -8,13 +8,19 @@ Create a new Pipecat project with guided setup for bot type, transport, AI servi
 **Usage:**
 
 ```shell
-pipecat init [OPTIONS]
+pipecat init [TARGET] [OPTIONS]
 ```
+
+**Arguments:**
+
+<ParamField path="TARGET" type="string">
+  Optional target directory. Use `.` to scaffold into the current directory without creating a `<name>` subfolder (same convention as `npm create vite@latest .`). When provided, the project name defaults to the directory's basename unless overridden with `--name`. Omit this argument to create a `<name>` subfolder (legacy behavior).
+</ParamField>
 
 **Options:**
 
 <ParamField path="--output / -o" type="string">
-  Output directory where files will be saved. Defaults to current directory.
+  Output directory where files will be saved. Defaults to current directory. Creates a `<name>` subfolder within this directory. Mutually exclusive with `TARGET`.
 </ParamField>
 
 <ParamField path="--name / -n" type="string">
@@ -145,6 +151,7 @@ pipecat init [OPTIONS]
 
 When run without `--name` or `--config`, the CLI guides you through selecting:
 
+- **Project name** - Defaults to the target directory's basename if a `TARGET` was provided (e.g., `pc init .` uses the current directory name)
 - **Bot type and client framework** - Phone, web (Next.js, Vite, Vanilla JS), or mobile
 - **Transport provider** - Daily, Twilio, Telnyx, Plivo, Exotel
 - **Pipeline mode** - Cascade or Realtime
@@ -166,10 +173,27 @@ All required fields must be specified or the command exits with a list of all mi
 pipecat init
 ```
 
+### Scaffold Into Current Directory
+
+```shell
+# In-place mode: scaffolds into `.` without creating a subfolder
+# Project name is derived from the directory name
+pipecat init .
+```
+
 ### Non-Interactive (Cascade)
 
 ```shell
 pipecat init --name my-bot --bot-type web --transport daily \
+  --mode cascade --stt deepgram_stt --llm openai_llm --tts cartesia_tts
+```
+
+### In-Place With Custom Options
+
+```shell
+# Combine in-place scaffolding with non-interactive flags
+# Project name still derived from directory unless --name is provided
+pipecat init . --bot-type web --transport daily \
   --mode cascade --stt deepgram_stt --llm openai_llm --tts cartesia_tts
 ```
 
@@ -282,8 +306,28 @@ pipecat init --output my-bot
 
 ## Generated Project Structure
 
+When scaffolding with a project name (default behavior):
+
 ```
 mybot/
+├── server/                 # Python bot server
+│   ├── bot.py              # Main bot implementation
+│   ├── pyproject.toml      # Python dependencies
+│   ├── .env.example        # Environment variables template
+│   ├── Dockerfile          # Container image (if cloud enabled)
+│   └── pcc-deploy.toml     # Deployment config (if cloud enabled)
+├── client/                 # Web client (if generated)
+│   ├── src/
+│   ├── package.json
+│   └── ...
+├── .gitignore
+└── README.md               # Project setup instructions
+```
+
+When using in-place mode (`pc init .`), the files are created directly in the target directory without a project name subfolder:
+
+```
+./
 ├── server/                 # Python bot server
 │   ├── bot.py              # Main bot implementation
 │   ├── pyproject.toml      # Python dependencies


### PR DESCRIPTION
Automated documentation update for [pipecat-cli PR #95](https://github.com/pipecat-ai/pipecat-cli/pull/95).

## Changes

### `api-reference/cli/init.mdx`
- **Added TARGET argument documentation** - New optional positional argument allows scaffolding into a specific directory (e.g., `pc init .` scaffolds into current directory without creating a subfolder)
- **Updated usage syntax** - Changed from `pipecat init [OPTIONS]` to `pipecat init [TARGET] [OPTIONS]`
- **Updated --output parameter** - Noted that it's mutually exclusive with TARGET
- **Added new examples** - Demonstrated in-place scaffolding with `pc init .` and combined with non-interactive flags
- **Updated Interactive Setup section** - Documented that project name defaults to directory basename when TARGET is provided
- **Updated Generated Project Structure** - Added comparison showing the difference between standard (nested) and in-place scaffolding

## Gaps identified

None. All relevant source changes have been documented:
- `src/pipecat_cli/commands/init.py` → documented new TARGET argument and updated examples
- `src/pipecat_cli/generators/project.py` → documented in-place project structure
- `src/pipecat_cli/prompts/questions.py` → documented default name behavior
- `src/pipecat_cli/main.py` → internal change (init command registration), no user-facing impact

Guides referencing `pipecat init` use only the basic interactive mode or quickstart command, which remain unchanged.