### PR TITLE
Document realtime_service_mode and decoupled turn events (PR #4533)

### DIFF
--- a/api-reference/server/events/overview.mdx
+++ b/api-reference/server/events/overview.mdx
@@ -109,6 +109,7 @@ Events on context aggregators from [`LLMContextAggregatorPair`](/api-reference/s
 | `on_user_turn_started`             | `user_aggregator`      | User begins speaking                                |
 | `on_user_turn_inference_triggered` | `user_aggregator`      | Enough signal to start LLM inference                |
 | `on_user_turn_stopped`             | `user_aggregator`      | User finishes speaking (includes transcript)        |
+| `on_user_turn_message_added`       | `user_aggregator`      | A user message was written to the LLM context       |
 | `on_user_turn_stop_timeout`        | `user_aggregator`      | User turn ended due to timeout                      |
 | `on_user_turn_idle`                | `user_aggregator`      | User has been idle for configured timeout           |
 | `on_user_mute_started`             | `user_aggregator`      | User input was muted                                |

--- a/api-reference/server/frames/system-frames.mdx
+++ b/api-reference/server/frames/system-frames.mdx
@@ -381,6 +381,21 @@ Inherits from `ServiceMetadataFrame`.
   calibrate wait times.
 </ParamField>
 
+### RealtimeServiceMetadataFrame
+
+Broadcast at pipeline start by realtime (speech-to-speech) LLM services (OpenAI Realtime, Azure Realtime, Inworld, Grok/xAI Realtime, Gemini Live, AWS Nova Sonic, Ultravox). Its presence lets downstream processors — notably `LLMContextAggregatorPair` — detect that a realtime service is in the pipeline and configure themselves accordingly. See [Realtime (Speech-to-Speech) Services](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services).
+
+Inherits from `ServiceMetadataFrame`.
+
+<ParamField path="emits_user_turn_frames" type="bool" default="True">
+  Whether the service is currently configured to emit `UserStartedSpeakingFrame`
+  / `UserStoppedSpeakingFrame` from server-side turn signals. `False` for
+  services with no server-side turn signals (e.g. Gemini Live, AWS Nova Sonic,
+  Ultravox), and also `False` when a service's server-side turn detection has
+  been disabled by configuration (e.g. OpenAI Realtime with
+  `turn_detection=False`).
+</ParamField>
+
 ## RTVI
 
 Frames for the [Real-Time Voice Interface (RTVI)](/api-reference/server/rtvi) protocol, which bridges clients and the pipeline. These frames handle custom messaging between the client and server.

--- a/api-reference/server/services/s2s/aws.mdx
+++ b/api-reference/server/services/s2s/aws.mdx
@@ -198,6 +198,14 @@ Configuration for automatic session continuation, passed via the `session_contin
 
 ## Usage
 
+<Tip>
+  Pair this service with
+  `LLMContextAggregatorPair(context, realtime_service_mode=True)`. Realtime mode
+  keeps context-writing correct for speech-to-speech services and adapts turn
+  handling to the service. See [Realtime (Speech-to-Speech)
+  Services](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services).
+</Tip>
+
 ### Basic Setup
 
 ```python

--- a/api-reference/server/services/s2s/gemini-live-vertex.mdx
+++ b/api-reference/server/services/s2s/gemini-live-vertex.mdx
@@ -174,6 +174,14 @@ The Vertex AI variant uses the same Settings as the base Gemini Live service. Se
 
 ## Usage
 
+<Tip>
+  Pair this service with
+  `LLMContextAggregatorPair(context, realtime_service_mode=True)`. Realtime mode
+  keeps context-writing correct for speech-to-speech services and adapts turn
+  handling to the service. See [Realtime (Speech-to-Speech)
+  Services](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services).
+</Tip>
+
 ### Basic Setup with Service Account Credentials
 
 ```python

--- a/api-reference/server/services/s2s/gemini-live.mdx
+++ b/api-reference/server/services/s2s/gemini-live.mdx
@@ -266,14 +266,24 @@ llm = GeminiLiveLLMService(
     ),
 )
 
-# Configure local VAD in your aggregator
+# Configure local VAD in your aggregator. realtime_service_mode=True keeps
+# context-writing correct with a realtime service; the local VAD here drives
+# turn-taking since server-side VAD is disabled.
 user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
     context,
+    realtime_service_mode=True,
     user_params=LLMUserAggregatorParams(
         vad_analyzer=SileroVADAnalyzer(),
     ),
 )
 ```
+
+<Tip>
+  Pass `realtime_service_mode=True` to `LLMContextAggregatorPair` for any
+  realtime (speech-to-speech) service. See [Realtime (Speech-to-Speech)
+  Services](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services)
+  for what it does and how it interacts with local VAD.
+</Tip>
 
 ### Text-Only Mode
 

--- a/api-reference/server/services/s2s/grok.mdx
+++ b/api-reference/server/services/s2s/grok.mdx
@@ -161,6 +161,14 @@ Grok provides several built-in tools in addition to custom function tools:
 
 ## Usage
 
+<Tip>
+  Pair this service with
+  `LLMContextAggregatorPair(context, realtime_service_mode=True)`. Realtime mode
+  keeps context-writing correct for speech-to-speech services and adapts turn
+  handling to the service. See [Realtime (Speech-to-Speech)
+  Services](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services).
+</Tip>
+
 ### Basic Setup
 
 ```python

--- a/api-reference/server/services/s2s/inworld.mdx
+++ b/api-reference/server/services/s2s/inworld.mdx
@@ -191,6 +191,14 @@ Inworld PCM audio supports sample rates: 8000, 16000, 24000, 32000, 44100, and 4
 
 ## Usage
 
+<Tip>
+  Pair this service with
+  `LLMContextAggregatorPair(context, realtime_service_mode=True)`. Realtime mode
+  keeps context-writing correct for speech-to-speech services and adapts turn
+  handling to the service. See [Realtime (Speech-to-Speech)
+  Services](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services).
+</Tip>
+
 ### Basic Setup
 
 ```python

--- a/api-reference/server/services/s2s/openai.mdx
+++ b/api-reference/server/services/s2s/openai.mdx
@@ -225,6 +225,14 @@ Reasoning configuration for reasoning-capable Realtime models (e.g. `gpt-realtim
 
 ## Usage
 
+<Tip>
+  Pair this service with
+  `LLMContextAggregatorPair(context, realtime_service_mode=True)`. Realtime mode
+  keeps context-writing correct for speech-to-speech services and adapts turn
+  handling to the service. See [Realtime (Speech-to-Speech)
+  Services](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services).
+</Tip>
+
 ### Basic Setup
 
 ```python

--- a/api-reference/server/services/s2s/ultravox.mdx
+++ b/api-reference/server/services/s2s/ultravox.mdx
@@ -160,6 +160,14 @@ Join an existing Ultravox call using a join URL.
 
 ## Usage
 
+<Tip>
+  Pair this service with
+  `LLMContextAggregatorPair(context, realtime_service_mode=True)`. Realtime mode
+  keeps context-writing correct for speech-to-speech services and adapts turn
+  handling to the service. See [Realtime (Speech-to-Speech)
+  Services](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services).
+</Tip>
+
 ### Basic Setup with Agent
 
 ```python

--- a/api-reference/server/utilities/turn-management/external-turn-management.mdx
+++ b/api-reference/server/utilities/turn-management/external-turn-management.mdx
@@ -41,6 +41,33 @@ user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
   those metrics.
 </Note>
 
+## Realtime (Speech-to-Speech) Services
+
+Realtime (speech-to-speech) LLM services — OpenAI Realtime, Azure Realtime, Grok/xAI Realtime, Inworld, Gemini Live, AWS Nova Sonic, and Ultravox — consume user audio directly and manage their own conversation flow. For these, pass `realtime_service_mode=True` to `LLMContextAggregatorPair`:
+
+```python
+from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair
+
+user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+    context,
+    realtime_service_mode=True,
+)
+```
+
+Setting `realtime_service_mode=True` adapts the pair's behavior in three ways:
+
+1. **Context writes are decoupled from `UserStoppedSpeakingFrame`.** Instead, the assistant response start triggers the user message write. This keeps the context correct even when the realtime service provides no turn frames and local turn detection (VAD) is disabled.
+2. **`UserStoppedSpeakingFrame` can fire without waiting for transcripts.** When local turn detection drives the conversation, this frame triggers the assistant response — letting it fire earlier reduces latency. The pair flips `wait_for_transcript=False` on the [stop strategies](/api-reference/server/utilities/turn-management/user-turn-strategies#stop-strategies) that support it.
+3. **Default turn strategies are replaced with external strategies when the service emits its own turn frames.** Services that emit `UserStartedSpeakingFrame` / `UserStoppedSpeakingFrame` (OpenAI Realtime, Azure, Grok, Inworld) drive `on_user_turn_started` / `on_user_turn_stopped` from those server-emitted frames. Services that don't emit them — either because they never do (Gemini Live, Nova Sonic, Ultravox) or because server-side turn detection was disabled at runtime (e.g. OpenAI Realtime with `turn_detection=False`) — keep the defaults so locally-driven turn detection (e.g. local VAD) can fire the events. Passing custom `user_turn_strategies` opts out of this swap.
+
+<Note>
+  In realtime mode, subscribe to
+  [`on_user_turn_message_added`](/api-reference/server/utilities/turn-management/turn-events#on_user_turn_message_added)
+  to receive the finalized user message. `on_user_turn_stopped` still fires but
+  its `UserTurnStoppedMessage.content` is `None`, since the message isn't
+  finalized until the assistant response starts.
+</Note>
+
 ## UserTurnProcessor
 
 `UserTurnProcessor` is a frame processor for managing user turn lifecycle when you need a single source of turn events shared across multiple context aggregators. It emits `UserStartedSpeakingFrame` and `UserStoppedSpeakingFrame` frames and handles interruptions.

--- a/api-reference/server/utilities/turn-management/transcriptions.mdx
+++ b/api-reference/server/utilities/turn-management/transcriptions.mdx
@@ -12,6 +12,15 @@ The key events for transcription collection are:
 - **`on_user_turn_stopped`** - Provides the user's complete transcript via `UserTurnStoppedMessage`
 - **`on_assistant_turn_stopped`** - Provides the assistant's complete transcript via `AssistantTurnStoppedMessage`
 
+<Note>
+  The examples below assume a cascade (STT → LLM → TTS) pipeline. With a realtime
+  (speech-to-speech) service and
+  `LLMContextAggregatorPair(context, realtime_service_mode=True)`, collect the
+  user transcript from
+  [`on_user_turn_message_added`](/api-reference/server/utilities/turn-management/turn-events#on_user_turn_message_added)
+  instead — in that mode `UserTurnStoppedMessage.content` is `None`.
+</Note>
+
 ## Basic Example
 
 ```python

--- a/api-reference/server/utilities/turn-management/turn-events.mdx
+++ b/api-reference/server/utilities/turn-management/turn-events.mdx
@@ -18,6 +18,7 @@ Turn events provide hooks into the conversation turn lifecycle, allowing you to 
 | `on_user_turn_started`             | `user_aggregator`      | User begins speaking                                |
 | `on_user_turn_inference_triggered` | `user_aggregator`      | Enough signal to start LLM inference                |
 | `on_user_turn_stopped`             | `user_aggregator`      | User finishes speaking (includes transcript)        |
+| `on_user_turn_message_added`       | `user_aggregator`      | A user message was written to the LLM context       |
 | `on_user_turn_stop_timeout`        | `user_aggregator`      | User turn ended due to timeout                      |
 | `on_user_turn_idle`                | `user_aggregator`      | User has been idle (not speaking) for timeout       |
 | `on_user_mute_started`             | `user_aggregator`      | User input was muted                                |
@@ -92,6 +93,34 @@ async def on_user_turn_stopped(aggregator, strategy, message: UserTurnStoppedMes
 | `aggregator` | `LLMUserAggregator`        | The user aggregator instance                |
 | `strategy`   | `BaseUserTurnStopStrategy` | The strategy that triggered the turn stop   |
 | `message`    | `UserTurnStoppedMessage`   | Contains the user's transcript and metadata |
+
+<Note>
+  In realtime mode (`realtime_service_mode=True` on
+  [`LLMContextAggregatorPair`](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services)),
+  the user message isn't finalized at turn-stop time, so
+  `message.content` is `None`. Subscribe to
+  [`on_user_turn_message_added`](#on_user_turn_message_added) instead to
+  get the finalized user text. Behavior in cascade (STT → LLM → TTS)
+  pipelines is unchanged.
+</Note>
+
+### on_user_turn_message_added
+
+Fired when a user message is written to the LLM context, carrying the finalized turn text. In cascade pipelines this coincides with `on_user_turn_stopped`. In realtime mode (`realtime_service_mode=True`) the write is triggered by the assistant response start rather than the user-turn-end frame, so this event — not `on_user_turn_stopped` — is the canonical way to subscribe to "context just updated, here's the user text."
+
+```python
+@user_aggregator.event_handler("on_user_turn_message_added")
+async def on_user_turn_message_added(aggregator, message: UserTurnMessageAddedMessage):
+    print(f"User said: {message.content}")
+    print(f"Turn started at: {message.timestamp}")
+```
+
+**Parameters:**
+
+| Parameter    | Type                          | Description                                  |
+| ------------ | ----------------------------- | -------------------------------------------- |
+| `aggregator` | `LLMUserAggregator`           | The user aggregator instance                 |
+| `message`    | `UserTurnMessageAddedMessage` | Contains the finalized user text and metadata |
 
 ### on_user_turn_stop_timeout
 
@@ -284,8 +313,32 @@ Contains the user's complete transcript when their turn ends.
 from pipecat.processors.aggregators.llm_response_universal import UserTurnStoppedMessage
 ```
 
+<ParamField path="content" type="str | None">
+  The complete transcribed text from the user's turn. `None` in realtime
+  mode (`realtime_service_mode=True`), where the user message isn't
+  finalized at turn-stop time — subscribe to
+  [`on_user_turn_message_added`](#on_user_turn_message_added) for the
+  finalized text instead.
+</ParamField>
+
+<ParamField path="timestamp" type="str">
+  ISO 8601 timestamp indicating when the user turn started.
+</ParamField>
+
+<ParamField path="user_id" type="str | None">
+  Optional identifier for the user, if available from the transport.
+</ParamField>
+
+### UserTurnMessageAddedMessage
+
+Accompanies `on_user_turn_message_added`, carrying the finalized user text written to the LLM context.
+
+```python
+from pipecat.processors.aggregators.llm_response_universal import UserTurnMessageAddedMessage
+```
+
 <ParamField path="content" type="str">
-  The complete transcribed text from the user's turn.
+  The aggregated, finalized user transcript for the turn. Always populated.
 </ParamField>
 
 <ParamField path="timestamp" type="str">

--- a/api-reference/server/utilities/turn-management/user-turn-strategies.mdx
+++ b/api-reference/server/utilities/turn-management/user-turn-strategies.mdx
@@ -298,6 +298,16 @@ For STT services that support finalization (Speechmatics, Soniox, Deepgram Flux,
   user turn. This is the minimum wait time and always runs to completion.
 </ParamField>
 
+<ParamField path="wait_for_transcript" type="bool" default="True">
+  When `True` (default), turn-stop signaling waits for a transcript to arrive
+  after VAD silence. When `False`, the strategy signals turn-stop as soon as its
+  timing requirements are met, without waiting for transcripts — useful when
+  local turn detection drives a realtime (speech-to-speech) service, where
+  waiting for transcripts is unnecessary latency.
+  [`LLMContextAggregatorPair`](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services)
+  flips this to `False` for you when `realtime_service_mode=True`.
+</ParamField>
+
 ```python
 from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
 
@@ -320,6 +330,15 @@ Uses an AI-powered turn detection model to determine when the user has finished 
 
 <ParamField path="turn_analyzer" type="BaseTurnAnalyzer" required>
   The turn detection analyzer instance to use for end-of-turn detection.
+</ParamField>
+
+<ParamField path="wait_for_transcript" type="bool" default="True">
+  When `True` (default), turn-stop signaling waits for a transcript to arrive
+  after the analyzer reports end-of-speech. When `False`, the strategy signals
+  turn-stop as soon as the analyzer fires, without waiting for transcripts —
+  useful when local turn detection drives a realtime (speech-to-speech) service.
+  [`LLMContextAggregatorPair`](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services)
+  flips this to `False` for you when `realtime_service_mode=True`.
 </ParamField>
 
 ```python
@@ -354,6 +373,15 @@ Delegates turn stop detection to an external processor. This strategy listens fo
 <ParamField path="timeout" type="float" default="0.5">
   A short delay in seconds used to handle consecutive or slightly delayed
   transcriptions.
+</ParamField>
+
+<ParamField path="wait_for_transcript" type="bool" default="True">
+  When `True` (default), turn-stop signaling waits for a transcript to arrive
+  after the external `UserStoppedSpeakingFrame`. When `False`, the strategy
+  signals turn-stop as soon as that frame arrives, independent of transcripts —
+  useful when local turn detection drives a realtime (speech-to-speech) service.
+  [`LLMContextAggregatorPair`](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services)
+  flips this to `False` for you when `realtime_service_mode=True`.
 </ParamField>
 
 ```python

--- a/pipecat/fundamentals/saving-transcripts.mdx
+++ b/pipecat/fundamentals/saving-transcripts.mdx
@@ -80,6 +80,15 @@ async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMes
   for later analysis.
 </Tip>
 
+<Note>
+  With a realtime (speech-to-speech) service and
+  `LLMContextAggregatorPair(context, realtime_service_mode=True)`, capture the
+  user transcript from
+  [`on_user_turn_message_added`](/api-reference/server/utilities/turn-management/turn-events#on_user_turn_message_added)
+  instead of `on_user_turn_stopped`, whose `message.content` is `None` in that
+  mode.
+</Note>
+
 ## Next Steps
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary

Documents the realtime-services turn-decoupling work shipping in pipecat-ai PR [#4533](https://github.com/pipecat-ai/pipecat/pull/4533). That PR adds `realtime_service_mode=True` on `LLMContextAggregatorPair`, which decouples context writes from turn frames for realtime (speech-to-speech) services, plus the supporting public API (a new turn event, a new message type, a new frame, and a new stop-strategy flag).

## What changed

**New public API documented**

- **`on_user_turn_message_added` event + `UserTurnMessageAddedMessage`** — the canonical way to get the finalized user text in realtime mode (where `on_user_turn_stopped` fires before the message is finalized).
- **`UserTurnStoppedMessage.content` is now `str | None`** — `None` in realtime mode.
- **`realtime_service_mode=True` on `LLMContextAggregatorPair`** — new "Realtime (Speech-to-Speech) Services" reference section explaining its three behaviors and how it interacts with local VAD.
- **`wait_for_transcript` flag** on `SpeechTimeoutUserTurnStopStrategy`, `TurnAnalyzerUserTurnStopStrategy`, and `ExternalUserTurnStopStrategy`.
- **`RealtimeServiceMetadataFrame`** — new system frame.

**Cross-references and guidance**

- `events/overview` and `transcriptions` updated to list/route to the new event.
- `saving-transcripts` guide notes the realtime-mode capture path.
- All S2S service pages (OpenAI, Azure-via-OpenAI, AWS Nova Sonic, Ultravox, Inworld, Grok/xAI, Gemini Live, Gemini Live Vertex) recommend `realtime_service_mode=True`; the Gemini Live "With Local VAD" example is updated to use it.

## Files

| Area | Pages |
| --- | --- |
| Turn management | `turn-events`, `user-turn-strategies`, `external-turn-management`, `transcriptions` |
| Frames | `system-frames` |
| Events | `events/overview` |
| Guides | `fundamentals/saving-transcripts` |
| S2S services | `aws`, `gemini-live`, `gemini-live-vertex`, `grok`, `inworld`, `openai`, `ultravox` |

No new pages, so `docs.json` and `supported-services.mdx` are unchanged.

## Related

- pipecat-ai PR: https://github.com/pipecat-ai/pipecat/pull/4533
