### PR TITLE
docs(flows): state the task-message role (developer, not system)

### DIFF
--- a/pipecat-flows/guides/nodes-and-messages.mdx
+++ b/pipecat-flows/guides/nodes-and-messages.mdx
@@ -47,6 +47,10 @@ The role message is a plain string, while task messages use OpenAI format as a l
 ],
 ```
 
+Use the `developer` role for task messages — not `system`. The `role_message`
+already supplies the LLM's system instruction, so a `system`-role task message
+competes with it and can be dropped when the context is summarized.
+
 ### Cross-Provider Compatibility
 
 Task messages use Pipecat's default OpenAI message format and are automatically translated to work with your chosen LLM provider. The `role_message` is sent as the LLM's system instruction via `LLMUpdateSettingsFrame`, which is handled by each provider's implementation.


### PR DESCRIPTION
## Summary

The Flows **nodes-and-messages** guide shows `"role": "developer"` in every `task_messages` example but never states it as a rule. An AI coding agent building a Flows bot reached for `"role": "system"` instead (reasoning "instructions → system role"), which collides with `role_message` — that's the LLM's system instruction — so the duplicate system message is deprioritized and can be dropped on context summarization.

This adds one explicit sentence after the message-format example stating the rule and the reason.

## Why here (not the agent guide)

This is the §3 source agents learn Flows from (`search_docs`). Fixing it where they look is better than documenting a Flows-internal detail in the always-on app-builder guide.

## Companion change

A matching one-line clarification to the `NodeConfig.task_messages` docstring in `pipecat-ai/pipecat-flows` (`types.py`) — so `search_api` carries the same rule — will land via the in-flight flows branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)