### PR TITLE
docs(ai-tools): reframe Pipecat Context Hub section CLI-first

### DIFF
--- a/pipecat/get-started/ai-tools.mdx
+++ b/pipecat/get-started/ai-tools.mdx
@@ -5,23 +5,66 @@ description: "Use AI coding tools with Pipecat documentation and source code."
 
 Pipecat offers several ways to give AI coding tools access to documentation and source code context, helping you build voice and multimodal applications faster.
 
-## Pipecat Context Hub (MCP Server)
+## Pipecat Context Hub (CLI and MCP)
 
-[Pipecat Context Hub](https://github.com/pipecat-ai/pipecat-context-hub) is a local-first MCP server that indexes Pipecat documentation, code examples, and framework API source on your machine. It runs a local vector database and is optimized for coding workflows. It returns relevant source code and snippets rather than synthesized answers, giving your AI coding tool the raw context it needs to solve implementation problems.
+[Pipecat Context Hub](https://github.com/pipecat-ai/pipecat-context-hub) indexes Pipecat documentation, code examples, and framework API source into a local vector database on your machine. It's built for coding workflows: queries return the actual source and snippets your AI tool needs to write working code, not synthesized prose.
 
-Because it runs locally, you can also add your own repositories (public or private) to the index for a more customized context.
+Pipecat's docs, examples, and API surface change often and span several repositories, so a model working from training data goes stale fast. The hub keeps a fresh local index you query directly. You can also point it at your own repositories (public or private) to index private code alongside the framework.
 
-Available tools include `search_docs`, `search_examples`, `search_api`, `get_code_snippet`, and `check_deprecation`.
+Every tool runs two ways: as a one-shot CLI command and as an MCP server. Use the CLI for a quick lookup. Add the MCP server when a session needs repeated, exploratory queries.
 
 ### Setup
 
-The hub is published to PyPI as `pipecat-ai-context-hub` and runs with [`uv`](https://docs.astral.sh/uv/) — no clone required. Build the local index once:
+The hub is published to PyPI as `pipecat-ai-context-hub` and runs with [`uv`](https://docs.astral.sh/uv/), no clone required. Build the local index once:
 
 ```bash
 uvx pipecat-ai-context-hub refresh   # build local index (~2 min first run)
 ```
 
-### Add to your coding tool
+The PyPI package is `pipecat-ai-context-hub`. The command and MCP server are both named `pipecat-context-hub`, and both spellings resolve once installed.
+
+If the index gets corrupted, you can force a rebuild:
+
+```bash
+uvx pipecat-ai-context-hub refresh --force
+```
+
+If your project targets an older Pipecat version, pin the hub to it so results match what you're running:
+
+```bash
+uvx pipecat-ai-context-hub refresh --framework-version v0.0.96
+```
+
+### Tools
+
+| Tool | Use it to |
+|------|-----------|
+| `search_docs` | Find guides and conceptual docs ("how do I ...?") |
+| `search_examples` | Find working example code by task or component |
+| `search_api` | Find class definitions, method signatures, frame types, and inheritance |
+| `get_doc` | Fetch a full doc page by ID or path |
+| `get_example` | Fetch the full source files for an example |
+| `get_code_snippet` | Fetch targeted code by symbol, intent, or file and line range |
+| `check_deprecation` | Check whether an import path is deprecated or removed (can evaluate lifecycle at a specific version) |
+| `get_hub_status` | Report index health, freshness, and the indexed Pipecat version |
+
+The three `search_*` tools return a ranked list of hits, each with a relevance `score`, plus an evidence report carrying an overall `confidence`, a `low_confidence` flag, and suggested follow-up queries. The agent triages that list, picks the best fit, then calls a `get_*` tool to pull the full content. The coding agent can pass your `pipecat_version` to score and filter results compatible with your version.
+
+To make your coding agent reach for these tools automatically, add the [recommended CLAUDE.md / AGENTS.md instructions](https://github.com/pipecat-ai/pipecat-context-hub/blob/main/docs/README.md#add-claudemd-instructions-recommended) to your project.
+
+### Quick lookups with the CLI (recommended)
+
+Every tool is also a one-shot CLI command, so you can query the index from a shell with no MCP setup. Reach for this when you need a single answer fast, like a deprecation check, an API signature, or an index health check. Each command prints the tool's JSON to stdout:
+
+```bash
+uvx pipecat-ai-context-hub check-deprecation PipelineTask
+uvx pipecat-ai-context-hub search-api "WebsocketServerParams"
+uvx pipecat-ai-context-hub status            # index health / freshness
+```
+
+### MCP server (for longer sessions)
+
+For a longer build or debugging session where the model probes the index repeatedly, add the hub as an MCP server instead of shelling out per query. It keeps the index warm for the whole session and exposes the same tools to your coding tool directly.
 
 <Tabs>
   <Tab title="Claude Code">
@@ -68,19 +111,7 @@ uvx pipecat-ai-context-hub refresh   # build local index (~2 min first run)
 
 A newly added MCP server loads when your coding tool starts a session, so add it before opening the session you want to use it in.
 
-### Use it without MCP
-
-The same tools are available as one-shot CLI commands, so you can query the index from a shell with no MCP setup — handy in a session where the MCP server isn't connected yet:
-
-```bash
-uvx pipecat-ai-context-hub check-deprecation PipelineTask
-uvx pipecat-ai-context-hub search-api "WebsocketServerParams"
-uvx pipecat-ai-context-hub status            # index health / freshness
-```
-
-Each command prints the tool's JSON to stdout. The package name is `pipecat-ai-context-hub`; the command and MCP server are named `pipecat-context-hub` (both spellings of the command resolve once installed).
-
-See the [repo docs](https://github.com/pipecat-ai/pipecat-context-hub) for additional configuration options, including pinning to a specific Pipecat version.
+See the [repo docs](https://github.com/pipecat-ai/pipecat-context-hub) for additional configuration options.
 
 ## CLAUDE.md
 

--- a/pipecat/get-started/ai-tools.mdx
+++ b/pipecat/get-started/ai-tools.mdx
@@ -15,13 +15,18 @@ Every tool runs two ways: as a one-shot CLI command and as an MCP server. Use th
 
 ### Setup
 
-The hub is published to PyPI as `pipecat-ai-context-hub` and runs with [`uv`](https://docs.astral.sh/uv/), no clone required. The examples below use `uvx`, uv's one-shot tool runner. Build the local index once:
+The hub is published to PyPI as `pipecat-ai-context-hub` and runs with [`uv`](https://docs.astral.sh/uv/), no clone required. The examples on this page use `uvx`, uv's one-shot runner, which fetches and runs the hub on demand. Build the local index once:
 
 ```bash
 uvx pipecat-ai-context-hub refresh   # build local index (~2 min first run)
 ```
 
-If you install the hub persistently with `uv tool install pipecat-ai-context-hub`, a shorter `pipecat-context-hub` command becomes available too.
+<Tip>
+  To install it once instead of fetching on demand, run `uv tool install
+  pipecat-ai-context-hub`. This puts the command on your `PATH`, so you drop the
+  `uvx` prefix and call it directly, using the shorter `pipecat-context-hub`
+  name.
+</Tip>
 
 If the index gets corrupted, you can force a rebuild:
 
@@ -37,16 +42,16 @@ uvx pipecat-ai-context-hub refresh --framework-version v0.0.96
 
 ### Tools
 
-| Tool | Use it to |
-|------|-----------|
-| `search_docs` | Find guides and conceptual docs ("how do I ...?") |
-| `search_examples` | Find working example code by task or component |
-| `search_api` | Find class definitions, method signatures, frame types, and inheritance |
-| `get_doc` | Fetch a full doc page by ID or path |
-| `get_example` | Fetch the full source files for an example |
-| `get_code_snippet` | Fetch targeted code by symbol, intent, or file and line range |
+| Tool                | Use it to                                                                                            |
+| ------------------- | ---------------------------------------------------------------------------------------------------- |
+| `search_docs`       | Find guides and conceptual docs ("how do I ...?")                                                    |
+| `search_examples`   | Find working example code by task or component                                                       |
+| `search_api`        | Find class definitions, method signatures, frame types, and inheritance                              |
+| `get_doc`           | Fetch a full doc page by ID or path                                                                  |
+| `get_example`       | Fetch the full source files for an example                                                           |
+| `get_code_snippet`  | Fetch targeted code by symbol, intent, or file and line range                                        |
 | `check_deprecation` | Check whether an import path is deprecated or removed (can evaluate lifecycle at a specific version) |
-| `get_hub_status` | Report index health, freshness, and the indexed Pipecat version |
+| `get_hub_status`    | Report index health, freshness, and the indexed Pipecat version                                      |
 
 The three `search_*` tools return a ranked list of hits, each with a relevance `score`. Each response also carries an evidence report with an overall `confidence`, a `low_confidence` flag, and suggested follow-up queries. The agent triages that list, picks the best fit, then calls a `get_*` tool to pull the full content. The coding agent can pass your `pipecat_version` to score and filter results for compatibility with the version you target. The remaining two tools stand alone: `check_deprecation` reports a symbol's lifecycle, and `get_hub_status` reports index health.
 

--- a/pipecat/get-started/ai-tools.mdx
+++ b/pipecat/get-started/ai-tools.mdx
@@ -15,13 +15,13 @@ Every tool runs two ways: as a one-shot CLI command and as an MCP server. Use th
 
 ### Setup
 
-The hub is published to PyPI as `pipecat-ai-context-hub` and runs with [`uv`](https://docs.astral.sh/uv/), no clone required. Build the local index once:
+The hub is published to PyPI as `pipecat-ai-context-hub` and runs with [`uv`](https://docs.astral.sh/uv/), no clone required. The examples below use `uvx`, uv's one-shot tool runner. Build the local index once:
 
 ```bash
 uvx pipecat-ai-context-hub refresh   # build local index (~2 min first run)
 ```
 
-The PyPI package is `pipecat-ai-context-hub`. The command and MCP server are both named `pipecat-context-hub`, and both spellings resolve once installed.
+If you install the hub persistently with `uv tool install pipecat-ai-context-hub`, a shorter `pipecat-context-hub` command becomes available too.
 
 If the index gets corrupted, you can force a rebuild:
 
@@ -48,21 +48,21 @@ uvx pipecat-ai-context-hub refresh --framework-version v0.0.96
 | `check_deprecation` | Check whether an import path is deprecated or removed (can evaluate lifecycle at a specific version) |
 | `get_hub_status` | Report index health, freshness, and the indexed Pipecat version |
 
-The three `search_*` tools return a ranked list of hits, each with a relevance `score`, plus an evidence report carrying an overall `confidence`, a `low_confidence` flag, and suggested follow-up queries. The agent triages that list, picks the best fit, then calls a `get_*` tool to pull the full content. The coding agent can pass your `pipecat_version` to score and filter results compatible with your version.
+The three `search_*` tools return a ranked list of hits, each with a relevance `score`. Each response also carries an evidence report with an overall `confidence`, a `low_confidence` flag, and suggested follow-up queries. The agent triages that list, picks the best fit, then calls a `get_*` tool to pull the full content. The coding agent can pass your `pipecat_version` to score and filter results for compatibility with the version you target. The remaining two tools stand alone: `check_deprecation` reports a symbol's lifecycle, and `get_hub_status` reports index health.
 
 To make your coding agent reach for these tools automatically, add the [recommended CLAUDE.md / AGENTS.md instructions](https://github.com/pipecat-ai/pipecat-context-hub/blob/main/docs/README.md#add-claudemd-instructions-recommended) to your project.
 
-### Quick lookups with the CLI (recommended)
+### CLI lookups
 
 Every tool is also a one-shot CLI command, so you can query the index from a shell with no MCP setup. Reach for this when you need a single answer fast, like a deprecation check, an API signature, or an index health check. Each command prints the tool's JSON to stdout:
 
 ```bash
-uvx pipecat-ai-context-hub check-deprecation PipelineTask
-uvx pipecat-ai-context-hub search-api "WebsocketServerParams"
-uvx pipecat-ai-context-hub status            # index health / freshness
+uvx pipecat-ai-context-hub check-deprecation PipelineTask     # is this symbol deprecated?
+uvx pipecat-ai-context-hub search-api "WebsocketServerParams"  # find an API signature
+uvx pipecat-ai-context-hub status                              # index health / freshness
 ```
 
-### MCP server (for longer sessions)
+### MCP server
 
 For a longer build or debugging session where the model probes the index repeatedly, add the hub as an MCP server instead of shelling out per query. It keeps the index warm for the whole session and exposes the same tools to your coding tool directly.
 


### PR DESCRIPTION
## What

Reworks the Pipecat Context Hub section in **Get Started → AI-Assisted
Development** (`pipecat/get-started/ai-tools.mdx`). It previously presented the
hub as an MCP server with the CLI as a "use it without MCP" fallback. This
reframes it CLI-first and fills in gaps.

## Why
- The CLI is the better default for one-off lookups: quick, deterministic, no
  session setup. The MCP server earns its place in longer sessions where the
  agent probes the index repeatedly. The old framing inverted that.
- The tool list was incomplete (5 of 8), and the page never explained that
  searches return ranked, scored results the agent can triage before drilling
  down.

## Changes

- Retitle to **"Pipecat Context Hub (CLI and MCP)"**.
- Add a short "why it exists": docs/examples/API move fast across repos, so a
  model on training data goes stale; the hub keeps a fresh local index.
- Reorder so the **CLI is recommended** and the **MCP server is for longer
  sessions**, with a one-line rule for choosing.
- Enumerate **all 8 tools** in a table (adds `get_doc`, `get_example`,
  `get_hub_status`) and explain ranked `score` hits + the evidence report
  (`confidence` / `low_confidence` / follow-up queries) + the `search_*` →
  `get_*` drill-down flow. Note `pipecat_version` for compatibility scoring.
- Document **force-rebuild** (`refresh --force`) and **version-pin**
  (`refresh --framework-version`) in Setup.
- Link to the hub's recommended CLAUDE.md / AGENTS.md [instructions](https://github.com/pipecat-ai/pi
pecat-context-hub/blob/main/docs/README.md#add-claudemd-instructions-recommended).