### PR TITLE
docs(ai-tools): drop hosted Kapa MCP; move Context Hub to uvx + add C…

### DIFF
--- a/pipecat/get-started/ai-tools.mdx
+++ b/pipecat/get-started/ai-tools.mdx
@@ -5,70 +5,9 @@ description: "Use AI coding tools with Pipecat documentation and source code."
 
 Pipecat offers several ways to give AI coding tools access to documentation and source code context, helping you build voice and multimodal applications faster.
 
-## MCP Server
+## Pipecat Context Hub (MCP Server)
 
-The Pipecat docs MCP server is a cloud-hosted service powered by [Kapa.ai](https://www.kapa.ai/) that searches across the full Pipecat documentation site. It returns synthesized answers with source citations, covering guides, API references, and other docs content. No local setup required.
-
-<Tabs>
-  <Tab title="Claude Code">
-    ```bash
-    claude mcp add --transport http pipecat-docs https://daily-docs.mcp.kapa.ai
-    ```
-  </Tab>
-  <Tab title="Codex">
-    ```bash
-    codex mcp add pipecat-docs --url "https://daily-docs.mcp.kapa.ai"
-    ```
-  </Tab>
-  <Tab title="Cursor">
-    <a href="cursor://anysphere.cursor-deeplink/mcp/install?name=pipecat-docs&config=eyJ1cmwiOiJodHRwczovL2RhaWx5LWRvY3MubWNwLmthcGEuYWkifQ%3D%3D">
-      <img
-        noZoom
-        src="https://cursor.com/deeplink/mcp-install-dark.svg"
-        alt="Add Pipecat MCP to Cursor"
-        height="32"
-      />
-    </a>
-
-    Or manually add to your Cursor MCP config:
-
-    ```json
-    {
-      "mcpServers": {
-        "pipecat-docs": {
-          "url": "https://daily-docs.mcp.kapa.ai"
-        }
-      }
-    }
-    ```
-  </Tab>
-  <Tab title="VS Code">
-    <a href="vscode:mcp/install?%7B%22name%22%3A%22pipecat-docs%22%2C%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fdaily-docs.mcp.kapa.ai%22%7D">
-      <img
-        noZoom
-        src="https://img.shields.io/badge/VS_Code-Install_MCP_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white"
-        alt="Add Pipecat MCP to VS Code"
-        height="32"
-      />
-    </a>
-
-    Or manually add to your VS Code MCP config (`.vscode/mcp.json`):
-
-    ```json
-    {
-      "servers": {
-        "pipecat-docs": {
-          "url": "https://daily-docs.mcp.kapa.ai"
-        }
-      }
-    }
-    ```
-  </Tab>
-</Tabs>
-
-## Pipecat Context Hub
-
-[Pipecat Context Hub](https://github.com/pipecat-ai/pipecat-context-hub) is a local-first MCP server that indexes Pipecat documentation, code examples, and framework API source on your machine. Unlike the cloud-hosted MCP server above, Context Hub runs a local vector database and is optimized for coding workflows — it returns relevant source code and snippets rather than synthesized answers, giving your AI coding tool the raw context it needs to solve implementation problems.
+[Pipecat Context Hub](https://github.com/pipecat-ai/pipecat-context-hub) is a local-first MCP server that indexes Pipecat documentation, code examples, and framework API source on your machine. It runs a local vector database and is optimized for coding workflows. It returns relevant source code and snippets rather than synthesized answers, giving your AI coding tool the raw context it needs to solve implementation problems.
 
 Because it runs locally, you can also add your own repositories (public or private) to the index for a more customized context.
 
@@ -76,11 +15,10 @@ Available tools include `search_docs`, `search_examples`, `search_api`, `get_cod
 
 ### Setup
 
+The hub is published to PyPI as `pipecat-ai-context-hub` and runs with [`uv`](https://docs.astral.sh/uv/) — no clone required. Build the local index once:
+
 ```bash
-git clone https://github.com/pipecat-ai/pipecat-context-hub.git
-cd pipecat-context-hub
-uv sync
-uv run pipecat-context-hub refresh   # build local index (~2 min first run)
+uvx pipecat-ai-context-hub refresh   # build local index (~2 min first run)
 ```
 
 ### Add to your coding tool
@@ -88,14 +26,12 @@ uv run pipecat-context-hub refresh   # build local index (~2 min first run)
 <Tabs>
   <Tab title="Claude Code">
     ```bash
-    claude mcp add pipecat-context-hub \
-      -- uv run --directory /path/to/pipecat-context-hub pipecat-context-hub serve
+    claude mcp add pipecat-context-hub -- uvx pipecat-ai-context-hub serve
     ```
   </Tab>
   <Tab title="Codex">
     ```bash
-    codex mcp add pipecat-context-hub \
-      -- uv run --directory /path/to/pipecat-context-hub pipecat-context-hub serve
+    codex mcp add pipecat-context-hub -- uvx pipecat-ai-context-hub serve
     ```
   </Tab>
   <Tab title="Cursor">
@@ -105,18 +41,13 @@ uv run pipecat-context-hub refresh   # build local index (~2 min first run)
     {
       "mcpServers": {
         "pipecat-context-hub": {
-          "command": "uv",
-          "args": [
-            "run",
-            "--directory",
-            "/path/to/pipecat-context-hub",
-            "pipecat-context-hub",
-            "serve"
-          ]
+          "command": "uvx",
+          "args": ["pipecat-ai-context-hub", "serve"]
         }
       }
     }
     ```
+
   </Tab>
   <Tab title="VS Code">
     Add to `.vscode/mcp.json`:
@@ -125,20 +56,29 @@ uv run pipecat-context-hub refresh   # build local index (~2 min first run)
     {
       "servers": {
         "pipecat-context-hub": {
-          "command": "uv",
-          "args": [
-            "run",
-            "--directory",
-            "/path/to/pipecat-context-hub",
-            "pipecat-context-hub",
-            "serve"
-          ]
+          "command": "uvx",
+          "args": ["pipecat-ai-context-hub", "serve"]
         }
       }
     }
     ```
+
   </Tab>
 </Tabs>
+
+A newly added MCP server loads when your coding tool starts a session, so add it before opening the session you want to use it in.
+
+### Use it without MCP
+
+The same tools are available as one-shot CLI commands, so you can query the index from a shell with no MCP setup — handy in a session where the MCP server isn't connected yet:
+
+```bash
+uvx pipecat-ai-context-hub check-deprecation PipelineTask
+uvx pipecat-ai-context-hub search-api "WebsocketServerParams"
+uvx pipecat-ai-context-hub status            # index health / freshness
+```
+
+Each command prints the tool's JSON to stdout. The package name is `pipecat-ai-context-hub`; the command and MCP server are named `pipecat-context-hub` (both spellings of the command resolve once installed).
 
 See the [repo docs](https://github.com/pipecat-ai/pipecat-context-hub) for additional configuration options, including pinning to a specific Pipecat version.
 


### PR DESCRIPTION
Update to latest MCP guidance and Pipecat Context Hub CLI.