### PR TITLE
ci: stage docs on main, promote to production on release

### DIFF
--- a/.github/workflows/mintlify-preview.yml
+++ b/.github/workflows/mintlify-preview.yml
@@ -1,0 +1,90 @@
+name: Mintlify Preview
+
+# Mintlify auto-previews only fire for PRs into the *deployment* branch, which
+# is now `production`. This workflow restores preview coverage for the staging
+# flow:
+#   - push to main      -> redeploy the stable "main" staging preview
+#   - pull_request->main -> create/update a per-branch preview, posted on the PR
+#
+# Requires two repo configuration values:
+#   - secret  MINTLIFY_API_KEY     (admin API key, prefixed `mint_`)
+#   - variable MINTLIFY_PROJECT_ID (from the Mintlify API keys page)
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+# One preview run per ref at a time; newer pushes supersede in-flight ones.
+concurrency:
+  group: mintlify-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    # Skip PRs from forks — repo secrets aren't available to them.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Determine branch
+        id: branch
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "name=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=main" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger Mintlify preview
+        id: preview
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+          PROJECT_ID: ${{ vars.MINTLIFY_PROJECT_ID }}
+          API_KEY: ${{ secrets.MINTLIFY_API_KEY }}
+        run: |
+          response=$(curl -sS -X POST \
+            "https://api.mintlify.com/v1/project/preview/${PROJECT_ID}" \
+            -H "Authorization: Bearer ${API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg b "$BRANCH" '{branch: $b}')")
+          echo "$response"
+          url=$(echo "$response" | jq -r '.previewUrl // empty')
+          if [ -z "$url" ]; then
+            echo "::error::Failed to trigger preview for branch '$BRANCH'"
+            exit 1
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "### 🔍 Mintlify preview for \`$BRANCH\`: $url" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upsert preview comment on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.preview.outputs.url }}
+        with:
+          script: |
+            const marker = '<!-- mintlify-preview -->';
+            const body = `${marker}\n🔍 **Mintlify preview** for this branch: ${process.env.PREVIEW_URL}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body,
+              });
+            }

--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -1,0 +1,39 @@
+name: Release to Production
+
+# Production publishes from the `production` branch (set as the deployment
+# branch in Mintlify). `main` is the staging line. This workflow advances
+# `production` to the current `main`, which is what triggers a prod deploy.
+
+on:
+  # Promote whenever a GitHub release is published.
+  release:
+    types: [published]
+  # Allow manual promotion from the Actions tab.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Prevent overlapping promotions from racing on the production ref.
+concurrency:
+  group: promote-to-production
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Fast-forward production to main
+        run: |
+          sha=$(git rev-parse HEAD)
+          echo "Promoting main ($sha) to production"
+          # Non-force push: fails if production has diverged (e.g. a direct
+          # hotfix on production not yet in main), which is a deliberate guard.
+          git push origin "HEAD:production"
+          echo "### ✅ Promoted \`main\` (\`$sha\`) to \`production\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Moves the docs repo from "every merge deploys to prod" to a staging → release-promote flow. Production now deploys from the `production` branch (set as the Mintlify deployment branch), so merges into `main` land in **staging** instead of prod.

## Changes

- **`promote-to-production.yml`** — on release publish or manual dispatch, fast-forwards `production` to current `main` (non-force, so a diverged `production` fails loudly). That push is what triggers the production deploy.
- **`mintlify-preview.yml`** — on push to `main`, redeploys the stable `main` staging preview; on PRs into `main`, creates/updates a per-branch preview and posts the URL on the PR (restoring per-PR previews, which no longer auto-fire now that the deployment branch is `production`).

## Configuration (already set in repo settings)

- Secret `MINTLIFY_API_KEY` — admin API key (`mint_…`)
- Variable `MINTLIFY_PROJECT_ID` — Mintlify project ID

## Testing

- This PR should itself trigger `mintlify-preview` and post a preview link below.
- After merge, run **Promote to Production** manually once to verify the `main → production` promotion and prod deploy before relying on the release trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)