### PR TITLE
docs: update for pipecat PR #4723

### DIFF
--- a/api-reference/server/services/transport/fastapi-websocket.mdx
+++ b/api-reference/server/services/transport/fastapi-websocket.mdx
@@ -123,6 +123,14 @@ Inherits from `TransportParams` with additional WebSocket-specific parameters.
   for 20ms at 16kHz PCM16 mono).
 </ParamField>
 
+<ParamField path="ws_close_timeout" type="float" default="0.5">
+  Maximum time, in seconds, to wait for the WebSocket close handshake during
+  disconnect. Prevents a dead or half-closed peer (e.g., a telephony call
+  already torn down on the provider's side) from stalling pipeline shutdown on
+  the ASGI server's close-handshake timeout. Increase it for high-latency peers
+  that need longer to complete a graceful close.
+</ParamField>
+
 ## Usage
 
 FastAPIWebsocketTransport integrates with your FastAPI application to handle telephony WebSocket connections. It works with telephony frame serializers to process audio streams from phone calls.


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4723](https://github.com/pipecat-ai/pipecat/pull/4723).

## Changes
- **api-reference/server/services/transport/fastapi-websocket.mdx** — Added `ws_close_timeout` parameter to FastAPIWebsocketParams Configuration section. This new parameter (default 0.5s) controls the maximum time to wait for the WebSocket close handshake during disconnect, preventing pipeline shutdown stalls when the peer is half-closed (e.g., telephony calls already torn down on the provider's side).

## Gaps identified
None