### PR TITLE
docs: update for pipecat PR #4643

### DIFF
--- a/api-reference/server/services/llm/aws.mdx
+++ b/api-reference/server/services/llm/aws.mdx
@@ -75,8 +75,8 @@ Before using AWS Bedrock LLM services, you need:
 
 <ParamField path="aws_access_key" type="str" default="None">
   AWS access key ID. If `None`, falls back to environment variables and the
-  default boto3 credential chain (instance profiles, IRSA, ECS task roles, SSO,
-  etc.).
+  default botocore credential chain (instance profiles, IRSA, ECS task roles,
+  SSO, etc.).
 </ParamField>
 
 <ParamField path="aws_secret_key" type="str" default="None">
@@ -109,7 +109,7 @@ Before using AWS Bedrock LLM services, you need:
 </ParamField>
 
 <ParamField path="client_config" type="botocore.config.Config" default="None">
-  Custom boto3 client configuration. If `None`, uses defaults with 5-minute
+  Custom botocore client configuration. If `None`, uses defaults with 5-minute
   connect/read timeouts and 3 retry attempts.
 </ParamField>
 
@@ -207,7 +207,7 @@ await task.queue_frame(
 
 ## Notes
 
-- **Credential resolution**: Credentials are resolved via a fallback chain: explicit parameters → environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) → boto3 credential provider chain (instance profiles, IRSA, ECS task roles, SSO, credential files). Services running with IAM roles no longer need to export static credentials.
+- **Credential resolution**: Credentials are resolved via a fallback chain: explicit parameters → environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) → botocore credential provider chain (instance profiles, IRSA, ECS task roles, SSO, credential files). Services running with IAM roles no longer need to export static credentials.
 - **No-op tool handling**: AWS Bedrock requires at least one tool to be defined when tool content exists in the conversation. The service automatically adds a placeholder tool when needed to prevent API errors.
 - **Model-specific parameters**: Some models (e.g., Claude Sonnet 4.5) don't allow certain parameter combinations. The service only includes explicitly set parameters in the inference config to avoid conflicts.
 - **Retry behavior**: When `retry_on_timeout=True`, the first attempt uses the `retry_timeout_secs` timeout. If it times out, a second attempt is made with no timeout limit.

--- a/api-reference/server/services/stt/aws.mdx
+++ b/api-reference/server/services/stt/aws.mdx
@@ -67,8 +67,8 @@ Before using AWS Transcribe STT services, you need:
 
 <ParamField path="api_key" type="str" default="None">
   AWS secret access key. If `None`, falls back to environment variables and the
-  default boto3 credential chain (instance profiles, IRSA, ECS task roles, SSO,
-  etc.).
+  default botocore credential chain (instance profiles, IRSA, ECS task roles,
+  SSO, etc.).
 </ParamField>
 
 <ParamField path="aws_access_key_id" type="str" default="None">

--- a/api-reference/server/services/tts/aws.mdx
+++ b/api-reference/server/services/tts/aws.mdx
@@ -70,8 +70,8 @@ Before using AWS Polly TTS services, you need:
 
 <ParamField path="api_key" type="str" default="None">
   AWS secret access key. If `None`, falls back to environment variables and the
-  default boto3 credential chain (instance profiles, IRSA, ECS task roles, SSO,
-  etc.).
+  default botocore credential chain (instance profiles, IRSA, ECS task roles,
+  SSO, etc.).
 </ParamField>
 
 <ParamField path="aws_access_key_id" type="str" default="None">


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4643](https://github.com/pipecat-ai/pipecat/pull/4643).

## Changes

**AWS Bedrock LLM** (`api-reference/server/services/llm/aws.mdx`):
- Updated `aws_access_key` parameter description: "boto3 credential chain" → "botocore credential chain"
- Updated `client_config` parameter description: "boto3 client configuration" → "botocore client configuration"
- Updated Notes section credential resolution: "boto3 credential provider chain" → "botocore credential provider chain"

**AWS Transcribe STT** (`api-reference/server/services/stt/aws.mdx`):
- Updated `api_key` parameter description: "boto3 credential chain" → "botocore credential chain"

**AWS Polly TTS** (`api-reference/server/services/tts/aws.mdx`):
- Updated `api_key` parameter description: "boto3 credential chain" → "botocore credential chain"

## Summary

PR #4643 replaced the `aioboto3` dependency with `aiobotocore` for AWS services. The public API remains unchanged, but internal implementation now uses `aiobotocore.session.get_session()` and `session.create_client()` instead of the aioboto3 wrappers. Documentation references to "boto3" credential chains have been updated to "botocore" to accurately reflect the underlying credential resolution mechanism.

## Gaps identified

None. All AWS service documentation files have been updated. The following files were not changed because they either had no relevant documentation or are marked as internal:
- `services/aws/agent_core.py` - Internal, no public doc page
- `services/aws/utils.py` - Internal utility functions
- `services/nvidia/sagemaker/tts.py` - No doc page exists