### PR TITLE
docs: update for pipecat PR #4687

### DIFF
--- a/api-reference/server/services/llm/sambanova.mdx
+++ b/api-reference/server/services/llm/sambanova.mdx
@@ -95,7 +95,7 @@ from pipecat.services.sambanova import SambaNovaLLMService
 
 llm = SambaNovaLLMService(
     api_key=os.getenv("SAMBANOVA_API_KEY"),
-    model="Llama-4-Maverick-17B-128E-Instruct",
+    model="Meta-Llama-3.3-70B-Instruct",
 )
 ```
 
@@ -107,7 +107,7 @@ from pipecat.services.sambanova import SambaNovaLLMService
 llm = SambaNovaLLMService(
     api_key=os.getenv("SAMBANOVA_API_KEY"),
     settings=SambaNovaLLMService.Settings(
-        model="Llama-4-Maverick-17B-128E-Instruct",
+        model="Meta-Llama-3.3-70B-Instruct",
         temperature=0.7,
         top_p=0.9,
         max_tokens=1024,


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4687](https://github.com/pipecat-ai/pipecat/pull/4687).

## Changes

- **api-reference/server/services/llm/sambanova.mdx**: Updated default model in usage examples from `Llama-4-Maverick-17B-128E-Instruct` to `Meta-Llama-3.3-70B-Instruct`. SambaNova Cloud removed the old default model, so both the basic setup example and the custom settings example now reference the new default.

## Gaps identified

None