### PR TITLE
docs: update for pipecat PR #4716

### DIFF
--- a/api-reference/server/services/transport/transport-params.mdx
+++ b/api-reference/server/services/transport/transport-params.mdx
@@ -168,5 +168,9 @@ Each transport extends `TransportParams` with provider-specific fields:
 | [DailyTransport](/api-reference/server/services/transport/daily)                        | `DailyParams`            | `api_key`, `api_url`, `dialin_settings`, `transcription_enabled`, `transcription_settings` |
 | [LiveKitTransport](/api-reference/server/services/transport/livekit)                    | `LiveKitParams`          | (no additional fields)                                                                     |
 | [SmallWebRTCTransport](/api-reference/server/services/transport/small-webrtc)           | `TransportParams`        | Uses base class directly                                                                   |
-| [WebsocketServerTransport](/api-reference/server/services/transport/websocket-server)   | `WebsocketServerParams`  | `add_wav_header`, `serializer`, `session_timeout`                                          |
+| [WebsocketServerTransport](/api-reference/server/services/transport/websocket-server)   | `WebsocketServerParams`  | `add_wav_header`, `serializer`, `session_timeout` **(deprecated)**                         |
 | [FastAPIWebsocketTransport](/api-reference/server/services/transport/fastapi-websocket) | `FastAPIWebsocketParams` | `serializer`, `session_timeout`                                                            |
+
+<Note>
+**WebsocketServerTransport** is deprecated as of version 1.4.0. Use [FastAPIWebsocketTransport](/api-reference/server/services/transport/fastapi-websocket) instead.
+</Note>

--- a/api-reference/server/services/transport/websocket-server.mdx
+++ b/api-reference/server/services/transport/websocket-server.mdx
@@ -82,6 +82,14 @@ Before using WebSocket transports, you need:
 
 ### WebsocketServerTransport
 
+<Warning>
+**Deprecated in version 1.4.0**
+
+`WebsocketServerTransport` is deprecated and will be removed in a future version. It was intended for development and testing only and has a critical limitation: it only supports a single client at a time.
+
+Use [FastAPIWebsocketTransport](/api-reference/server/services/transport/fastapi-websocket) instead for production use.
+</Warning>
+
 <ParamField path="params" type="WebsocketServerParams" required>
   Transport configuration parameters.
 </ParamField>
@@ -277,11 +285,13 @@ async def on_disconnected(transport, websocket):
 | `transport` | `WebsocketClientTransport` | The transport instance          |
 | `websocket` | `WebSocketClientProtocol`  | The WebSocket connection object |
 
-<Note>
-  The WebSocket server only supports one client connection at a time. If a new
-  client connects while one is already connected, the existing connection will
-  be closed.
-</Note>
+<Warning>
+**Single Client Limitation**
+
+The WebSocket server only supports one client connection at a time. If a new client connects while one is already connected, the existing connection will be closed.
+
+This limitation is why `WebsocketServerTransport` is deprecated in favor of [FastAPIWebsocketTransport](/api-reference/server/services/transport/fastapi-websocket), which supports multiple concurrent clients.
+</Warning>
 
 ## Additional Resources
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4716](https://github.com/pipecat-ai/pipecat/pull/4716).

## Changes

### Updated reference pages
- **api-reference/server/services/transport/websocket-server.mdx**
  - Added deprecation warning to WebsocketServerTransport configuration section (introduced in version 1.4.0)
  - Updated single-client limitation note to reference the deprecation and recommend FastAPIWebsocketTransport
  
- **api-reference/server/services/transport/transport-params.mdx**
  - Marked WebsocketServerTransport as deprecated in the transport subclasses table
  - Added note recommending FastAPIWebsocketTransport as replacement

## Summary

WebsocketServerTransport has been deprecated in pipecat 1.4.0 because it was intended for development and testing only and has a critical limitation: it only supports a single client at a time. The documentation now clearly warns users about this deprecation and directs them to use FastAPIWebsocketTransport instead for production use.

## Gaps identified
None