### PR TITLE
fix(typo): correct env.example to .env.example in quickstart and deployment docs

### DIFF
--- a/client/get-started/quickstart.mdx
+++ b/client/get-started/quickstart.mdx
@@ -84,7 +84,7 @@ The rest is up to you! The CLI generates a complete project with two main direct
 
 ```bash
 cd my-voice-app/bot
-cp env.example .env       # add your API keys
+cp .env.example .env       # add your API keys
 uv sync
 uv run bot.py
 ```
@@ -194,7 +194,7 @@ async connect() {
 
 ## Deploying to production
 
-The `env.example` file shows the production configuration. Point `VITE_BOT_START_URL` at your deployed bot's start endpoint:
+The `.env.example` file shows the production configuration. Point `VITE_BOT_START_URL` at your deployed bot's start endpoint:
 
 ```bash
 # Pipecat Cloud

--- a/pipecat/deployment/platforms/modal.mdx
+++ b/pipecat/deployment/platforms/modal.mdx
@@ -66,7 +66,7 @@ This guide walks through the Modal example included in the Pipecat repository. A
 
 ```bash
 cd server
-cp env.example .env
+cp .env.example .env
 # Modify .env to provide your service API Keys
 ```
 

--- a/pipecat/get-started/quickstart.mdx
+++ b/pipecat/get-started/quickstart.mdx
@@ -77,7 +77,7 @@ cd pipecat-quickstart
 Create your environment file:
 
 ```bash
-cp env.example .env
+cp .env.example .env
 ```
 
 Open the `.env` file in your text editor and add your API keys:


### PR DESCRIPTION
Hey folks

As I was testing the quickstart, I got stuck at the step where you copy the environment template
 `cp env.example .env` was failing with a "no such file" error, because the actual file is named `.env.example` (with a leading dot).

I found the same typo in a couple of other places too (the Modal deployment guide and the client quickstart).

This PR updates them all to the correct file name.