### PR TITLE
Add filter_repeated_sequences parameter to MarkdownTextFilter docs

### DIFF
--- a/api-reference/server/utilities/text/markdown-text-filter.mdx
+++ b/api-reference/server/utilities/text/markdown-text-filter.mdx
@@ -35,6 +35,10 @@ Configure the filter behavior with these options:
   Whether to remove Markdown tables from the output
 </ParamField>
 
+<ParamField path="filter_repeated_sequences" type="bool" default="True">
+  Whether to remove repeated sequences of 5 or more identical characters from the output
+</ParamField>
+
 ## Features
 
 The filter handles these Markdown elements:
@@ -43,6 +47,7 @@ The filter handles these Markdown elements:
 - **Code**: Removes inline code ticks and optionally removes code blocks
 - **Lists**: Preserves numbered lists while removing Markdown formatting
 - **Tables**: Optionally removes Markdown tables
+- **Repeated Characters**: Optionally removes sequences of 5+ repeated characters
 - **Whitespace**: Carefully preserves meaningful whitespace for natural speech
 - **HTML**: Removes HTML tags and converts entities to their plain text equivalents
 
@@ -77,6 +82,17 @@ md_filter = MarkdownTextFilter(
 )
 ```
 
+### Preserving Repeated Characters
+
+```python
+# Keep repeated characters intact (e.g., for expressive text)
+md_filter = MarkdownTextFilter(
+    params=MarkdownTextFilter.InputParams(
+        filter_repeated_sequences=False
+    )
+)
+```
+
 ## What Gets Removed
 
 | Markdown Feature           | Example                  | Result       |
@@ -88,7 +104,7 @@ md_filter = MarkdownTextFilter(
 | Code blocks (when enabled) | ` ```python\ncode\n``` ` | ` `          |
 | Tables (when enabled)      | `\|A\|B\|\n\|--\|--\|`   | ` `          |
 | HTML tags                  | `<em>text</em>`          | `text`       |
-| Repeated characters        | `!!!!!!!`                | `!`          |
+| Repeated characters (when enabled) | `!!!!!!!`       | `!`          |
 
 ## Notes
 

--- a/api-reference/server/utilities/text/markdown-text-filter.mdx
+++ b/api-reference/server/utilities/text/markdown-text-filter.mdx
@@ -85,7 +85,7 @@ md_filter = MarkdownTextFilter(
 ### Preserving Repeated Characters
 
 ```python
-# Keep repeated characters intact (e.g., for expressive text)
+# Keep repeated characters intact (e.g., for phone extension numbers like 22222)
 md_filter = MarkdownTextFilter(
     params=MarkdownTextFilter.InputParams(
         filter_repeated_sequences=False
@@ -104,7 +104,7 @@ md_filter = MarkdownTextFilter(
 | Code blocks (when enabled) | ` ```python\ncode\n``` ` | ` `          |
 | Tables (when enabled)      | `\|A\|B\|\n\|--\|--\|`   | ` `          |
 | HTML tags                  | `<em>text</em>`          | `text`       |
-| Repeated characters (when enabled) | `!!!!!!!`       | `!`          |
+| Repeated characters (when enabled) | `22222`         | *(removed)*  |
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Documents the new `filter_repeated_sequences` parameter added to `MarkdownTextFilter.InputParams` in pipecat-ai/pipecat#4674.

## Changes

- Added `<ParamField>` entry for `filter_repeated_sequences` in Input Parameters section
- Updated Features list to note repeated character removal is optional
- Added a "Preserving Repeated Characters" usage example
- Updated the "What Gets Removed" table to clarify the behavior is conditional