### PR TITLE
docs: update for pipecat-flows PR #281

### DIFF
--- a/api-reference/pipecat-flows/types.mdx
+++ b/api-reference/pipecat-flows/types.mdx
@@ -119,12 +119,11 @@ Dataclass for defining function call schemas with Flows-specific properties. Pro
 </ParamField>
 
 <ParamField path="handler" type="FunctionHandler" default="None">
-  Function handler to process the function call. Can be a modern handler
-  `(args, flow_manager)`, legacy handler `(args)`, or zero-arg handler `()`.
-  Legacy and zero-arg handlers are deprecated. The handler returns any
-  JSON-serializable value, or a
-  [`ConsolidatedFunctionResult`](#consolidatedfunctionresult) tuple to also
-  specify the next node.
+  Function handler to process the function call. Can be a modern handler `(args,
+  flow_manager)`, legacy handler `(args)`, or zero-arg handler `()`. Legacy and
+  zero-arg handlers are deprecated. The handler returns any JSON-serializable
+  value, or a [`ConsolidatedFunctionResult`](#consolidatedfunctionresult) tuple
+  to also specify the next node.
 </ParamField>
 
 <ParamField path="cancel_on_interruption" type="bool" default="False">
@@ -186,8 +185,13 @@ TypedDict for configuring actions that execute during node transitions.
 </ParamField>
 
 <ParamField path="text" type="str" default="None">
-  Text content used by `tts_say` and optionally by `end_conversation` (as a
-  goodbye message).
+  Text to speak for the `tts_say` action, or the optional goodbye message for
+  the `end_conversation` action.
+</ParamField>
+
+<ParamField path="append_text_to_context" type="bool" default="True">
+  For the built-in TTS actions (`tts_say` and `end_conversation`), whether the
+  spoken text is appended to the LLM context. Defaults to `True`.
 </ParamField>
 
 <Note>
@@ -197,11 +201,11 @@ TypedDict for configuring actions that execute during node transitions.
 
 ### Built-in Action Types
 
-| Type               | Description                                                 | Required Fields   |
-| ------------------ | ----------------------------------------------------------- | ----------------- |
-| `tts_say`          | Speak text using the pipeline's TTS service                 | `text`            |
-| `end_conversation` | End the conversation, optionally speaking a goodbye message | `text` (optional) |
-| `function`         | Execute a function inline in the pipeline                   | `handler`         |
+| Type               | Description                                                                                             | Required Fields   |
+| ------------------ | ------------------------------------------------------------------------------------------------------- | ----------------- |
+| `tts_say`          | Speak text using the pipeline's TTS service. The spoken text is appended to the LLM context by default. | `text`            |
+| `end_conversation` | End the conversation, optionally speaking a goodbye message.                                            | `text` (optional) |
+| `function`         | Execute a function inline in the pipeline                                                               | `handler`         |
 
 ### Example
 
@@ -221,10 +225,10 @@ node_config: NodeConfig = {
 
 Enum defining strategies for managing conversation context during node transitions.
 
-| Value                | Description                                                                                                                            |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `APPEND`             | Append new messages to existing context. This is the default behavior.                                                                 |
-| `RESET`              | Reset context with new messages only. Previous conversation history is discarded.                                                      |
+| Value                | Description                                                                                                                                                                                                                  |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `APPEND`             | Append new messages to existing context. This is the default behavior.                                                                                                                                                       |
+| `RESET`              | Reset context with new messages only. Previous conversation history is discarded.                                                                                                                                            |
 | `RESET_WITH_SUMMARY` | **Deprecated.** Reset context but include an LLM-generated summary. Use Pipecat's native [context summarization](/pipecat/fundamentals/context-summarization) instead. Requires `summary_prompt` in `ContextStrategyConfig`. |
 
 ```python
@@ -380,6 +384,7 @@ FlowFunctionHandler = Callable[[FlowArgs, FlowManager], Awaitable[Any]]
 Type for modern function handlers that receive both arguments and the `FlowManager` instance.
 
 **Args:**
+
 - `args` (`FlowArgs`): Dictionary of arguments from the function call.
 - `flow_manager` (`FlowManager`): Reference to the FlowManager instance.
 
@@ -414,6 +419,7 @@ LegacyFunctionHandler = Callable[[FlowArgs], Awaitable[Any]]
 Type for legacy function handlers that only receive arguments. Both legacy and modern handlers are supported; the flow manager detects the signature automatically and emits a `DeprecationWarning`.
 
 **Args:**
+
 - `args` (`FlowArgs`): Dictionary of arguments from the function call.
 
 **Returns:** Any JSON-serializable value, or a `ConsolidatedFunctionResult` tuple to also specify the next node.

--- a/api-reference/pipecat-flows/types.mdx
+++ b/api-reference/pipecat-flows/types.mdx
@@ -186,8 +186,13 @@ TypedDict for configuring actions that execute during node transitions.
 </ParamField>
 
 <ParamField path="text" type="str" default="None">
-  Text content used by `tts_say` and optionally by `end_conversation` (as a
-  goodbye message).
+  Text to speak for the `tts_say` action, or the optional goodbye message for
+  the `end_conversation` action.
+</ParamField>
+
+<ParamField path="append_text_to_context" type="bool" default="True">
+  For the built-in TTS actions (`tts_say` and `end_conversation`), whether the
+  spoken text is appended to the LLM context. Defaults to `True`.
 </ParamField>
 
 <Note>
@@ -199,8 +204,8 @@ TypedDict for configuring actions that execute during node transitions.
 
 | Type               | Description                                                 | Required Fields   |
 | ------------------ | ----------------------------------------------------------- | ----------------- |
-| `tts_say`          | Speak text using the pipeline's TTS service                 | `text`            |
-| `end_conversation` | End the conversation, optionally speaking a goodbye message | `text` (optional) |
+| `tts_say`          | Speak text using the pipeline's TTS service. The spoken text is appended to the LLM context by default; set `append_text_to_context=False` to opt out. | `text`            |
+| `end_conversation` | End the conversation, optionally speaking a goodbye message. If `text` is provided, it is appended to the LLM context by default; set `append_text_to_context=False` to opt out. | `text` (optional) |
 | `function`         | Execute a function inline in the pipeline                   | `handler`         |
 
 ### Example

--- a/pipecat-flows/guides/actions.mdx
+++ b/pipecat-flows/guides/actions.mdx
@@ -27,6 +27,18 @@ Speak a phrase immediately (useful for "please wait" messages):
 ]
 ```
 
+The spoken text is appended to the LLM context by default. To prevent the text from being added to the context, set `append_text_to_context=False`:
+
+```python
+"pre_actions": [
+    {
+        "type": "tts_say",
+        "text": "Processing...",
+        "append_text_to_context": False
+    }
+]
+```
+
 ### end_conversation
 
 Gracefully terminate the conversation:
@@ -36,6 +48,18 @@ Gracefully terminate the conversation:
     {
         "type": "end_conversation",
         "text": "Thank you for your time!"
+    }
+]
+```
+
+The goodbye text is appended to the LLM context by default. To prevent the text from being added to the context, set `append_text_to_context=False`:
+
+```python
+"post_actions": [
+    {
+        "type": "end_conversation",
+        "text": "Goodbye!",
+        "append_text_to_context": False
     }
 ]
 ```

--- a/pipecat-flows/guides/context-strategies.mdx
+++ b/pipecat-flows/guides/context-strategies.mdx
@@ -14,10 +14,11 @@ Flows provides three built-in ways to manage conversation context as you move be
 3. **RESET_WITH_SUMMARY**: The context is cleared but includes an AI-generated summary of the previous conversation along with the new node's messages. Helps reduce context size while preserving key information.
 
 <Warning>
-  `RESET_WITH_SUMMARY` is deprecated and will be removed in 2.0. Use Pipecat's native
-  [`LLMSummarizeContextFrame`](/pipecat/fundamentals/context-summarization) instead. To trigger
-  on-demand summarization during a node transition, push an `LLMSummarizeContextFrame` in a
-  pre-action.
+  `RESET_WITH_SUMMARY` is deprecated and will be removed in 2.0. Use Pipecat's
+  native
+  [`LLMSummarizeContextFrame`](/pipecat/fundamentals/context-summarization)
+  instead. To trigger on-demand summarization during a node transition, push an
+  `LLMSummarizeContextFrame` in a pre-action.
 </Warning>
 
 ## When to Use Each Strategy

--- a/pipecat-flows/guides/context-strategies.mdx
+++ b/pipecat-flows/guides/context-strategies.mdx
@@ -20,6 +20,13 @@ Flows provides three built-in ways to manage conversation context as you move be
   pre-action.
 </Warning>
 
+<Info>
+  **Initial node behavior:** The initial flow node follows its context strategy (default `APPEND`)
+  instead of always replacing the context. With the default strategy, context written before the
+  node's first inference — for example by a `tts_say` pre-action — is now preserved rather than
+  discarded. Set `context_strategy=RESET` on the initial node for the previous clean-slate behavior.
+</Info>
+
 ## When to Use Each Strategy
 
 - Use **APPEND** when full conversation history is important for context


### PR DESCRIPTION
Automated documentation update for [pipecat-flows PR #281](https://github.com/pipecat-ai/pipecat-flows/pull/281).

## Changes

### Updated API reference pages
- **api-reference/pipecat-flows/types.mdx**
  - Added `append_text_to_context` parameter to `ActionConfig` with default value `True`
  - Updated `text` parameter description to clarify usage for both `tts_say` and `end_conversation` actions
  - Updated Built-in Action Types table to document the new parameter behavior

### Updated guide pages
- **pipecat-flows/guides/actions.mdx**
  - Added documentation and examples for `append_text_to_context` parameter in `tts_say` action
  - Added documentation and examples for `append_text_to_context` parameter in `end_conversation` action

- **pipecat-flows/guides/context-strategies.mdx**
  - Added info box documenting that the initial flow node now follows its context strategy (default `APPEND`) instead of always replacing the context

## Summary

These changes reflect two key improvements from PR #281:

1. **Context control for TTS actions**: The built-in `tts_say` and `end_conversation` actions now support an `append_text_to_context` parameter (defaults to `True`), giving developers control over whether spoken text is added to the LLM context.

2. **Initial node context behavior**: The initial flow node now respects its context strategy instead of always using `RESET`. With the default `APPEND` strategy, context written before the node's first inference (e.g., by a `tts_say` pre-action) is now preserved.

## Gaps identified

None