### PR TITLE
Add Rumik AI community integration

### DIFF
--- a/api-reference/server/services/community-integrations.mdx
+++ b/api-reference/server/services/community-integrations.mdx
@@ -85,6 +85,7 @@ Text-to-Speech services receive text input and output audio streams or chunks.
 | [Murf AI](https://murf.ai/api)                                   | https://github.com/murf-ai/pipecat-murf-tts                  | [murf-ai](https://github.com/murf-ai)                               |
 | [Pipecat TTS Cache](https://pypi.org/project/pipecat-tts-cache/) | https://github.com/omChauhanDev/pipecat-tts-cache            | [omChauhanDev](https://github.com/omChauhanDev)                     |
 | [Respeecher](https://www.respeecher.com/real-time-tts-api)       | https://github.com/respeecher/pipecat-respeecher             | [respeecher](https://github.com/respeecher)                         |
+| [Rumik AI](https://rumik.ai/)                                    | https://github.com/ira-rumik/pipecat-rumik                   | [ira-rumik](https://github.com/ira-rumik)                           |
 | [Simplismart](https://simplismart.ai)                            | https://github.com/simpli-smart/pipecat-simplismart          | [simpli-smart](https://github.com/simpli-smart)                     |
 | [Supertonic](https://github.com/supertone-inc/supertonic)        | https://github.com/architjambhule66-debug/pipecat-supertonic | [architjambhule66-debug](https://github.com/architjambhule66-debug) |
 | [Typecast](https://typecast.ai/)                                 | https://github.com/neosapience/pipecat-typecast              | [neosapience](https://github.com/neosapience)                       |


### PR DESCRIPTION
Adds Rumik AI to the Text-to-Speech section of the Community Integrations page.

  Package/repo:
  - https://github.com/ira-rumik/pipecat-rumik
  - https://pypi.org/project/pipecat-rumik/0.1.3/

  The package provides:
  - `RumikTTSService` for WebSocket streaming TTS
  - `RumikHttpTTSService` for HTTP TTS
  - `RumikTTSSettings` for runtime-configurable settings

  The package repo includes README usage docs, examples, tests, changelog .