### PR TITLE
docs: update for pipecat PR #4755

### DIFF
--- a/api-reference/server/services/tts/rime.mdx
+++ b/api-reference/server/services/tts/rime.mdx
@@ -304,9 +304,9 @@ tts = RimeNonJsonTTSService(
 
 `RimeTTSService` provides a set of helper methods for implementing Rime-specific customizations, meant to be used as part of text transformers. These include methods for spelling out text, adjusting speech rate, and modifying pitch. See the [Text Transformers for TTS](/pipecat/learn/text-to-speech#text-transforms) section in the Text-to-Speech guide for usage examples.
 
-### SPELL(text: str) -> str:
+### RimeTTSService.SPELL(text: str) -> str
 
-Implements [Rime's spell function](https://docs.rime.ai/api-reference/spell) to spell out text character by character.
+Static method that implements [Rime's spell function](https://docs.rime.ai/api-reference/spell) to spell out text character by character. Call this method on the class, not on an instance.
 
 ```python
 # Text transformers for TTS
@@ -322,9 +322,9 @@ tts = RimeTTSService(
 )
 ```
 
-### PAUSE_TAG(seconds: float) -> str:
+### RimeTTSService.PAUSE_TAG(seconds: float) -> str
 
-Implements [Rime's custom pause functionality](https://docs.rime.ai/api-reference/custom-pauses) to generate a properly formatted pause tag you can insert into the text.
+Static method that implements [Rime's custom pause functionality](https://docs.rime.ai/api-reference/custom-pauses) to generate a properly formatted pause tag you can insert into the text. Call this method on the class, not on an instance.
 
 ```python
 # Text transformers for TTS


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4755](https://github.com/pipecat-ai/pipecat/pull/4755).

## Changes
- **api-reference/server/services/tts/rime.mdx** — Updated `SPELL()` and `PAUSE_TAG()` method signatures to indicate they are static methods. Changed headers from `SPELL(text: str) -> str:` to `RimeTTSService.SPELL(text: str) -> str` and added clarification that these methods should be called on the class, not on an instance.

## Gaps identified
None