### PR TITLE
docs: update for pipecat PR #4772

### DIFF
--- a/api-reference/server/services/stt/soniox.mdx
+++ b/api-reference/server/services/stt/soniox.mdx
@@ -7,7 +7,7 @@ description: "Speech-to-text service implementation using Soniox's WebSocket API
 
 `SonioxSTTService` provides real-time speech-to-text transcription using Soniox's WebSocket API with support for over 60 languages, custom context, multiple languages in the same conversation, and advanced features for accurate multilingual transcription.
 
-By default, Soniox uses the `stt-rt-v4` model with `vad_force_turn_endpoint=True`, which disables Soniox's native turn detection and relies on Pipecat's local VAD to finalize transcripts. This configuration significantly reduces the time to final segment (~250ms median). Pipecat enables smart-turn detection by default using `LocalSmartTurnAnalyzerV3`. To use Soniox's native turn detection instead, set `vad_force_turn_endpoint=False`.
+By default, Soniox uses the `stt-rt-v5` model with `vad_force_turn_endpoint=True`, which disables Soniox's native turn detection and relies on Pipecat's local VAD to finalize transcripts. This configuration significantly reduces the time to final segment (~250ms median). Pipecat enables smart-turn detection by default using `LocalSmartTurnAnalyzerV3`. To use Soniox's native turn detection instead, set `vad_force_turn_endpoint=False`.
 
 <CardGroup cols={2}>
   <Card
@@ -124,7 +124,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 | Parameter                        | Type                         | Default       | Description                                                                                                                                            |
 | -------------------------------- | ---------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `model`                          | `str`                        | `"stt-rt-v4"` | Model to use for transcription. _(Inherited from base STT settings.)_                                                                                  |
+| `model`                          | `str`                        | `"stt-rt-v5"` | Model to use for transcription. _(Inherited from base STT settings.)_                                                                                  |
 | `language`                       | `Language \| str`            | `None`        | Language for speech recognition. _(Inherited from base STT settings.)_                                                                                 |
 | `language_hints`                 | `list[Language]`             | `None`        | Language hints for transcription. Helps the model prioritize expected languages.                                                                       |
 | `language_hints_strict`          | `bool`                       | `None`        | If true, strictly enforce language hints (only transcribe in provided languages).                                                                      |
@@ -132,6 +132,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 | `enable_speaker_diarization`     | `bool`                       | `False`       | Enable speaker diarization. Tokens are annotated with speaker IDs.                                                                                     |
 | `enable_language_identification` | `bool`                       | `False`       | Enable language identification. Tokens are annotated with language IDs, and the detected language is included in the final `TranscriptionFrame`.       |
 | `max_endpoint_delay_ms`          | `int`                        | `None`        | Maximum delay in milliseconds before endpoint detection finalizes the turn. Valid range: 500-3000.                                                     |
+| `endpoint_sensitivity`           | `float`                      | `None`        | Endpoint detection sensitivity (-1.0 to 1.0); higher values finalize turns sooner, lower values delay finalization. Introduced in the v5 model.        |
 | `client_reference_id`            | `str`                        | `None`        | Client reference ID for transcription tracking.                                                                                                        |
 
 ## Usage
@@ -155,7 +156,7 @@ from pipecat.transcriptions.language import Language
 stt = SonioxSTTService(
     api_key=os.getenv("SONIOX_API_KEY"),
     settings=SonioxSTTService.Settings(
-        model="stt-rt-v4",
+        model="stt-rt-v5",
         language_hints=[Language.EN, Language.ES],
         language_hints_strict=True,
         enable_language_identification=True,
@@ -175,7 +176,7 @@ from pipecat.services.soniox.stt import (
 stt = SonioxSTTService(
     api_key=os.getenv("SONIOX_API_KEY"),
     settings=SonioxSTTService.Settings(
-        model="stt-rt-v4",
+        model="stt-rt-v5",
         context=SonioxContextObject(
             general=[
                 SonioxContextGeneralItem(key="domain", value="medical"),


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4772](https://github.com/pipecat-ai/pipecat/pull/4772).

## Changes

Updated `api-reference/server/services/stt/soniox.mdx`:
- Changed default model from `stt-rt-v4` to `stt-rt-v5` (Overview, Settings table, code examples)
- Added new `endpoint_sensitivity` parameter to Settings table: Endpoint detection sensitivity (-1.0 to 1.0); higher values finalize turns sooner, lower values delay finalization. Introduced in the v5 model.

## Gaps identified

None