### PR TITLE
docs: update for pipecat PR #4686

### DIFF
--- a/api-reference/server/services/transport/vonage.mdx
+++ b/api-reference/server/services/transport/vonage.mdx
@@ -83,8 +83,10 @@ Before using `VonageVideoConnectorTransport`, you need:
 
 - **Vonage Video API**: Integrate with Vonage's managed WebRTC infrastructure
 - **Audio and Video I/O**: Bidirectional audio and video streaming
+- **Captions Support**: Real-time caption/transcription streaming from participants
+- **Individual Audio Streams**: Per-subscriber audio stream access with separate resampling
 - **Participant Management**: Stream subscription and participant lifecycle events
-- **Auto-subscription**: Optionally auto-subscribe to incoming audio and video streams
+- **Auto-subscription**: Optionally auto-subscribe to incoming audio, video, and caption streams
 - **Interruption Handling**: Automatic media buffer clearing on pipeline interruptions
 
 ## Configuration
@@ -143,6 +145,15 @@ Inherits all parameters from [TransportParams](/api-reference/server/services/tr
   participants.
 </ParamField>
 
+<ParamField path="captions_in_enabled" type="bool" default="False">
+  Whether to enable captions input processing from participant streams.
+</ParamField>
+
+<ParamField path="captions_in_auto_subscribe" type="bool" default="False">
+  Whether to automatically subscribe to incoming caption streams from session
+  participants.
+</ParamField>
+
 <ParamField
   path="video_in_preferred_resolution"
   type="tuple[int, int]"
@@ -171,7 +182,7 @@ Inherits all parameters from [TransportParams](/api-reference/server/services/tr
 
 ### SubscribeSettings
 
-Used with `subscribe_to_stream()` to control per-stream subscription quality when `audio_in_auto_subscribe` or `video_in_auto_subscribe` are disabled.
+Used with `subscribe_to_stream()` to control per-stream subscription quality when `audio_in_auto_subscribe`, `video_in_auto_subscribe`, or `captions_in_auto_subscribe` are disabled.
 
 <ParamField path="subscribe_to_audio" type="bool" default="True">
   Whether to subscribe to the stream's audio track.
@@ -179,6 +190,10 @@ Used with `subscribe_to_stream()` to control per-stream subscription quality whe
 
 <ParamField path="subscribe_to_video" type="bool" default="False">
   Whether to subscribe to the stream's video track.
+</ParamField>
+
+<ParamField path="subscribe_to_captions" type="bool" default="False">
+  Whether to subscribe to the stream's caption track.
 </ParamField>
 
 <ParamField path="preferred_resolution" type="tuple[int, int]" default="None">
@@ -227,7 +242,7 @@ See the [complete example](https://github.com/pipecat-ai/pipecat/blob/main/examp
 
 ### Subscribing to streams manually
 
-When `audio_in_auto_subscribe` or `video_in_auto_subscribe` is disabled, subscribe to a specific participant's stream with `subscribe_to_stream()`, passing [SubscribeSettings](#subscribesettings) to control which tracks are received and at what quality. The `streamId` is available from the `on_participant_joined` event data.
+When `audio_in_auto_subscribe`, `video_in_auto_subscribe`, or `captions_in_auto_subscribe` is disabled, subscribe to a specific participant's stream with `subscribe_to_stream()`, passing [SubscribeSettings](#subscribesettings) to control which tracks are received and at what quality. The `streamId` is available from the `on_participant_joined` event data.
 
 ```python
 from pipecat.transports.vonage.video_connector import SubscribeSettings
@@ -237,6 +252,7 @@ await transport.subscribe_to_stream(
     params=SubscribeSettings(
         subscribe_to_audio=True,
         subscribe_to_video=True,
+        subscribe_to_captions=True,
         preferred_resolution=(1280, 720),
         preferred_framerate=30,
     ),


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4686](https://github.com/pipecat-ai/pipecat/pull/4686).

## Changes
- **Vonage transport** (`api-reference/server/services/transport/vonage.mdx`):
  - Added `captions_in_enabled` parameter for enabling caption input processing
  - Added `captions_in_auto_subscribe` parameter for auto-subscribing to caption streams
  - Added `subscribe_to_captions` parameter to SubscribeSettings for manual stream subscription
  - Updated Key Features section to mention captions support and per-subscriber audio stream access
  - Updated manual subscription example to include captions parameter

## Gaps identified
None