### PR TITLE
Add Rumik TTS documentation

### DIFF
--- a/api-reference/server/services/tts/rumik.mdx
+++ b/api-reference/server/services/tts/rumik.mdx
@@ -1,0 +1,231 @@
+---
+title: "Rumik"
+description: "Text-to-speech service implementations using Rumik's Voice API"
+---
+
+## Overview
+
+Rumik provides text-to-speech synthesis with two service implementations:
+
+- **`RumikTTSService`** (WebSocket) — Streaming synthesis for interactive voice agents. The service keeps a persistent WebSocket connection open, streams audio chunks into Pipecat audio contexts, and handles interruptions by reconnecting.
+- **`RumikHttpTTSService`** (HTTP) — Simpler request/response synthesis. The service receives WAV audio from Rumik, converts it to raw PCM, and emits Pipecat audio frames.
+
+<CardGroup cols={2}>
+  <Card
+    title="Rumik TTS API Reference"
+    icon="code"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.rumik.tts.html"
+  >
+    Pipecat's API methods for Rumik TTS integration
+  </Card>
+  <Card
+    title="WebSocket Example"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-rumik.py"
+  >
+    Complete example with WebSocket streaming
+  </Card>
+  <Card
+    title="HTTP Example"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-rumik-http.py"
+  >
+    Complete example using the HTTP service
+  </Card>
+  <Card
+    title="Update Settings Example"
+    icon="settings"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/update-settings/tts/tts-rumik.py"
+  >
+    Runtime settings update example
+  </Card>
+</CardGroup>
+
+## Installation
+
+To use Rumik TTS services, install the Rumik optional dependency group:
+
+```bash
+uv add "pipecat-ai[rumik]"
+```
+
+## Prerequisites
+
+Before using Rumik TTS services, you need:
+
+1. **Rumik Account**: Access to Rumik's Voice API
+2. **API Key**: A Rumik API key for authentication
+3. **Gateway URL**: The Rumik gateway URL for your deployment
+
+### Required Environment Variables
+
+- `RUMIK_API_KEY`: Your Rumik API key for authentication
+- `RUMIK_GATEWAY_URL`: Your Rumik gateway base URL
+
+## Configuration
+
+Rumik offers two service implementations: `RumikTTSService` (WebSocket) for streaming synthesis and `RumikHttpTTSService` (HTTP) for request/response synthesis.
+
+### RumikTTSService
+
+<ParamField path="api_key" type="str" required>
+  Rumik API key for authentication.
+</ParamField>
+
+<ParamField path="gateway_url" type="str" required>
+  Rumik gateway base URL.
+</ParamField>
+
+<ParamField path="settings" type="RumikTTSService.Settings" default="None">
+  Runtime-configurable settings. See [RumikTTSService
+  Settings](#rumikttsservice-settings) below.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="24000">
+  Output audio sample rate in Hz. Rumik currently returns 24 kHz mono PCM audio,
+  so this must be `24000`.
+</ParamField>
+
+<ParamField path="full_response_aggregation" type="bool" default="True">
+  Whether to buffer a full LLM response before sending text to Rumik. This can
+  reduce sentence-level gaps for deployments with higher time-to-first-byte.
+</ParamField>
+
+### RumikHttpTTSService
+
+<ParamField path="api_key" type="str" required>
+  Rumik API key for authentication.
+</ParamField>
+
+<ParamField path="gateway_url" type="str" required>
+  Rumik gateway base URL.
+</ParamField>
+
+<ParamField path="aiohttp_session" type="aiohttp.ClientSession" required>
+  An aiohttp session for HTTP requests. You must create and manage this
+  yourself.
+</ParamField>
+
+<ParamField path="settings" type="RumikHttpTTSService.Settings" default="None">
+  Runtime-configurable settings. See [RumikHttpTTSService
+  Settings](#rumikhttpttsservice-settings) below.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="24000">
+  Output audio sample rate in Hz. Rumik currently returns 24 kHz mono PCM audio,
+  so this must be `24000`.
+</ParamField>
+
+#### RumikTTSService Settings
+
+Runtime-configurable settings passed via the `settings` constructor argument using `RumikTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
+
+| Parameter        | Type              | Default   | Description                            |
+| ---------------- | ----------------- | --------- | -------------------------------------- |
+| `model`          | `str`             | `"muga"`  | Model identifier. _(Inherited.)_       |
+| `voice`          | `str`             | `None`    | Voice identifier. _(Inherited.)_       |
+| `language`       | `Language \| str` | `None`    | Language for synthesis. _(Inherited.)_ |
+| `speaker_id`     | `int`             | `0`       | Speaker ID used by WebSocket requests. |
+| `description`    | `str`             | `neutral` | Voice or style description.            |
+| `temperature`    | `float`           | `0.6`     | Sampling temperature.                  |
+| `topk`           | `int`             | `40`      | Top-k sampling value.                  |
+| `max_new_tokens` | `int`             | `2048`    | Maximum generated audio tokens.        |
+
+#### RumikHttpTTSService Settings
+
+Runtime-configurable settings passed via the `settings` constructor argument using `RumikHttpTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
+
+| Parameter        | Type              | Default   | Description                            |
+| ---------------- | ----------------- | --------- | -------------------------------------- |
+| `model`          | `str`             | `"muga"`  | Model identifier. _(Inherited.)_       |
+| `voice`          | `str`             | `None`    | Voice identifier. _(Inherited.)_       |
+| `language`       | `Language \| str` | `None`    | Language for synthesis. _(Inherited.)_ |
+| `speaker_id`     | `int`             | `0`       | Speaker ID used by WebSocket requests. |
+| `description`    | `str`             | `neutral` | Voice or style description.            |
+| `temperature`    | `float`           | `0.6`     | Sampling temperature.                  |
+| `topk`           | `int`             | `40`      | Top-k sampling value.                  |
+| `max_new_tokens` | `int`             | `2048`    | Maximum generated audio tokens.        |
+
+## Usage
+
+### Basic Setup (WebSocket)
+
+```python
+import os
+
+from pipecat.services.rumik import RumikTTSService
+
+tts = RumikTTSService(
+    api_key=os.getenv("RUMIK_API_KEY"),
+    gateway_url=os.getenv("RUMIK_GATEWAY_URL"),
+    settings=RumikTTSService.Settings(
+        model="muga",
+        speaker_id=0,
+    ),
+)
+```
+
+### HTTP Service
+
+```python
+import os
+
+import aiohttp
+
+from pipecat.services.rumik import RumikHttpTTSService
+
+async with aiohttp.ClientSession() as session:
+    tts = RumikHttpTTSService(
+        api_key=os.getenv("RUMIK_API_KEY"),
+        gateway_url=os.getenv("RUMIK_GATEWAY_URL"),
+        aiohttp_session=session,
+        settings=RumikHttpTTSService.Settings(
+            model="muga",
+            description="neutral",
+            temperature=0.6,
+            topk=40,
+            max_new_tokens=2048,
+        ),
+    )
+```
+
+### Updating Settings at Runtime
+
+Rumik settings can be changed mid-conversation using `TTSUpdateSettingsFrame`:
+
+```python
+from pipecat.frames.frames import TTSUpdateSettingsFrame
+from pipecat.services.rumik import RumikTTSService
+
+await task.queue_frame(
+    TTSUpdateSettingsFrame(
+        delta=RumikTTSService.Settings(
+            model="mulberry",
+            speaker_id=0,
+        )
+    )
+)
+```
+
+## Notes
+
+- **Audio format**: Rumik currently returns 24 kHz, 16-bit, mono PCM audio. The HTTP service receives WAV audio and converts it to raw PCM frames for Pipecat.
+- **WebSocket sessions**: The WebSocket service uses a persistent connection and can send multiple text requests over the same session.
+- **Interruption handling**: The WebSocket service reconnects when Pipecat interrupts active playback.
+- **Full-response aggregation**: `RumikTTSService` defaults to `full_response_aggregation=True`, which sends one complete LLM response per synthesis request.
+
+## Event Handlers
+
+Rumik WebSocket TTS supports the standard [service connection events](/api-reference/server/events/service-events):
+
+| Event                 | Description                         |
+| --------------------- | ----------------------------------- |
+| `on_connected`        | Connected to Rumik WebSocket        |
+| `on_disconnected`     | Disconnected from Rumik WebSocket   |
+| `on_connection_error` | WebSocket connection error occurred |
+
+```python
+@tts.event_handler("on_connected")
+async def on_connected(service):
+    print("Connected to Rumik")
+```

--- a/api-reference/server/services/tts/rumik.mdx
+++ b/api-reference/server/services/tts/rumik.mdx
@@ -1,29 +1,36 @@
 ---
-title: "Rumik"
-description: "Text-to-speech service implementations using Rumik's Voice API"
+title: "Rumik AI"
+description: "Text-to-speech service implementations using Rumik AI's Voice API"
 ---
 
 ## Overview
 
-Rumik provides text-to-speech synthesis with two service implementations:
+Rumik AI provides text-to-speech synthesis with two service implementations:
 
 - **`RumikTTSService`** (WebSocket) — Streaming synthesis for interactive voice agents. The service keeps a persistent WebSocket connection open, streams audio chunks into Pipecat audio contexts, and handles interruptions by reconnecting.
-- **`RumikHttpTTSService`** (HTTP) — Simpler request/response synthesis. The service receives WAV audio from Rumik, converts it to raw PCM, and emits Pipecat audio frames.
+- **`RumikHttpTTSService`** (HTTP) — Simpler request/response synthesis. The service receives WAV audio from Rumik AI, converts it to raw PCM, and emits Pipecat audio frames.
 
 <CardGroup cols={2}>
   <Card
-    title="Rumik TTS API Reference"
+    title="Rumik AI TTS API Reference"
     icon="code"
     href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.rumik.tts.html"
   >
-    Pipecat's API methods for Rumik TTS integration
+    Pipecat's API methods for Rumik AI TTS integration
   </Card>
   <Card
-    title="WebSocket Example"
+    title="Muga Voice Example"
     icon="play"
-    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-rumik.py"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-rumik-muga.py"
   >
-    Complete example with WebSocket streaming
+    Cascading voice pipeline using Rumik AI's muga model
+  </Card>
+  <Card
+    title="Mulberry Voice Example"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-rumik-mulberry.py"
+  >
+    Cascading voice pipeline using Mulberry speaker and style settings
   </Card>
   <Card
     title="HTTP Example"
@@ -39,120 +46,24 @@ Rumik provides text-to-speech synthesis with two service implementations:
   >
     Runtime settings update example
   </Card>
+  <Card
+    title="Rumik AI Dashboard"
+    icon="key"
+    href="https://playground.rumik.ai/"
+  >
+    Sign in, create API keys, and manage usage in the Rumik AI dashboard
+  </Card>
 </CardGroup>
 
 ## Installation
 
-To use Rumik TTS services, install the Rumik optional dependency group:
+To use Rumik AI TTS services, install the `rumik` optional dependency group:
 
 ```bash
 uv add "pipecat-ai[rumik]"
 ```
 
-## Prerequisites
-
-Before using Rumik TTS services, you need:
-
-1. **Rumik Account**: Access to Rumik's Voice API
-2. **API Key**: A Rumik API key for authentication
-3. **Gateway URL**: The Rumik gateway URL for your deployment
-
-### Required Environment Variables
-
-- `RUMIK_API_KEY`: Your Rumik API key for authentication
-- `RUMIK_GATEWAY_URL`: Your Rumik gateway base URL
-
-## Configuration
-
-Rumik offers two service implementations: `RumikTTSService` (WebSocket) for streaming synthesis and `RumikHttpTTSService` (HTTP) for request/response synthesis.
-
-### RumikTTSService
-
-<ParamField path="api_key" type="str" required>
-  Rumik API key for authentication.
-</ParamField>
-
-<ParamField path="gateway_url" type="str" required>
-  Rumik gateway base URL.
-</ParamField>
-
-<ParamField path="settings" type="RumikTTSService.Settings" default="None">
-  Runtime-configurable settings. See [RumikTTSService
-  Settings](#rumikttsservice-settings) below.
-</ParamField>
-
-<ParamField path="sample_rate" type="int" default="24000">
-  Output audio sample rate in Hz. Rumik currently returns 24 kHz mono PCM audio,
-  so this must be `24000`.
-</ParamField>
-
-<ParamField path="full_response_aggregation" type="bool" default="True">
-  Whether to buffer a full LLM response before sending text to Rumik. This can
-  reduce sentence-level gaps for deployments with higher time-to-first-byte.
-</ParamField>
-
-### RumikHttpTTSService
-
-<ParamField path="api_key" type="str" required>
-  Rumik API key for authentication.
-</ParamField>
-
-<ParamField path="gateway_url" type="str" required>
-  Rumik gateway base URL.
-</ParamField>
-
-<ParamField path="aiohttp_session" type="aiohttp.ClientSession" required>
-  An aiohttp session for HTTP requests. You must create and manage this
-  yourself.
-</ParamField>
-
-<ParamField path="settings" type="RumikHttpTTSService.Settings" default="None">
-  Runtime-configurable settings. See [RumikHttpTTSService
-  Settings](#rumikhttpttsservice-settings) below.
-</ParamField>
-
-<ParamField path="sample_rate" type="int" default="24000">
-  Output audio sample rate in Hz. Rumik currently returns 24 kHz mono PCM audio,
-  so this must be `24000`.
-</ParamField>
-
-#### RumikTTSService Settings
-
-Runtime-configurable settings passed via the `settings` constructor argument using `RumikTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
-
-| Parameter            | Type              | Default  | Description                                                      |
-| -------------------- | ----------------- | -------- | ---------------------------------------------------------------- |
-| `model`              | `str`             | `"muga"` | Model identifier. _(Inherited.)_                                 |
-| `voice`              | `str`             | `None`   | Preset speaker voice. Sent to Rumik as `speaker`. _(Inherited.)_ |
-| `language`           | `Language \| str` | `None`   | Language for synthesis. _(Inherited.)_                           |
-| `description`        | `str`             | `None`   | Natural-language voice/style description for expressive models.  |
-| `f0_up_key`          | `int`             | `None`   | Pitch shift in semitones for preset speaker voices.              |
-| `temperature`        | `float`           | `0.6`    | Sampling temperature.                                            |
-| `top_p`              | `float`           | `0.95`   | Nucleus sampling value.                                          |
-| `top_k`              | `int`             | `50`     | Top-k sampling value.                                            |
-| `repetition_penalty` | `float`           | `1.2`    | Penalty applied to repeated tokens.                              |
-| `max_new_tokens`     | `int`             | `2048`   | Maximum generated audio tokens.                                  |
-
-#### RumikHttpTTSService Settings
-
-Runtime-configurable settings passed via the `settings` constructor argument using `RumikHttpTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
-
-| Parameter            | Type              | Default  | Description                                                      |
-| -------------------- | ----------------- | -------- | ---------------------------------------------------------------- |
-| `model`              | `str`             | `"muga"` | Model identifier. _(Inherited.)_                                 |
-| `voice`              | `str`             | `None`   | Preset speaker voice. Sent to Rumik as `speaker`. _(Inherited.)_ |
-| `language`           | `Language \| str` | `None`   | Language for synthesis. _(Inherited.)_                           |
-| `description`        | `str`             | `None`   | Natural-language voice/style description for expressive models.  |
-| `f0_up_key`          | `int`             | `None`   | Pitch shift in semitones for preset speaker voices.              |
-| `temperature`        | `float`           | `0.6`    | Sampling temperature.                                            |
-| `top_p`              | `float`           | `0.95`   | Nucleus sampling value.                                          |
-| `top_k`              | `int`             | `50`     | Top-k sampling value.                                            |
-| `repetition_penalty` | `float`           | `1.2`    | Penalty applied to repeated tokens.                              |
-| `max_new_tokens`     | `int`             | `2048`   | Maximum generated audio tokens.                                  |
-
-## Usage
-
-### Basic Setup (WebSocket)
+## Quick Start
 
 ```python
 import os
@@ -167,6 +78,109 @@ tts = RumikTTSService(
     ),
 )
 ```
+
+## Prerequisites
+
+Before using Rumik AI TTS services, you need:
+
+1. **Rumik AI Account**: Sign in to the [Rumik AI dashboard](https://playground.rumik.ai/)
+2. **API Key**: Create an API key from the [Rumik AI dashboard](https://playground.rumik.ai/)
+3. **Gateway URL**: The Rumik AI gateway URL for your deployment
+
+### Required Environment Variables
+
+- `RUMIK_API_KEY`: Your Rumik AI API key for authentication
+- `RUMIK_GATEWAY_URL`: Your Rumik AI gateway base URL
+
+## Configuration
+
+Rumik AI offers two service implementations: `RumikTTSService` (WebSocket) for streaming synthesis and `RumikHttpTTSService` (HTTP) for request/response synthesis.
+
+### RumikTTSService
+
+<ParamField path="api_key" type="str" required>
+  Rumik AI API key for authentication.
+</ParamField>
+
+<ParamField path="gateway_url" type="str" required>
+  Rumik AI gateway base URL.
+</ParamField>
+
+<ParamField path="settings" type="RumikTTSService.Settings" default="None">
+  Runtime-configurable settings. See [RumikTTSService
+  Settings](#rumikttsservice-settings) below.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="24000">
+  Output audio sample rate in Hz. Rumik AI currently returns 24 kHz mono PCM audio,
+  so this must be `24000`.
+</ParamField>
+
+<ParamField path="full_response_aggregation" type="bool" default="True">
+  Whether to buffer a full LLM response before sending text to Rumik AI. This can
+  reduce sentence-level gaps for deployments with higher time-to-first-byte.
+</ParamField>
+
+### RumikHttpTTSService
+
+<ParamField path="api_key" type="str" required>
+  Rumik AI API key for authentication.
+</ParamField>
+
+<ParamField path="gateway_url" type="str" required>
+  Rumik AI gateway base URL.
+</ParamField>
+
+<ParamField path="aiohttp_session" type="aiohttp.ClientSession" required>
+  An aiohttp session for HTTP requests. You must create and manage this
+  yourself.
+</ParamField>
+
+<ParamField path="settings" type="RumikHttpTTSService.Settings" default="None">
+  Runtime-configurable settings. See [RumikHttpTTSService
+  Settings](#rumikhttpttsservice-settings) below.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="24000">
+  Output audio sample rate in Hz. Rumik AI currently returns 24 kHz mono PCM audio,
+  so this must be `24000`.
+</ParamField>
+
+#### RumikTTSService Settings
+
+Runtime-configurable settings passed via the `settings` constructor argument using `RumikTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
+
+| Parameter            | Type              | Default  | Description                                                      |
+| -------------------- | ----------------- | -------- | ---------------------------------------------------------------- |
+| `model`              | `str`             | `"muga"` | Model identifier. _(Inherited.)_                                 |
+| `voice`              | `str`             | `None`   | Preset speaker voice. Sent to Rumik AI as `speaker`. _(Inherited.)_ |
+| `language`           | `Language \| str` | `None`   | Language for synthesis. _(Inherited.)_                           |
+| `description`        | `str`             | `None`   | Natural-language voice/style description for expressive models.  |
+| `f0_up_key`          | `int`             | `None`   | Pitch shift in semitones for preset speaker voices.              |
+| `temperature`        | `float`           | `None`   | Sampling temperature. When omitted, uses the Rumik AI API default. |
+| `top_p`              | `float`           | `None`   | Nucleus sampling value. When omitted, uses the Rumik AI API default. |
+| `top_k`              | `int`             | `None`   | Top-k sampling value. When omitted, uses the Rumik AI API default. |
+| `repetition_penalty` | `float`           | `None`   | Penalty applied to repeated tokens. When omitted, uses the Rumik AI API default. |
+| `max_new_tokens`     | `int`             | `None`   | Maximum generated audio tokens. When omitted, uses the Rumik AI API default. |
+
+#### RumikHttpTTSService Settings
+
+Runtime-configurable settings passed via the `settings` constructor argument using `RumikHttpTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
+
+| Parameter            | Type              | Default  | Description                                                      |
+| -------------------- | ----------------- | -------- | ---------------------------------------------------------------- |
+| `model`              | `str`             | `"muga"` | Model identifier. _(Inherited.)_                                 |
+| `voice`              | `str`             | `None`   | Preset speaker voice. Sent to Rumik AI as `speaker`. _(Inherited.)_ |
+| `language`           | `Language \| str` | `None`   | Language for synthesis. _(Inherited.)_                           |
+| `description`        | `str`             | `None`   | Natural-language voice/style description for expressive models.  |
+| `f0_up_key`          | `int`             | `None`   | Pitch shift in semitones for preset speaker voices.              |
+| `temperature`        | `float`           | `None`   | Sampling temperature. When omitted, uses the Rumik AI API default. |
+| `top_p`              | `float`           | `None`   | Nucleus sampling value. When omitted, uses the Rumik AI API default. |
+| `top_k`              | `int`             | `None`   | Top-k sampling value. When omitted, uses the Rumik AI API default. |
+| `repetition_penalty` | `float`           | `None`   | Penalty applied to repeated tokens. When omitted, uses the Rumik AI API default. |
+| `max_new_tokens`     | `int`             | `None`   | Maximum generated audio tokens. When omitted, uses the Rumik AI API default. |
+
+## Usage
 
 ### Expressive Voice Settings
 
@@ -190,72 +204,80 @@ tts = RumikTTSService(
 ### HTTP Service
 
 ```python
+import asyncio
 import os
 
 import aiohttp
 
 from pipecat.services.rumik import RumikHttpTTSService
 
-async with aiohttp.ClientSession() as session:
-    tts = RumikHttpTTSService(
-        api_key=os.getenv("RUMIK_API_KEY"),
-        gateway_url=os.getenv("RUMIK_GATEWAY_URL"),
-        aiohttp_session=session,
-        settings=RumikHttpTTSService.Settings(
-            model="mulberry",
-            voice="speaker_2",
-            description="calm female narrator",
-            f0_up_key=0,
-            temperature=0.6,
-            top_p=0.95,
-            top_k=50,
-            repetition_penalty=1.2,
-            max_new_tokens=2048,
-        ),
-    )
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        tts = RumikHttpTTSService(
+            api_key=os.getenv("RUMIK_API_KEY"),
+            gateway_url=os.getenv("RUMIK_GATEWAY_URL"),
+            aiohttp_session=session,
+            settings=RumikHttpTTSService.Settings(
+                model="mulberry",
+                voice="speaker_2",
+                description="calm female narrator",
+                f0_up_key=0,
+                temperature=0.6,
+                top_p=0.95,
+                top_k=50,
+                repetition_penalty=1.2,
+                max_new_tokens=2048,
+            ),
+        )
+
+
+asyncio.run(main())
 ```
 
 ### Updating Settings at Runtime
 
-Rumik settings can be changed mid-conversation using `TTSUpdateSettingsFrame`:
+Rumik AI settings can be changed mid-conversation using `TTSUpdateSettingsFrame`:
 
 ```python
 from pipecat.frames.frames import TTSUpdateSettingsFrame
 from pipecat.services.rumik import RumikTTSService
 
-await task.queue_frame(
-    TTSUpdateSettingsFrame(
-        delta=RumikTTSService.Settings(
-            model="mulberry",
-            voice="speaker_1",
-            description="warm, upbeat narrator",
-            f0_up_key=0,
+
+async def update_rumik_voice(task):
+    await task.queue_frame(
+        TTSUpdateSettingsFrame(
+            delta=RumikTTSService.Settings(
+                model="mulberry",
+                voice="speaker_1",
+                description="warm, upbeat narrator",
+                f0_up_key=0,
+            )
         )
     )
-)
 ```
 
 ## Notes
 
-- **Audio format**: Rumik currently returns 24 kHz, 16-bit, mono PCM audio. The HTTP service receives WAV audio and converts it to raw PCM frames for Pipecat.
+- **Audio format**: Rumik AI currently returns 24 kHz, 16-bit, mono PCM audio. The HTTP service receives WAV audio and converts it to raw PCM frames for Pipecat.
 - **WebSocket sessions**: The WebSocket service uses a persistent connection and can send multiple text requests over the same session.
-- **Voice selection**: Use `voice` for preset speaker voices. The service sends this setting to Rumik as `speaker`.
+- **Voice selection**: Use `voice` for preset speaker voices. The service sends this setting to Rumik AI as `speaker`.
 - **Model steering**: `muga` can be steered with tone tags in the input text. Expressive models can use `description`, optional preset `voice`, and `f0_up_key`.
 - **Interruption handling**: The WebSocket service reconnects when Pipecat interrupts active playback.
 - **Full-response aggregation**: `RumikTTSService` defaults to `full_response_aggregation=True`, which sends one complete LLM response per synthesis request.
 
 ## Event Handlers
 
-Rumik WebSocket TTS supports the standard [service connection events](/api-reference/server/events/service-events):
+Rumik AI WebSocket TTS supports the standard [service connection events](/api-reference/server/events/service-events):
 
 | Event                 | Description                         |
 | --------------------- | ----------------------------------- |
-| `on_connected`        | Connected to Rumik WebSocket        |
-| `on_disconnected`     | Disconnected from Rumik WebSocket   |
+| `on_connected`        | Connected to Rumik AI WebSocket     |
+| `on_disconnected`     | Disconnected from Rumik AI WebSocket |
 | `on_connection_error` | WebSocket connection error occurred |
 
 ```python
 @tts.event_handler("on_connected")
 async def on_connected(service):
-    print("Connected to Rumik")
+    print("Connected to Rumik AI")
 ```

--- a/api-reference/server/services/tts/rumik.mdx
+++ b/api-reference/server/services/tts/rumik.mdx
@@ -120,31 +120,35 @@ Rumik offers two service implementations: `RumikTTSService` (WebSocket) for stre
 
 Runtime-configurable settings passed via the `settings` constructor argument using `RumikTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter        | Type              | Default   | Description                            |
-| ---------------- | ----------------- | --------- | -------------------------------------- |
-| `model`          | `str`             | `"muga"`  | Model identifier. _(Inherited.)_       |
-| `voice`          | `str`             | `None`    | Voice identifier. _(Inherited.)_       |
-| `language`       | `Language \| str` | `None`    | Language for synthesis. _(Inherited.)_ |
-| `speaker_id`     | `int`             | `0`       | Speaker ID used by WebSocket requests. |
-| `description`    | `str`             | `neutral` | Voice or style description.            |
-| `temperature`    | `float`           | `0.6`     | Sampling temperature.                  |
-| `topk`           | `int`             | `40`      | Top-k sampling value.                  |
-| `max_new_tokens` | `int`             | `2048`    | Maximum generated audio tokens.        |
+| Parameter            | Type              | Default  | Description                                                      |
+| -------------------- | ----------------- | -------- | ---------------------------------------------------------------- |
+| `model`              | `str`             | `"muga"` | Model identifier. _(Inherited.)_                                 |
+| `voice`              | `str`             | `None`   | Preset speaker voice. Sent to Rumik as `speaker`. _(Inherited.)_ |
+| `language`           | `Language \| str` | `None`   | Language for synthesis. _(Inherited.)_                           |
+| `description`        | `str`             | `None`   | Natural-language voice/style description for expressive models.  |
+| `f0_up_key`          | `int`             | `None`   | Pitch shift in semitones for preset speaker voices.              |
+| `temperature`        | `float`           | `0.6`    | Sampling temperature.                                            |
+| `top_p`              | `float`           | `0.95`   | Nucleus sampling value.                                          |
+| `top_k`              | `int`             | `50`     | Top-k sampling value.                                            |
+| `repetition_penalty` | `float`           | `1.2`    | Penalty applied to repeated tokens.                              |
+| `max_new_tokens`     | `int`             | `2048`   | Maximum generated audio tokens.                                  |
 
 #### RumikHttpTTSService Settings
 
 Runtime-configurable settings passed via the `settings` constructor argument using `RumikHttpTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter        | Type              | Default   | Description                            |
-| ---------------- | ----------------- | --------- | -------------------------------------- |
-| `model`          | `str`             | `"muga"`  | Model identifier. _(Inherited.)_       |
-| `voice`          | `str`             | `None`    | Voice identifier. _(Inherited.)_       |
-| `language`       | `Language \| str` | `None`    | Language for synthesis. _(Inherited.)_ |
-| `speaker_id`     | `int`             | `0`       | Speaker ID used by WebSocket requests. |
-| `description`    | `str`             | `neutral` | Voice or style description.            |
-| `temperature`    | `float`           | `0.6`     | Sampling temperature.                  |
-| `topk`           | `int`             | `40`      | Top-k sampling value.                  |
-| `max_new_tokens` | `int`             | `2048`    | Maximum generated audio tokens.        |
+| Parameter            | Type              | Default  | Description                                                      |
+| -------------------- | ----------------- | -------- | ---------------------------------------------------------------- |
+| `model`              | `str`             | `"muga"` | Model identifier. _(Inherited.)_                                 |
+| `voice`              | `str`             | `None`   | Preset speaker voice. Sent to Rumik as `speaker`. _(Inherited.)_ |
+| `language`           | `Language \| str` | `None`   | Language for synthesis. _(Inherited.)_                           |
+| `description`        | `str`             | `None`   | Natural-language voice/style description for expressive models.  |
+| `f0_up_key`          | `int`             | `None`   | Pitch shift in semitones for preset speaker voices.              |
+| `temperature`        | `float`           | `0.6`    | Sampling temperature.                                            |
+| `top_p`              | `float`           | `0.95`   | Nucleus sampling value.                                          |
+| `top_k`              | `int`             | `50`     | Top-k sampling value.                                            |
+| `repetition_penalty` | `float`           | `1.2`    | Penalty applied to repeated tokens.                              |
+| `max_new_tokens`     | `int`             | `2048`   | Maximum generated audio tokens.                                  |
 
 ## Usage
 
@@ -160,7 +164,25 @@ tts = RumikTTSService(
     gateway_url=os.getenv("RUMIK_GATEWAY_URL"),
     settings=RumikTTSService.Settings(
         model="muga",
-        speaker_id=0,
+    ),
+)
+```
+
+### Expressive Voice Settings
+
+```python
+import os
+
+from pipecat.services.rumik import RumikTTSService
+
+tts = RumikTTSService(
+    api_key=os.getenv("RUMIK_API_KEY"),
+    gateway_url=os.getenv("RUMIK_GATEWAY_URL"),
+    settings=RumikTTSService.Settings(
+        model="mulberry",
+        voice="speaker_1",
+        description="warm, friendly narrator",
+        f0_up_key=0,
     ),
 )
 ```
@@ -180,10 +202,14 @@ async with aiohttp.ClientSession() as session:
         gateway_url=os.getenv("RUMIK_GATEWAY_URL"),
         aiohttp_session=session,
         settings=RumikHttpTTSService.Settings(
-            model="muga",
-            description="neutral",
+            model="mulberry",
+            voice="speaker_2",
+            description="calm female narrator",
+            f0_up_key=0,
             temperature=0.6,
-            topk=40,
+            top_p=0.95,
+            top_k=50,
+            repetition_penalty=1.2,
             max_new_tokens=2048,
         ),
     )
@@ -201,7 +227,9 @@ await task.queue_frame(
     TTSUpdateSettingsFrame(
         delta=RumikTTSService.Settings(
             model="mulberry",
-            speaker_id=0,
+            voice="speaker_1",
+            description="warm, upbeat narrator",
+            f0_up_key=0,
         )
     )
 )
@@ -211,6 +239,8 @@ await task.queue_frame(
 
 - **Audio format**: Rumik currently returns 24 kHz, 16-bit, mono PCM audio. The HTTP service receives WAV audio and converts it to raw PCM frames for Pipecat.
 - **WebSocket sessions**: The WebSocket service uses a persistent connection and can send multiple text requests over the same session.
+- **Voice selection**: Use `voice` for preset speaker voices. The service sends this setting to Rumik as `speaker`.
+- **Model steering**: `muga` can be steered with tone tags in the input text. Expressive models can use `description`, optional preset `voice`, and `f0_up_key`.
 - **Interruption handling**: The WebSocket service reconnects when Pipecat interrupts active playback.
 - **Full-response aggregation**: `RumikTTSService` defaults to `full_response_aggregation=True`, which sends one complete LLM response per synthesis request.
 

--- a/docs.json
+++ b/docs.json
@@ -412,6 +412,7 @@
                       "api-reference/server/services/tts/piper",
                       "api-reference/server/services/tts/resembleai",
                       "api-reference/server/services/tts/rime",
+                      "api-reference/server/services/tts/rumik",
                       "api-reference/server/services/tts/sarvam",
                       "api-reference/server/services/tts/smallest",
                       "api-reference/server/services/tts/soniox",
@@ -1826,6 +1827,10 @@
     {
       "source": "/server/services/tts/rime",
       "destination": "/api-reference/server/services/tts/rime"
+    },
+    {
+      "source": "/server/services/tts/rumik",
+      "destination": "/api-reference/server/services/tts/rumik"
     },
     {
       "source": "/server/services/tts/sarvam",


### PR DESCRIPTION
## Summary

  Adds documentation for Rumik text-to-speech services.

  This includes:

  - a new Rumik TTS service page
  - configuration docs for `RumikTTSService` and `RumikHttpTTSService`
  - `RumikTTSSettings` settings tables
  - WebSocket, HTTP, and runtime settings usage examples
  - notes and event handlers
  - `docs.json` navigation and redirect entries

  ## Checks

  - `npx prettier --check docs.json api-reference/server/services/tts/rumik.mdx`
  - `node -e "JSON.parse(require('fs').readFileSync('docs.json','utf8')); console.log('docs.json valid')"`