### PR TITLE
docs: update for pipecat PR #4688

### DIFF
--- a/api-reference/server/services/llm/nebius.mdx
+++ b/api-reference/server/services/llm/nebius.mdx
@@ -50,7 +50,7 @@ Before using Nebius LLM services, you need:
 
 1. **Nebius Account**: Sign up at [Nebius](https://nebius.com/)
 2. **API Key**: Generate an API key from the Token Factory dashboard
-3. **Model Selection**: Choose from available models (default: `openai/gpt-oss-120b`)
+3. **Model Selection**: Choose from available models (default: `Qwen/Qwen3-30B-A3B-Instruct-2507`)
 
 ### Required Environment Variables
 
@@ -80,7 +80,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 | Parameter           | Type    | Default                 | Description                                                                            |
 | ------------------- | ------- | ----------------------- | -------------------------------------------------------------------------------------- |
-| `model`             | `str`   | `"openai/gpt-oss-120b"` | Nebius model identifier. Check Nebius Token Factory for available models.              |
+| `model`             | `str`   | `"Qwen/Qwen3-30B-A3B-Instruct-2507"` | Nebius model identifier. Check Nebius Token Factory for available models.              |
 | `temperature`       | `float` | `NOT_GIVEN`             | Sampling temperature (0.0 to 2.0). Lower values are more focused, higher are creative. |
 | `max_tokens`        | `int`   | `NOT_GIVEN`             | Maximum tokens to generate.                                                            |
 | `top_p`             | `float` | `NOT_GIVEN`             | Top-p (nucleus) sampling (0.0 to 1.0). Controls diversity of output.                   |
@@ -115,7 +115,7 @@ from pipecat.services.nebius import NebiusLLMService
 llm = NebiusLLMService(
     api_key=os.getenv("NEBIUS_API_KEY"),
     settings=NebiusLLMService.Settings(
-        model="openai/gpt-oss-120b",
+        model="Qwen/Qwen3-30B-A3B-Instruct-2507",
         temperature=0.7,
         max_tokens=1000,
     ),


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4688](https://github.com/pipecat-ai/pipecat/pull/4688).

## Changes

- **api-reference/server/services/llm/nebius.mdx**: Updated default model from `openai/gpt-oss-120b` to `Qwen/Qwen3-30B-A3B-Instruct-2507` in:
  - Prerequisites section (Model Selection note)
  - Settings table (model parameter default)
  - Usage example (With Custom Settings)

## Gaps identified

None