### PR TITLE
docs: update for pipecat PR #4665

### DIFF
--- a/api-reference/server/frames/control-frames.mdx
+++ b/api-reference/server/frames/control-frames.mdx
@@ -231,6 +231,13 @@ Signals the beginning of a TTS audio response.
   Identifier linking this TTS output to its originating context.
 </ParamField>
 
+<ParamField path="append_to_context" type="bool" default="True">
+  Whether the spoken text for this response will be appended to the LLM
+  context. When `True`, the assistant aggregator will track this output as an
+  assistant turn, firing `on_assistant_turn_started` and
+  `on_assistant_turn_stopped` events.
+</ParamField>
+
 ### TTSStoppedFrame
 
 Signals the end of a TTS audio response.

--- a/api-reference/server/utilities/turn-management/turn-events.mdx
+++ b/api-reference/server/utilities/turn-management/turn-events.mdx
@@ -197,6 +197,12 @@ async def on_assistant_turn_started(aggregator):
 | ------------ | ------------------------ | --------------------------------- |
 | `aggregator` | `LLMAssistantAggregator` | The assistant aggregator instance |
 
+<Note>
+  This event fires for both LLM responses and `TTSSpeakFrame` utterances (when
+  `append_to_context=True`). For `TTSSpeakFrame` utterances, the event fires as
+  soon as the TTS service begins speaking.
+</Note>
+
 ### on_assistant_turn_stopped
 
 Fired when the assistant finishes responding or is interrupted. This event includes the complete assistant transcript for the turn.
@@ -218,10 +224,11 @@ async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMes
 | `message`    | `AssistantTurnStoppedMessage` | Contains the assistant's transcript and metadata |
 
 <Note>
-  This event fires when the LLM response completes, when the user interrupts, or
-  when a user image is appended to context. The event always fires when a turn
-  ends, even if `content` is empty (e.g., the turn was interrupted before any
-  tokens were generated).
+  This event fires when an assistant turn ends: when an LLM response or
+  `TTSSpeakFrame` utterance completes, when the user interrupts, or when a user
+  image is appended to context. The event always fires when a turn ends, even if
+  `content` is empty (e.g., the turn was interrupted before any tokens were
+  generated).
 </Note>
 
 ### on_assistant_thought


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4665](https://github.com/pipecat-ai/pipecat/pull/4665).

## Changes

### api-reference/server/frames/control-frames.mdx
- Added `append_to_context` parameter to `TTSStartedFrame` documentation
- Documents the boolean parameter (default `True`) that determines whether the spoken text will be appended to the LLM context
- Explains that when `True`, the assistant aggregator tracks this as an assistant turn and fires turn events

### api-reference/server/utilities/turn-management/turn-events.mdx
- Added Note to `on_assistant_turn_started` clarifying it fires for both LLM responses and `TTSSpeakFrame` utterances
- Updated Note for `on_assistant_turn_stopped` to explicitly mention that it fires for both LLM responses and `TTSSpeakFrame` utterances
- Clarifies the timing: for `TTSSpeakFrame` utterances, the start event now fires when TTS begins speaking (improvement from the bug fix)

## Context

PR #4665 fixed interruption handling for standalone `TTSSpeakFrame(append_to_context=True)` utterances. Previously:
- `on_assistant_turn_stopped` didn't fire when these utterances were interrupted
- Partially-spoken text wasn't recorded to context
- `on_assistant_turn_started` fired at the end rather than the start

The fix adds an `append_to_context` field to `TTSStartedFrame` and uses it to properly track assistant turns for TTS-driven utterances.

## Gaps identified

None - the changes only affect internal frame types and turn management behavior. All relevant documentation has been updated.