### PR TITLE
Document @tool_options on register_function and switcher defaults

### DIFF
--- a/api-reference/server/utilities/service-switchers/llm-switcher.mdx
+++ b/api-reference/server/utilities/service-switchers/llm-switcher.mdx
@@ -95,11 +95,12 @@ llm_switcher.register_function(
   parameter.
 </ParamField>
 
-<ParamField path="cancel_on_interruption" type="bool" default="True">
+<ParamField path="cancel_on_interruption" type="bool | None" default="None">
   Whether to cancel this function call when a user interruption occurs. When
   `False`, the call is treated as asynchronous: the LLM continues the
   conversation immediately without waiting for the result, and the result is
-  injected later via a developer message.
+  injected later via a developer message. Defaults to `None`, which falls back
+  to the handler's `@tool_options` value, then to `True`.
 </ParamField>
 
 <ParamField path="timeout_secs" type="float | None" default="None">
@@ -131,11 +132,12 @@ llm_switcher.register_direct_function(
   The direct function to register. Must follow the DirectFunction protocol.
 </ParamField>
 
-<ParamField path="cancel_on_interruption" type="bool" default="True">
+<ParamField path="cancel_on_interruption" type="bool | None" default="None">
   Whether to cancel this function call when a user interruption occurs. When
   `False`, the call is treated as asynchronous: the LLM continues the
   conversation immediately without waiting for the result, and the result is
-  injected later via a developer message.
+  injected later via a developer message. Defaults to `None`, which falls back
+  to the handler's `@tool_options` value, then to `True`.
 </ParamField>
 
 <ParamField path="timeout_secs" type="float | None" default="None">

--- a/pipecat/learn/function-calling.mdx
+++ b/pipecat/learn/function-calling.mdx
@@ -261,6 +261,8 @@ context = LLMContext(tools=[weather_function])
 llm.register_function("get_current_weather", fetch_weather_from_api)
 ```
 
+If the handler carries [`@tool_options`](#per-tool-options-with-@tool_options), `register_function` honors it the same way bundling does — or pass `cancel_on_interruption` / `timeout_secs` to `register_function` directly to override.
+
 To remove the tool, un-advertise it with an [`LLMSetToolsFrame`](#changing-tools-mid-conversation); call `llm.unregister_function(...)` only afterward, since unregistering a still-advertised tool leaves the LLM able to call a handler that's no longer there.
 
 This is uncommon — bundling keeps a tool and its handler together — but the option is there when you need to manage registration directly.


### PR DESCRIPTION
For pipecat PR #4709: register_function now reads a handler's @tool_options when call options aren't passed explicitly, and LLMSwitcher.register_function / register_direct_function default cancel_on_interruption to None (falling back to @tool_options, then True). Update the LLMSwitcher reference param docs and note the behavior in the function-calling guide's manual-registration section.