### PR TITLE
docs: add available voices list to Mistral TTS page

### DIFF
--- a/api-reference/server/services/tts/mistral.mdx
+++ b/api-reference/server/services/tts/mistral.mdx
@@ -8,6 +8,7 @@ description: "Text-to-speech service using Mistral's Voxtral TTS API"
 `MistralTTSService` provides text-to-speech synthesis using Mistral's Voxtral TTS API. It uses HTTP streaming with Server-Sent Events to generate PCM-encoded audio at 24kHz.
 
 Key features include:
+
 - Streaming TTS with real-time audio generation
 - Automatic resampling to pipeline sample rate
 - Built-in metrics support
@@ -78,11 +79,11 @@ Before using `MistralTTSService`, you need:
 
 Runtime-configurable settings passed via the `settings` constructor argument using `MistralTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter  | Type              | Default                  | Description                                 |
-| ---------- | ----------------- | ------------------------ | ------------------------------------------- |
-| `model`    | `str`             | `"voxtral-mini-tts-2603"` | Mistral TTS model to use. _(Inherited.)_    |
-| `voice`    | `str`             | `None`                   | Voice identifier. _(Inherited.)_            |
-| `language` | `Language \| str` | `None`                   | Language for synthesis. _(Inherited.)_      |
+| Parameter  | Type              | Default                   | Description                              |
+| ---------- | ----------------- | ------------------------- | ---------------------------------------- |
+| `model`    | `str`             | `"voxtral-mini-tts-2603"` | Mistral TTS model to use. _(Inherited.)_ |
+| `voice`    | `str`             | `None`                    | Voice identifier. _(Inherited.)_         |
+| `language` | `Language \| str` | `None`                    | Language for synthesis. _(Inherited.)_   |
 
 ## Available Voices
 
@@ -96,50 +97,28 @@ curl "https://api.mistral.ai/v1/audio/voices?limit=200&offset=0" \
   -H "Authorization: Bearer $MISTRAL_API_KEY"
 ```
 
-### 🇫🇷 French (fr_fr) — Marie
+You will have to extract the 'slug' or 'id' field from the response for each voice to use in the `voice` setting, for example:
 
-| Slug               | Mood    | UUID                                   |
-| ------------------ | ------- | -------------------------------------- |
-| `fr_marie_neutral` | Neutral | `5a271406-039d-46fe-835b-fbbb00eaf08d` |
-| `fr_marie_happy`   | Happy   | `49d024dd-981b-4462-bb17-74d381eb8fd7` |
-| `fr_marie_sad`     | Sad     | `4adeb2c6-25a3-44bc-8100-5234dfc1193b` |
-| `fr_marie_excited` | Excited | `2f62b1af-aea3-4079-9d10-7ca665ee7243` |
-| `fr_marie_curious` | Curious | `e0580ce5-e63c-4cbe-88c8-a983b80c5f1f` |
-| `fr_marie_angry`   | Angry   | `a7c07cdc-1c35-4d87-a938-c610a654f600` |
+```json
+{
+  "name": "Marie - Neutral",
+  "slug": "fr_marie_neutral",
+  "languages": ["fr_fr"],
+  "gender": "female",
+  "age": 30,
+  "tags": ["composed", "steady", "neutral"],
+  "color": "#77778B",
+  "description": null,
+  "appearance": null,
+  "retention_notice": 30,
+  "id": "5a271406-039d-46fe-835b-fbbb00eaf08d",
+  "created_at": "2026-03-12T09:46:53.411124Z",
+  "user_id": null,
+  "trimmed_seconds": null
+}
+```
 
-### 🇬🇧 British English (en_gb) — Oliver & Jane
-
-| Slug                  | Mood       | UUID                                   |
-| --------------------- | ---------- | -------------------------------------- |
-| `gb_oliver_neutral`   | Neutral    | `e3596645-b1af-469e-b857-f18ddedc7652` |
-| `gb_oliver_sad`       | Sad        | `d4101b8f-12c3-450d-a812-7d700b3a3245` |
-| `gb_oliver_excited`   | Excited    | `e8e5b1de-493c-4061-8414-e2170f9f4b6f` |
-| `gb_oliver_curious`   | Curious    | `390c8a2b-60a6-4882-8437-c49a8bd33b63` |
-| `gb_oliver_confident` | Confident  | `8169ab87-bc99-4669-a5ec-6855860ace24` |
-| `gb_oliver_cheerful`  | Cheerful   | `5ad5d44e-6b4e-4a57-a8a8-4cae088034ed` |
-| `gb_oliver_angry`     | Angry      | `862274a7-8333-48f7-b668-f19c932999e0` |
-| `gb_jane_neutral`     | Neutral    | `82c99ee6-f932-423f-a4a3-d403c8914b8d` |
-| `gb_jane_sad`         | Sad        | `c7a8eb83-5247-4540-89f3-6650d349100d` |
-| `gb_jane_curious`     | Curious    | `5de47977-6e47-4266-a938-3bc1d76b4676` |
-| `gb_jane_confident`   | Confident  | `cbe96cf0-85ec-4a10-accb-0b35c93b6dfd` |
-| `gb_jane_frustrated`  | Frustrated | `60844938-221d-4d1e-8233-34203f787d9f` |
-| `gb_jane_jealousy`    | Jealousy   | `e7168caa-f7ed-4e1c-98a1-434251f4f2b0` |
-| `gb_jane_shameful`    | Shameful   | `230ccacf-8800-4aa0-8ac2-8d004f1d9fb7` |
-| `gb_jane_sarcasm`     | Sarcasm    | `a3e41ea8-020b-44c0-8d8b-f6cc03524e31` |
-| `gb_jane_confused`    | Confused   | `7d0a90a3-c211-4489-aaa0-61269299edc7` |
-
-### 🇺🇸 American English (en_us) — Paul
-
-| Slug                 | Mood       | UUID                                   |
-| -------------------- | ---------- | -------------------------------------- |
-| `en_paul_neutral`    | Neutral    | `c69964a6-ab8b-4f8a-9465-ec0925096ec8` |
-| `en_paul_sad`        | Sad        | `530e2e20-58e2-45d8-b0a5-4594f4915944` |
-| `en_paul_happy`      | Happy      | `1024d823-a11e-43ee-bf3d-d440dccc0577` |
-| `en_paul_frustrated` | Frustrated | `1f017bcb-02e5-460d-989b-db065c0c6122` |
-| `en_paul_excited`    | Excited    | `5940190b-f58a-4c3e-8264-a40d63fd6883` |
-| `en_paul_confident`  | Confident  | `98559b22-62b5-4a64-a7cd-fc78ca41faa8` |
-| `en_paul_cheerful`   | Cheerful   | `01d985cd-5e0c-4457-bfd8-80ba31a5bc03` |
-| `en_paul_angry`      | Angry      | `cb891218-482c-4392-9878-91e8d999d57a` |
+Slug example: `fr_marie_neutral` and UUID example: `5a271406-039d-46fe-835b-fbbb00eaf08d` can both be used as the `voice` identifier in the service settings.
 
 ## Usage
 
@@ -155,6 +134,7 @@ tts = MistralTTSService(
 ```
 
 ### With a Built-in Voice
+
 ```python
 tts = MistralTTSService(
     api_key=os.getenv("MISTRAL_API_KEY"),

--- a/api-reference/server/services/tts/mistral.mdx
+++ b/api-reference/server/services/tts/mistral.mdx
@@ -84,6 +84,63 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 | `voice`    | `str`             | `None`                   | Voice identifier. _(Inherited.)_            |
 | `language` | `Language \| str` | `None`                   | Language for synthesis. _(Inherited.)_      |
 
+## Available Voices
+
+Mistral provides built-in voices grouped by language. The `voice` setting accepts
+either the **slug** (e.g. `fr_marie_neutral`) or the **UUID**.
+
+You can always retrieve the latest list of voices via the Mistral API:
+
+```bash
+curl "https://api.mistral.ai/v1/audio/voices?limit=200&offset=0" \
+  -H "Authorization: Bearer $MISTRAL_API_KEY"
+```
+
+### 🇫🇷 French (fr_fr) — Marie
+
+| Slug               | Mood    | UUID                                   |
+| ------------------ | ------- | -------------------------------------- |
+| `fr_marie_neutral` | Neutral | `5a271406-039d-46fe-835b-fbbb00eaf08d` |
+| `fr_marie_happy`   | Happy   | `49d024dd-981b-4462-bb17-74d381eb8fd7` |
+| `fr_marie_sad`     | Sad     | `4adeb2c6-25a3-44bc-8100-5234dfc1193b` |
+| `fr_marie_excited` | Excited | `2f62b1af-aea3-4079-9d10-7ca665ee7243` |
+| `fr_marie_curious` | Curious | `e0580ce5-e63c-4cbe-88c8-a983b80c5f1f` |
+| `fr_marie_angry`   | Angry   | `a7c07cdc-1c35-4d87-a938-c610a654f600` |
+
+### 🇬🇧 British English (en_gb) — Oliver & Jane
+
+| Slug                  | Mood       | UUID                                   |
+| --------------------- | ---------- | -------------------------------------- |
+| `gb_oliver_neutral`   | Neutral    | `e3596645-b1af-469e-b857-f18ddedc7652` |
+| `gb_oliver_sad`       | Sad        | `d4101b8f-12c3-450d-a812-7d700b3a3245` |
+| `gb_oliver_excited`   | Excited    | `e8e5b1de-493c-4061-8414-e2170f9f4b6f` |
+| `gb_oliver_curious`   | Curious    | `390c8a2b-60a6-4882-8437-c49a8bd33b63` |
+| `gb_oliver_confident` | Confident  | `8169ab87-bc99-4669-a5ec-6855860ace24` |
+| `gb_oliver_cheerful`  | Cheerful   | `5ad5d44e-6b4e-4a57-a8a8-4cae088034ed` |
+| `gb_oliver_angry`     | Angry      | `862274a7-8333-48f7-b668-f19c932999e0` |
+| `gb_jane_neutral`     | Neutral    | `82c99ee6-f932-423f-a4a3-d403c8914b8d` |
+| `gb_jane_sad`         | Sad        | `c7a8eb83-5247-4540-89f3-6650d349100d` |
+| `gb_jane_curious`     | Curious    | `5de47977-6e47-4266-a938-3bc1d76b4676` |
+| `gb_jane_confident`   | Confident  | `cbe96cf0-85ec-4a10-accb-0b35c93b6dfd` |
+| `gb_jane_frustrated`  | Frustrated | `60844938-221d-4d1e-8233-34203f787d9f` |
+| `gb_jane_jealousy`    | Jealousy   | `e7168caa-f7ed-4e1c-98a1-434251f4f2b0` |
+| `gb_jane_shameful`    | Shameful   | `230ccacf-8800-4aa0-8ac2-8d004f1d9fb7` |
+| `gb_jane_sarcasm`     | Sarcasm    | `a3e41ea8-020b-44c0-8d8b-f6cc03524e31` |
+| `gb_jane_confused`    | Confused   | `7d0a90a3-c211-4489-aaa0-61269299edc7` |
+
+### 🇺🇸 American English (en_us) — Paul
+
+| Slug                 | Mood       | UUID                                   |
+| -------------------- | ---------- | -------------------------------------- |
+| `en_paul_neutral`    | Neutral    | `c69964a6-ab8b-4f8a-9465-ec0925096ec8` |
+| `en_paul_sad`        | Sad        | `530e2e20-58e2-45d8-b0a5-4594f4915944` |
+| `en_paul_happy`      | Happy      | `1024d823-a11e-43ee-bf3d-d440dccc0577` |
+| `en_paul_frustrated` | Frustrated | `1f017bcb-02e5-460d-989b-db065c0c6122` |
+| `en_paul_excited`    | Excited    | `5940190b-f58a-4c3e-8264-a40d63fd6883` |
+| `en_paul_confident`  | Confident  | `98559b22-62b5-4a64-a7cd-fc78ca41faa8` |
+| `en_paul_cheerful`   | Cheerful   | `01d985cd-5e0c-4457-bfd8-80ba31a5bc03` |
+| `en_paul_angry`      | Angry      | `cb891218-482c-4392-9878-91e8d999d57a` |
+
 ## Usage
 
 ### Basic Setup
@@ -97,7 +154,21 @@ tts = MistralTTSService(
 )
 ```
 
-### With Custom Settings
+### With a Built-in Voice
+```python
+tts = MistralTTSService(
+    api_key=os.getenv("MISTRAL_API_KEY"),
+    settings=MistralTTSService.Settings(
+        model="voxtral-mini-tts-2603",
+        voice="fr_marie_neutral",  # see Available Voices section for all slugs
+        language="fr",
+    ),
+)
+```
+
+### With a Custom Voice
+
+If you have created a custom voice in your Mistral account, use its UUID as the `voice` identifier:
 
 ```python
 import os
@@ -106,9 +177,7 @@ from pipecat.services.mistral import MistralTTSService
 tts = MistralTTSService(
     api_key=os.getenv("MISTRAL_API_KEY"),
     settings=MistralTTSService.Settings(
-        model="voxtral-mini-tts-2603",
-        voice="your-voice-id",
-        language="en",
+        voice="your-custom-voice-uuid",  # UUID from your Mistral account dashboard
     ),
 )
 ```
@@ -130,6 +199,7 @@ tts = MistralTTSService(
 - **Audio format conversion**: The Mistral API returns base64-encoded float32 PCM chunks via Server-Sent Events. The service automatically converts these to int16 PCM for the Pipecat pipeline.
 - **Native sample rate**: Mistral's TTS API outputs audio at 24kHz. When a different sample rate is specified, the service automatically resamples the audio.
 - **Streaming**: The service uses HTTP streaming with Server-Sent Events for real-time audio generation, allowing for low-latency synthesis.
+- **Voice identifiers**: Both slugs (e.g. `fr_marie_neutral`) and UUIDs are accepted. Built-in voice slugs are listed in the [Available Voices](#available-voices) section. Custom voices created in your Mistral account dashboard are referenced by their UUID.
 
 ## Event Handlers
 


### PR DESCRIPTION
## What
- Adds a complete "Available Voices" section to the Mistral TTS documentation page,
  listing all 30 built-in voices available via the Voxtral TTS API
- Renames "With Custom Settings" to "With a Built-in Voice" and adds a separate
  "With a Custom Voice" section to clarify the difference

## Why
The `voice` parameter was documented but with no indication of valid values,
causing errors like `Voice 'neutral_female' not found` (HTTP 404) for users
who guessed descriptive names instead of using the correct slugs or UUIDs.
The distinction between built-in voices and custom (user-created) voices was
also not clear.

## Changes
- Added "Available Voices" section between Settings and Usage, listing all 30
  voices grouped by language (fr_fr, en_gb, en_us) with slug, mood and UUID
- Added curl snippet showing how to fetch the latest voice list from the API
- Renamed "With Custom Settings" to "With a Built-in Voice" with a real slug example
- Added new "With a Custom Voice" section explaining UUID usage for custom voices
- Added a note clarifying that both slugs and UUIDs are accepted

## How voices were verified
Voices retrieved on 2026-06-11 via:
  GET https://api.mistral.ai/v1/audio/voices?limit=200&offset=0

Note: Mistral may add or remove voices over time. The curl snippet is included
so users can always fetch the current list themselves.