### PR TITLE
docs: update for pipecat PR #4559

### DIFF
--- a/api-reference/server/rtvi/rtvi-observer.mdx
+++ b/api-reference/server/rtvi/rtvi-observer.mdx
@@ -90,19 +90,46 @@ task = PipelineWorker(
 </ParamField>
 
 <ParamField path="bot_output_transforms" default="None">
-A list of tuples to transform text just before sending it to TTS. Each tuple should be of the form `(aggregation_type, transform_function)`, where `aggregation_type` is a string (or `'*'` for all types), and `transform_function` is a callable that takes `(text, aggregation_type)` and returns the transformed text.
+A list of tuples to transform text before sending it to the client. Each tuple should be of the form `(aggregation_type, transform_function)`.
+
+The preferred transform signature is:
+
+```python
+async def my_transform(
+    text: str,
+    agg_type: AggregationType | str,
+    accumulated_text: str | None = None,
+    remaining_text: str | None = None,
+) -> BotOutputTransformResult:
+    ...
+```
+
+When `accumulated_text` and `remaining_text` are `None`, the transform is being called for the full segment text (`bot-output` message). When they are provided, the transform is being called for a progress event and must return a `BotOutputTransformResult` with `accumulated_text` and `remaining_text` set, enabling word-level transforms on the client side.
+
+The legacy 2-parameter signature `(text, agg_type) -> str` is deprecated but still works. Transforms using it will emit a `DeprecationWarning` at registration time.
 
 **Example:**
 
 ```python
-def redact_sensitive(text, agg_type):
-    # Example: redact numbers
+from pipecat.processors.frameworks.rtvi import BotOutputTransformResult
+
+async def redact_sensitive(text, agg_type, accumulated_text=None, remaining_text=None):
     import re
-    return re.sub(r"\d+", "[REDACTED]", text)
+    # Transform the full text
+    redacted = re.sub(r"\d{4}", "****", text)
+    
+    # If this is a progress event, also transform the partial strings
+    if accumulated_text is not None and remaining_text is not None:
+        return BotOutputTransformResult(
+            text=redacted,
+            accumulated_text=re.sub(r"\d{4}", "****", accumulated_text),
+            remaining_text=re.sub(r"\d{4}", "****", remaining_text),
+        )
+    return BotOutputTransformResult(text=redacted)
 
 bot_output_transforms = [
-    ("credit_card", redact_sensitive),  # Only for 'credit_card' type
-    ("*", lambda text, agg_type: text.upper()),  # For all types, make uppercase
+    ("sentence", redact_sensitive),  # Only for 'sentence' type
+    ("*", my_other_transform),  # For all types
 ]
 
 observer = RTVIObserver(

--- a/api-reference/server/rtvi/rtvi-observer.mdx
+++ b/api-reference/server/rtvi/rtvi-observer.mdx
@@ -113,23 +113,26 @@ The legacy 2-parameter signature `(text, agg_type) -> str` is deprecated but sti
 ```python
 from pipecat.processors.frameworks.rtvi import BotOutputTransformResult
 
-async def redact_sensitive(text, agg_type, accumulated_text=None, remaining_text=None):
-    import re
-    # Transform the full text
-    redacted = re.sub(r"\d{4}", "****", text)
-    
-    # If this is a progress event, also transform the partial strings
-    if accumulated_text is not None and remaining_text is not None:
-        return BotOutputTransformResult(
-            text=redacted,
-            accumulated_text=re.sub(r"\d{4}", "****", accumulated_text),
-            remaining_text=re.sub(r"\d{4}", "****", remaining_text),
-        )
-    return BotOutputTransformResult(text=redacted)
+async def redact_sensitive(
+        text: str,
+        agg_type: str,
+        accumulated_text: str | None = None,
+        remaining_text: str | None = None,
+    ) -> BotOutputTransformResult:
+        transformed = "XXXX-XXXX-XXXX-" + text[-4:]
+        if accumulated_text is not None and remaining_text is not None:
+            ratio = len(accumulated_text) / max(len(text), 1)
+            split = int(ratio * len(transformed))
+            return BotOutputTransformResult(
+                text=transformed,
+                accumulated_text=transformed[:split],
+                remaining_text=transformed[split:],
+            )
+        return BotOutputTransformResult(text=transformed)
 
 bot_output_transforms = [
-    ("sentence", redact_sensitive),  # Only for 'sentence' type
-    ("*", my_other_transform),  # For all types
+    ("credit_card", redact_sensitive),  # Only for 'credit_card' type
+    ("*", lambda text, agg_type: text.upper()),  # For all types, make uppercase
 ]
 
 observer = RTVIObserver(

--- a/api-reference/server/rtvi/rtvi-processor.mdx
+++ b/api-reference/server/rtvi/rtvi-processor.mdx
@@ -33,6 +33,19 @@ task = PipelineWorker(pipeline, rtvi_processor=GoogleRTVIProcessor())
 
 To disable RTVI entirely, set `enable_rtvi=False`.
 
+## Properties
+
+### client_version
+
+Returns the negotiated client protocol version as `[major, minor, patch]`. Defaults to `[0, 0, 0]` until the client sends a `client-ready` message.
+
+```python
+version = rtvi.client_version
+if version[0] == 2:
+    # Client is using protocol v2
+    pass
+```
+
 ## Readiness Protocol
 
 ### Client Ready State
@@ -50,9 +63,10 @@ async def on_client_ready(rtvi):
 
 <Note>
   The processor validates the client's RTVI protocol version during the
-  handshake. If the client's major version doesn't match the server's protocol
-  version, an error response is sent but the connection continues. Check server
-  logs for version compatibility warnings.
+  handshake. The server protocol version is 2.0.0. Clients with major version 2
+  are fully compatible. Clients with major version 1 (deprecated) are still
+  supported with the legacy `bot-output` format. Other versions are rejected
+  with an error response.
 </Note>
 
 ### Bot Ready State

--- a/api-reference/server/rtvi/rtvi-processor.mdx
+++ b/api-reference/server/rtvi/rtvi-processor.mdx
@@ -65,8 +65,9 @@ async def on_client_ready(rtvi):
   The processor validates the client's RTVI protocol version during the
   handshake. The server protocol version is 2.0.0. Clients with major version 2
   are fully compatible. Clients with major version 1 (deprecated) are still
-  supported with the legacy `bot-output` format. Other versions are rejected
-  with an error response.
+  supported with the legacy `bot-output` format. If the client's major version
+  doesn't match the server's protocol version, an error response is sent but the
+  connection continues. Check server logs for version compatibility warnings.
 </Note>
 
 ### Bot Ready State


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4559](https://github.com/pipecat-ai/pipecat/pull/4559).

## Changes

- **api-reference/server/rtvi/rtvi-observer.mdx**: Updated `bot_output_transforms` parameter documentation to describe the new 4-parameter signature `(text, agg_type, accumulated_text, remaining_text) -> BotOutputTransformResult`. The legacy 2-parameter signature is now deprecated but still supported. Updated example code to demonstrate the new signature.

- **api-reference/server/rtvi/rtvi-processor.mdx**: Added `client_version` property documentation. Updated protocol version compatibility note to reflect v2.0.0 with backward compatibility for 1.x clients (legacy format).

## Gaps identified

None