### PR TITLE
docs: update for pipecat PR #4684

### DIFF
--- a/api-reference/server/services/stt/whisper.mdx
+++ b/api-reference/server/services/stt/whisper.mdx
@@ -54,6 +54,11 @@ uv add "pipecat-ai[whisper]"
 uv add "pipecat-ai[mlx-whisper]"
 ```
 
+<Note>
+  MLX Whisper requires macOS on Apple Silicon (arm64). It will not work on other
+  platforms, including Intel Macs.
+</Note>
+
 ## Prerequisites
 
 ### Local Model Setup
@@ -246,5 +251,7 @@ stt = WhisperSTTServiceMLX(
 - **First run downloads**: If the selected model hasn't been downloaded previously, the first run will download it from the Hugging Face model hub. This may take significant time depending on model size.
 - **Segmented transcription**: Both `WhisperSTTService` and `WhisperSTTServiceMLX` extend `SegmentedSTTService`, meaning they process complete audio segments after VAD detects the user has stopped speaking.
 - **No-speech filtering**: The `no_speech_prob` threshold helps filter out hallucinations. Increase it to be more permissive, decrease it to filter more aggressively.
+- **MLX platform requirement**: `WhisperSTTServiceMLX` requires macOS on Apple Silicon (arm64). On other platforms (including Intel Macs), use `WhisperSTTService` instead.
 - **MLX quantization**: The `LARGE_V3_TURBO_Q4` model provides reduced memory usage with minimal quality loss on Apple Silicon.
+- **Model enums**: `Model` and `MLXModel` are `StrEnum` types, meaning enum members can be compared directly to strings (e.g., `Model.TINY == "tiny"`). Both enum members and plain strings work when setting the model.
 - **Language support**: Whisper supports 99+ languages. Use the `Language` enum for type-safe language selection. The default is `Language.EN` (English). Set `language=None` in settings to enable automatic language detection, which will transcribe whatever language the user speaks.


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4684](https://github.com/pipecat-ai/pipecat/pull/4684).

## Changes

### Updated: `api-reference/server/services/stt/whisper.mdx`

- **Installation section**: Added platform requirement note for MLX Whisper (macOS Apple Silicon only)
- **Notes section**: 
  - Added MLX platform requirement clarification (macOS arm64 only, not Intel Macs)
  - Documented that `Model` and `MLXModel` are now `StrEnum` types, allowing direct string comparison
  - Noted that both enum members and plain strings work for model selection

## Context

PR #4684 changed `Model` and `MLXModel` from `Enum` to `StrEnum`, making enum members directly comparable to strings (e.g., `Model.TINY == "tiny"`). The API remains backward compatible.

The PR also added platform-specific import handling for MLX Whisper to prevent import errors on non-macOS platforms, as MLX is only available on macOS with Apple Silicon.

## Gaps identified

None