### PR TITLE
rename task frames to worker

### DIFF
--- a/api-reference/client/js/callbacks.mdx
+++ b/api-reference/client/js/callbacks.mdx
@@ -294,7 +294,7 @@ Callback receives a `TranscriptData` object:
     Search capabilities are currently only supported by Google Gemini. To take
     advantage of this event, your pipeline must include a
     [`GoogleLLMService`](/api-reference/server/services/llm/google) and your
-    pipeline task should include the
+    pipeline worker should include the
     [`GoogleRTVIObserver`](/api-reference/server/rtvi/google-rtvi-observer) in
     lieu of the typical `RTVIObserver`.
   </Warning>

--- a/api-reference/client/js/transports/websocket.mdx
+++ b/api-reference/client/js/transports/websocket.mdx
@@ -175,7 +175,7 @@ async def run_bot(websocket_client):
         ]
     )
 
-    task = PipelineWorker(
+    worker = PipelineWorker(
         pipeline,
         params,
     )

--- a/api-reference/server/events/overview.mdx
+++ b/api-reference/server/events/overview.mdx
@@ -10,8 +10,8 @@ Pipecat provides an event system that lets you hook into lifecycle changes acros
 Events are available on most Pipecat objects (anything that inherits from `BaseObject`). You register handlers using the `@event_handler` decorator, and Pipecat calls them automatically when things happen.
 
 ```python
-@task.event_handler("on_pipeline_started")
-async def on_pipeline_started(task, frame):
+@worker.event_handler("on_pipeline_started")
+async def on_pipeline_started(worker, frame):
     print("Pipeline is running!")
 
 @tts.event_handler("on_connected")
@@ -48,12 +48,12 @@ Handlers can be either `async` or synchronous functions — Pipecat detects whic
 You can register multiple handlers for the same event. They execute in the order they were registered:
 
 ```python
-@task.event_handler("on_pipeline_finished")
-async def log_finished(task, frame):
+@worker.event_handler("on_pipeline_finished")
+async def log_finished(worker, frame):
     print("Pipeline finished (handler 1)")
 
-@task.event_handler("on_pipeline_finished")
-async def cleanup(task, frame):
+@worker.event_handler("on_pipeline_finished")
+async def cleanup(worker, frame):
     print("Cleaning up (handler 2)")
 ```
 
@@ -83,7 +83,7 @@ Events on [`PipelineWorker`](/api-reference/server/pipeline/pipeline-worker#even
 | ----------------------------- | ---------------------------------------------------------------- |
 | `on_pipeline_started`         | Pipeline has started processing                                  |
 | `on_pipeline_finished`        | Pipeline reached a terminal state (stopped, ended, or cancelled) |
-| `on_pipeline_error`           | An error frame reached the pipeline worker                         |
+| `on_pipeline_error`           | An error frame reached the pipeline worker                       |
 | `on_frame_reached_upstream`   | A filtered frame type reached the pipeline source                |
 | `on_frame_reached_downstream` | A filtered frame type reached the pipeline sink                  |
 | `on_idle_timeout`             | No activity detected within the idle timeout period              |

--- a/api-reference/server/events/overview.mdx
+++ b/api-reference/server/events/overview.mdx
@@ -83,7 +83,7 @@ Events on [`PipelineWorker`](/api-reference/server/pipeline/pipeline-worker#even
 | ----------------------------- | ---------------------------------------------------------------- |
 | `on_pipeline_started`         | Pipeline has started processing                                  |
 | `on_pipeline_finished`        | Pipeline reached a terminal state (stopped, ended, or cancelled) |
-| `on_pipeline_error`           | An error frame reached the pipeline task                         |
+| `on_pipeline_error`           | An error frame reached the pipeline worker                         |
 | `on_frame_reached_upstream`   | A filtered frame type reached the pipeline source                |
 | `on_frame_reached_downstream` | A filtered frame type reached the pipeline sink                  |
 | `on_idle_timeout`             | No activity detected within the idle timeout period              |

--- a/api-reference/server/frames/control-frames.mdx
+++ b/api-reference/server/frames/control-frames.mdx
@@ -354,22 +354,22 @@ Request that a service re-emit its metadata. Useful after switching services to 
   The service to request metadata from.
 </ParamField>
 
-## Task Frames
+## Pipeline Worker Frames
 
-Task frames are pushed upstream to the pipeline task, which converts them into the appropriate downstream frame. This indirection lets processors request pipeline-level actions without needing direct access to the pipeline task.
+Pipeline worker frames are pushed upstream to the pipeline task, which converts them into the appropriate downstream frame. This indirection lets processors request pipeline-level actions without needing direct access to the pipeline task.
 
-### TaskFrame
+### WorkerFrame
 
 Base frame for task control.
 
-### EndTaskFrame
+### EndWorkerFrame
 
-Request graceful pipeline shutdown. The pipeline task converts this into an `EndFrame` and pushes it downstream. Inherits from `TaskFrame` and `UninterruptibleFrame`.
+Request graceful pipeline shutdown. The pipeline task converts this into an `EndFrame` and pushes it downstream. Inherits from `WorkerFrame` and `UninterruptibleFrame`.
 
 <ParamField path="reason" type="Any | None">
   Optional reason for the shutdown request.
 </ParamField>
 
-### StopTaskFrame
+### StopWorkerFrame
 
-Request pipeline stop while keeping processors alive. Converted to a `StopFrame` downstream. Inherits from `TaskFrame` and `UninterruptibleFrame`.
+Request pipeline stop while keeping processors alive. Converted to a `StopFrame` downstream. Inherits from `WorkerFrame` and `UninterruptibleFrame`.

--- a/api-reference/server/frames/control-frames.mdx
+++ b/api-reference/server/frames/control-frames.mdx
@@ -356,15 +356,15 @@ Request that a service re-emit its metadata. Useful after switching services to 
 
 ## Pipeline Worker Frames
 
-Pipeline worker frames are pushed upstream to the pipeline task, which converts them into the appropriate downstream frame. This indirection lets processors request pipeline-level actions without needing direct access to the pipeline task.
+Pipeline worker frames are pushed upstream to the pipeline worker, which converts them into the appropriate downstream frame. This indirection lets processors request pipeline-level actions without needing direct access to the pipeline worker.
 
 ### WorkerFrame
 
-Base frame for task control.
+Base frame for worker control.
 
 ### EndWorkerFrame
 
-Request graceful pipeline shutdown. The pipeline task converts this into an `EndFrame` and pushes it downstream. Inherits from `WorkerFrame` and `UninterruptibleFrame`.
+Request graceful pipeline shutdown. The pipeline worker converts this into an `EndFrame` and pushes it downstream. Inherits from `WorkerFrame` and `UninterruptibleFrame`.
 
 <ParamField path="reason" type="Any | None">
   Optional reason for the shutdown request.

--- a/api-reference/server/frames/overview.mdx
+++ b/api-reference/server/frames/overview.mdx
@@ -189,7 +189,7 @@ Add an initial message to the context, then push `LLMRunFrame` to kick off proce
 @transport.event_handler("on_client_connected")
 async def on_client_connected(transport, client):
     context.add_message({"role": "user", "content": "Please introduce yourself."})
-    await task.queue_frames([LLMRunFrame()])
+    await worker.queue_frames([LLMRunFrame()])
 ```
 
 ### Injecting a Prompt
@@ -230,7 +230,7 @@ await aggregator.push_frame(EndWorkerFrame(), FrameDirection.UPSTREAM)
 Push settings frames to adjust LLM, TTS, or STT configuration mid-conversation:
 
 ```python
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(delta=OpenAILLMService.Settings(temperature=0.1))
 )
 ```
@@ -243,7 +243,7 @@ Add or replace available function-calling tools while the conversation is active
 new_tools = ToolsSchema(
     standard_tools=[weather_function, restaurant_function]
 )
-await task.queue_frames([LLMSetToolsFrame(tools=new_tools)])
+await worker.queue_frames([LLMSetToolsFrame(tools=new_tools)])
 ```
 
 ### Playing Sound Effects

--- a/api-reference/server/frames/overview.mdx
+++ b/api-reference/server/frames/overview.mdx
@@ -216,13 +216,13 @@ async def on_function_calls_started(service, function_calls):
 
 ### Ending a Conversation
 
-Push `EndTaskFrame` upstream to gracefully shut down the pipeline. Pair it with a `TTSSpeakFrame` to say goodbye first:
+Push `EndWorkerFrame` upstream to gracefully shut down the pipeline. Pair it with a `TTSSpeakFrame` to say goodbye first:
 
 ```python
 await aggregator.push_frame(
     TTSSpeakFrame("It seems like you're busy. Have a nice day!")
 )
-await aggregator.push_frame(EndTaskFrame(), FrameDirection.UPSTREAM)
+await aggregator.push_frame(EndWorkerFrame(), FrameDirection.UPSTREAM)
 ```
 
 ### Changing Service Settings at Runtime

--- a/api-reference/server/frames/system-frames.mdx
+++ b/api-reference/server/frames/system-frames.mdx
@@ -426,26 +426,26 @@ Responds to an `RTVIClientMessageFrame`. Include the original client message fra
   `server-response`.
 </ParamField>
 
-## Task Frames
+## Pipeline Worker Frames
 
-Task frames provide a system-priority mechanism for requesting pipeline actions from outside the normal frame flow. They are converted into their corresponding standard frames when processed.
+Pipeline worker frames provide a system-priority mechanism for requesting pipeline actions from outside the normal frame flow. They are converted into their corresponding standard frames when processed.
 
-### TaskSystemFrame
+### WorkerSystemFrame
 
-Base class for system-priority task frames.
+Base class for system-priority worker frames.
 
-### CancelTaskFrame
+### CancelWorkerFrame
 
 Requests immediate pipeline cancellation. Converted to a `CancelFrame` when processed by the pipeline.
 
-Inherits from `TaskSystemFrame`.
+Inherits from `WorkerSystemFrame`.
 
 <ParamField path="reason" type="Any | None" default="None">
   Optional reason for the cancellation request.
 </ParamField>
 
-### InterruptionTaskFrame
+### InterruptionWorkerFrame
 
 Requests a pipeline interruption. Converted to an `InterruptionFrame` when processed.
 
-Inherits from `TaskSystemFrame`.
+Inherits from `WorkerSystemFrame`.

--- a/api-reference/server/introduction.mdx
+++ b/api-reference/server/introduction.mdx
@@ -10,7 +10,7 @@ This is the API reference for the server-side Pipecat Python framework. It cover
 
 - **Services**: Integrations for STT, LLM, TTS, speech-to-speech, image generation, video, transports, and more. Over 100 providers supported.
 - **Utilities**: Frame processors, audio filters, observers, turn detection, context summarization, MCP, and other helpers.
-- **Pipeline**: Configuration, task management, idle detection, and parallel pipelines.
+- **Pipeline**: Configuration, asyncio task management, idle detection, and parallel pipelines.
 - **Frames**: Data frames, control frames, system frames, and LLM frames that flow through the pipeline.
 - **Events**: Frame processor and service events for hooking into the pipeline lifecycle.
 

--- a/api-reference/server/pipeline/heartbeats.mdx
+++ b/api-reference/server/pipeline/heartbeats.mdx
@@ -16,7 +16,7 @@ from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 
 pipeline = Pipeline([...])
 params = params=PipelineParams(enable_heartbeats=True)
-task = PipelineWorker(pipeline, params)
+worker = PipelineWorker(pipeline, params)
 ```
 
 ## How It Works
@@ -58,5 +58,6 @@ The heartbeat system uses two timing values:
 - **Monitor window** (10x the interval) — how long to wait before logging a warning if no heartbeat is received.
 
 <Note>
-  The heartbeat interval is configurable via the `heartbeats_period_secs` parameter in `PipelineParams`. The monitor window is always 10x the interval.
+  The heartbeat interval is configurable via the `heartbeats_period_secs`
+  parameter in `PipelineParams`. The monitor window is always 10x the interval.
 </Note>

--- a/api-reference/server/pipeline/pipeline-idle-detection.mdx
+++ b/api-reference/server/pipeline/pipeline-idle-detection.mdx
@@ -30,10 +30,10 @@ You can configure idle detection behavior when creating a `PipelineWorker`:
 from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 
 # Default configuration - cancel after 5 minutes of inactivity
-task = PipelineWorker(pipeline)
+worker = PipelineWorker(pipeline)
 
 # Custom configuration
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     idle_timeout_secs=600,  # 10 minute timeout
     idle_timeout_frames=(BotSpeakingFrame,),  # Only monitor bot speaking
@@ -66,8 +66,8 @@ task = PipelineWorker(
 You can respond to idle timeout events by adding an event handler:
 
 ```python
-@task.event_handler("on_idle_timeout")
-async def on_idle_timeout(task):
+@worker.event_handler("on_idle_timeout")
+async def on_idle_timeout(worker):
     logger.info("Pipeline has been idle for too long")
     # Perform any custom cleanup or logging
     # Note: If cancel_on_idle_timeout=True, the pipeline will be cancelled after this handler runs
@@ -86,25 +86,25 @@ from pipecat.pipeline.worker import PipelineWorker
 # Create pipeline
 pipeline = Pipeline([...])
 
-# Configure task with custom idle settings
-task = PipelineWorker(
+# Configure worker with custom idle settings
+worker = PipelineWorker(
     pipeline,
     idle_timeout_secs=180,  # 3 minutes
     cancel_on_idle_timeout=False  # Don't auto-cancel
 )
 
 # Add event handler for idle timeout
-@task.event_handler("on_idle_timeout")
-async def on_idle_timeout(task):
+@worker.event_handler("on_idle_timeout")
+async def on_idle_timeout(worker):
     logger.info("Conversation has been idle for 3 minutes")
 
     # Add a farewell message
-    await task.queue_frame(TTSSpeakFrame("I haven't heard from you in a while. Goodbye!"))
+    await worker.queue_frame(TTSSpeakFrame("I haven't heard from you in a while. Goodbye!"))
 
     # Then end the conversation gracefully
-    await task.queue_frame(EndFrame())
+    await worker.queue_frame(EndFrame())
 
 runner = WorkerRunner()
 
-await runner.run(task)
+await runner.run(worker)
 ```

--- a/api-reference/server/pipeline/pipeline-idle-detection.mdx
+++ b/api-reference/server/pipeline/pipeline-idle-detection.mdx
@@ -57,7 +57,7 @@ task = PipelineWorker(
 </ParamField>
 
 <ParamField path="cancel_on_idle_timeout" type="bool" default="True">
-  Whether to automatically cancel the pipeline task when idle timeout is
+  Whether to automatically cancel the pipeline worker when idle timeout is
   reached.
 </ParamField>
 

--- a/api-reference/server/pipeline/pipeline-params.mdx
+++ b/api-reference/server/pipeline/pipeline-params.mdx
@@ -23,7 +23,7 @@ params = PipelineParams(
 
 # Pass to PipelineWorker
 pipeline = Pipeline([...])
-task = PipelineWorker(pipeline, params=params)
+worker = PipelineWorker(pipeline, params=params)
 ```
 
 ## Available Parameters
@@ -142,9 +142,9 @@ params = PipelineParams(
     }
 )
 
-# Create pipeline and task
+# Create pipeline and worker
 pipeline = Pipeline([...])
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=params,
     observers=[FileObserver("pipeline_logs.jsonl")]
@@ -152,7 +152,7 @@ task = PipelineWorker(
 
 # Run the pipeline
 runner = WorkerRunner()
-await runner.run(task)
+await runner.run(worker)
 ```
 
 ## Additional Information

--- a/api-reference/server/pipeline/pipeline-worker.mdx
+++ b/api-reference/server/pipeline/pipeline-worker.mdx
@@ -5,15 +5,15 @@ description: "Manage pipeline execution and lifecycle with PipelineWorker"
 
 ## Overview
 
-`PipelineWorker` is the central class for managing pipeline execution. It handles the lifecycle of the pipeline, processes frames in both directions, manages task cancellation, and provides event handlers for monitoring pipeline activity.
+`PipelineWorker` is the central class for managing pipeline execution. It handles the lifecycle of the pipeline, processes frames in both directions, manages cancellation, and provides event handlers for monitoring pipeline activity.
 
 <Note>
   `PipelineWorker` builds on
   [`BaseWorker`](/api-reference/server/workers/base-worker), so it can take part
   in a multi-worker system. See
   [Workers](/api-reference/server/workers/base-worker) for the full worker
-  model. `PipelineTask` is a deprecated alias for `PipelineWorker`; existing code
-  that uses it keeps working.
+  model. `PipelineTask` is a deprecated alias for `PipelineWorker`; existing
+  code that uses it keeps working.
 </Note>
 
 ## Basic Usage
@@ -26,7 +26,7 @@ from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 # Create a pipeline
 pipeline = Pipeline([...])
 
-# Create a task with the pipeline
+# Create a worker with the pipeline
 worker = PipelineWorker(pipeline)
 
 # Queue frames for processing

--- a/api-reference/server/pipeline/pipeline-worker.mdx
+++ b/api-reference/server/pipeline/pipeline-worker.mdx
@@ -27,14 +27,14 @@ from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 pipeline = Pipeline([...])
 
 # Create a task with the pipeline
-task = PipelineWorker(pipeline)
+worker = PipelineWorker(pipeline)
 
 # Queue frames for processing
-await task.queue_frame(TTSSpeakFrame("Hello, how can I help you today?"))
+await worker.queue_frame(TTSSpeakFrame("Hello, how can I help you today?"))
 
 # Run the pipeline
 runner = WorkerRunner()
-await runner.run(task)
+await runner.run(worker)
 ```
 
 ## Constructor Parameters
@@ -119,7 +119,7 @@ await runner.run(task)
   etc.) shared across tool handlers. Passed by reference to every function
   handler via `FunctionCallParams.app_resources`. The framework never copies or
   clears this object; the caller retains their handle and can read mutations
-  after the task finishes.
+  after the worker finishes.
 </ParamField>
 
 <ParamField path="tool_resources" type="Any" default="None">
@@ -128,24 +128,24 @@ await runner.run(task)
 
 ## Methods
 
-### Task Lifecycle Management
+### Worker Lifecycle Management
 
 <ResponseField name="run()" type="async">
 Starts and manages the pipeline execution until completion or cancellation. Typically called via `WorkerRunner` rather than directly:
 
 ```python
 runner = WorkerRunner()
-await runner.run(task)
+await runner.run(worker)
 ```
 
 </ResponseField>
 
 <ResponseField name="stop_when_done()" type="async">
-Sends an EndFrame to the pipeline to gracefully stop the task after all queued
+Sends an EndFrame to the pipeline to gracefully stop the worker after all queued
 frames have been processed.
 
 ```python
-await task.stop_when_done()
+await worker.stop_when_done()
 ```
 
 </ResponseField>
@@ -154,16 +154,16 @@ await task.stop_when_done()
 Stops the running pipeline immediately by sending a CancelFrame.
 
 ```python
-  await task.cancel()
+  await worker.cancel()
 ```
 
 </ResponseField>
 
 <ResponseField name="has_finished()" type="bool">
-Returns whether the task has finished (all processors have stopped).
+Returns whether the worker has finished (all processors have stopped).
 
 ```python
-if task.has_finished(): print("Task is complete")
+if worker.has_finished(): print("Worker is complete")
 ```
 
 </ResponseField>
@@ -184,11 +184,11 @@ Downstream frames are pushed from the beginning of the pipeline. Upstream frames
 
 ```python
 # Push a frame downstream (default behavior)
-await task.queue_frame(TTSSpeakFrame("Hello!"))
+await worker.queue_frame(TTSSpeakFrame("Hello!"))
 
 # Push a frame upstream from the end of the pipeline
 from pipecat.processors.frame_processor import FrameDirection
-await task.queue_frame(UserStoppedSpeakingFrame(), direction=FrameDirection.UPSTREAM)
+await worker.queue_frame(UserStoppedSpeakingFrame(), direction=FrameDirection.UPSTREAM)
 ```
 
 </ResponseField>
@@ -209,12 +209,12 @@ Downstream frames are pushed from the beginning of the pipeline. Upstream frames
 ```python
 # Push frames downstream (default behavior)
 frames = [TTSSpeakFrame("Hello!"), TTSSpeakFrame("How are you?")]
-await task.queue_frames(frames)
+await worker.queue_frames(frames)
 
 # Push frames upstream from the end of the pipeline
 from pipecat.processors.frame_processor import FrameDirection
 frames = [TranscriptionFrame("user input"), UserStoppedSpeakingFrame()]
-await task.queue_frames(frames, direction=FrameDirection.UPSTREAM)
+await worker.queue_frames(frames, direction=FrameDirection.UPSTREAM)
 ```
 
 </ResponseField>
@@ -227,7 +227,7 @@ PipelineWorker provides event handlers for monitoring pipeline lifecycle and fra
 | ----------------------------- | --------------------------------------------------- |
 | `on_pipeline_started`         | Pipeline has started processing                     |
 | `on_pipeline_finished`        | Pipeline reached a terminal state                   |
-| `on_pipeline_error`           | An error frame reached the pipeline worker            |
+| `on_pipeline_error`           | An error frame reached the pipeline worker          |
 | `on_frame_reached_upstream`   | A filtered frame type reached the pipeline source   |
 | `on_frame_reached_downstream` | A filtered frame type reached the pipeline sink     |
 | `on_idle_timeout`             | No activity detected within the idle timeout period |
@@ -237,25 +237,25 @@ PipelineWorker provides event handlers for monitoring pipeline lifecycle and fra
 Fired when the `StartFrame` has been processed by all processors in the pipeline. This indicates the pipeline is fully initialized and running.
 
 ```python
-@task.event_handler("on_pipeline_started")
-async def on_pipeline_started(task, frame):
+@worker.event_handler("on_pipeline_started")
+async def on_pipeline_started(worker, frame):
     print("Pipeline is running!")
 ```
 
 **Parameters:**
 
-| Parameter | Type           | Description                        |
-| --------- | -------------- | ---------------------------------- |
-| `task`    | `PipelineWorker` | The pipeline worker instance         |
-| `frame`   | `StartFrame`   | The start frame that was processed |
+| Parameter | Type             | Description                        |
+| --------- | ---------------- | ---------------------------------- |
+| `worker`  | `PipelineWorker` | The pipeline worker instance       |
+| `frame`   | `StartFrame`     | The start frame that was processed |
 
 ### on_pipeline_finished
 
 Fired after the pipeline reaches any terminal state. This includes normal completion (`EndFrame`), explicit stop (`StopFrame`), or cancellation (`CancelFrame`). Use this event for cleanup, logging, or post-processing.
 
 ```python
-@task.event_handler("on_pipeline_finished")
-async def on_pipeline_finished(task, frame):
+@worker.event_handler("on_pipeline_finished")
+async def on_pipeline_finished(worker, frame):
     if isinstance(frame, EndFrame):
         print("Pipeline ended normally")
     elif isinstance(frame, CancelFrame):
@@ -266,18 +266,18 @@ async def on_pipeline_finished(task, frame):
 
 **Parameters:**
 
-| Parameter | Type           | Description                                                    |
-| --------- | -------------- | -------------------------------------------------------------- |
-| `task`    | `PipelineWorker` | The pipeline worker instance                                     |
-| `frame`   | `Frame`        | The terminal frame (`EndFrame`, `StopFrame`, or `CancelFrame`) |
+| Parameter | Type             | Description                                                    |
+| --------- | ---------------- | -------------------------------------------------------------- |
+| `worker`  | `PipelineWorker` | The pipeline worker instance                                   |
+| `frame`   | `Frame`          | The terminal frame (`EndFrame`, `StopFrame`, or `CancelFrame`) |
 
 ### on_pipeline_error
 
 Fired when an `ErrorFrame` reaches the pipeline worker (upstream from a processor). If the error is fatal, the pipeline will be cancelled after this handler runs.
 
 ```python
-@task.event_handler("on_pipeline_error")
-async def on_pipeline_error(task, frame):
+@worker.event_handler("on_pipeline_error")
+async def on_pipeline_error(worker, frame):
     print(f"Pipeline error: {frame.error}")
     if frame.fatal:
         print("Fatal error — pipeline will be cancelled")
@@ -285,10 +285,10 @@ async def on_pipeline_error(task, frame):
 
 **Parameters:**
 
-| Parameter | Type           | Description                        |
-| --------- | -------------- | ---------------------------------- |
-| `task`    | `PipelineWorker` | The pipeline worker instance         |
-| `frame`   | `ErrorFrame`   | The error frame with error details |
+| Parameter | Type             | Description                        |
+| --------- | ---------------- | ---------------------------------- |
+| `worker`  | `PipelineWorker` | The pipeline worker instance       |
+| `frame`   | `ErrorFrame`     | The error frame with error details |
 
 ### on_frame_reached_upstream
 
@@ -298,19 +298,19 @@ Fired when a frame of a registered type reaches the pipeline source (the start o
 from pipecat.frames.frames import TranscriptionFrame
 
 # Configure which frame types to monitor
-task.set_reached_upstream_filter((TranscriptionFrame,))
+worker.set_reached_upstream_filter((TranscriptionFrame,))
 
-@task.event_handler("on_frame_reached_upstream")
-async def on_frame_reached_upstream(task, frame):
+@worker.event_handler("on_frame_reached_upstream")
+async def on_frame_reached_upstream(worker, frame):
     print(f"Frame reached upstream: {frame}")
 ```
 
 **Parameters:**
 
-| Parameter | Type           | Description                                |
-| --------- | -------------- | ------------------------------------------ |
-| `task`    | `PipelineWorker` | The pipeline worker instance                 |
-| `frame`   | `Frame`        | The frame that reached the pipeline source |
+| Parameter | Type             | Description                                |
+| --------- | ---------------- | ------------------------------------------ |
+| `worker`  | `PipelineWorker` | The pipeline worker instance               |
+| `frame`   | `Frame`          | The frame that reached the pipeline source |
 
 <Note>
   This event only fires for frame types you've explicitly registered. By
@@ -326,36 +326,36 @@ Fired when a frame of a registered type reaches the pipeline sink (the end of th
 from pipecat.frames.frames import TTSAudioRawFrame
 
 # Configure which frame types to monitor
-task.set_reached_downstream_filter((TTSAudioRawFrame,))
+worker.set_reached_downstream_filter((TTSAudioRawFrame,))
 
-@task.event_handler("on_frame_reached_downstream")
-async def on_frame_reached_downstream(task, frame):
+@worker.event_handler("on_frame_reached_downstream")
+async def on_frame_reached_downstream(worker, frame):
     print(f"Frame reached downstream: {frame}")
 ```
 
 **Parameters:**
 
-| Parameter | Type           | Description                              |
-| --------- | -------------- | ---------------------------------------- |
-| `task`    | `PipelineWorker` | The pipeline worker instance               |
-| `frame`   | `Frame`        | The frame that reached the pipeline sink |
+| Parameter | Type             | Description                              |
+| --------- | ---------------- | ---------------------------------------- |
+| `worker`  | `PipelineWorker` | The pipeline worker instance             |
+| `frame`   | `Frame`          | The frame that reached the pipeline sink |
 
 ### on_idle_timeout
 
 Fired when no activity frames (as specified by `idle_timeout_frames`) have been received within the idle timeout period. See [Pipeline Idle Detection](/api-reference/server/pipeline/pipeline-idle-detection) for configuration details.
 
 ```python
-@task.event_handler("on_idle_timeout")
-async def on_idle_timeout(task):
+@worker.event_handler("on_idle_timeout")
+async def on_idle_timeout(worker):
     print("Pipeline has been idle too long")
-    await task.queue_frame(TTSSpeakFrame("Are you still there?"))
+    await worker.queue_frame(TTSSpeakFrame("Are you still there?"))
 ```
 
 **Parameters:**
 
-| Parameter | Type           | Description                |
-| --------- | -------------- | -------------------------- |
-| `task`    | `PipelineWorker` | The pipeline worker instance |
+| Parameter | Type             | Description                  |
+| --------- | ---------------- | ---------------------------- |
+| `worker`  | `PipelineWorker` | The pipeline worker instance |
 
 <Note>
   If `cancel_on_idle_timeout` is `True` (the default), the pipeline will be

--- a/api-reference/server/pipeline/pipeline-worker.mdx
+++ b/api-reference/server/pipeline/pipeline-worker.mdx
@@ -86,7 +86,7 @@ await runner.run(task)
 </ParamField>
 
 <ParamField path="cancel_on_idle_timeout" type="bool" default="True">
-  Whether to automatically cancel the pipeline task when idle timeout is
+  Whether to automatically cancel the pipeline worker when idle timeout is
   reached. See [Pipeline Idle
   Detection](/api-reference/server/pipeline/pipeline-idle-detection) for
   details.
@@ -227,7 +227,7 @@ PipelineWorker provides event handlers for monitoring pipeline lifecycle and fra
 | ----------------------------- | --------------------------------------------------- |
 | `on_pipeline_started`         | Pipeline has started processing                     |
 | `on_pipeline_finished`        | Pipeline reached a terminal state                   |
-| `on_pipeline_error`           | An error frame reached the pipeline task            |
+| `on_pipeline_error`           | An error frame reached the pipeline worker            |
 | `on_frame_reached_upstream`   | A filtered frame type reached the pipeline source   |
 | `on_frame_reached_downstream` | A filtered frame type reached the pipeline sink     |
 | `on_idle_timeout`             | No activity detected within the idle timeout period |
@@ -246,7 +246,7 @@ async def on_pipeline_started(task, frame):
 
 | Parameter | Type           | Description                        |
 | --------- | -------------- | ---------------------------------- |
-| `task`    | `PipelineWorker` | The pipeline task instance         |
+| `task`    | `PipelineWorker` | The pipeline worker instance         |
 | `frame`   | `StartFrame`   | The start frame that was processed |
 
 ### on_pipeline_finished
@@ -268,12 +268,12 @@ async def on_pipeline_finished(task, frame):
 
 | Parameter | Type           | Description                                                    |
 | --------- | -------------- | -------------------------------------------------------------- |
-| `task`    | `PipelineWorker` | The pipeline task instance                                     |
+| `task`    | `PipelineWorker` | The pipeline worker instance                                     |
 | `frame`   | `Frame`        | The terminal frame (`EndFrame`, `StopFrame`, or `CancelFrame`) |
 
 ### on_pipeline_error
 
-Fired when an `ErrorFrame` reaches the pipeline task (upstream from a processor). If the error is fatal, the pipeline will be cancelled after this handler runs.
+Fired when an `ErrorFrame` reaches the pipeline worker (upstream from a processor). If the error is fatal, the pipeline will be cancelled after this handler runs.
 
 ```python
 @task.event_handler("on_pipeline_error")
@@ -287,7 +287,7 @@ async def on_pipeline_error(task, frame):
 
 | Parameter | Type           | Description                        |
 | --------- | -------------- | ---------------------------------- |
-| `task`    | `PipelineWorker` | The pipeline task instance         |
+| `task`    | `PipelineWorker` | The pipeline worker instance         |
 | `frame`   | `ErrorFrame`   | The error frame with error details |
 
 ### on_frame_reached_upstream
@@ -309,7 +309,7 @@ async def on_frame_reached_upstream(task, frame):
 
 | Parameter | Type           | Description                                |
 | --------- | -------------- | ------------------------------------------ |
-| `task`    | `PipelineWorker` | The pipeline task instance                 |
+| `task`    | `PipelineWorker` | The pipeline worker instance                 |
 | `frame`   | `Frame`        | The frame that reached the pipeline source |
 
 <Note>
@@ -337,7 +337,7 @@ async def on_frame_reached_downstream(task, frame):
 
 | Parameter | Type           | Description                              |
 | --------- | -------------- | ---------------------------------------- |
-| `task`    | `PipelineWorker` | The pipeline task instance               |
+| `task`    | `PipelineWorker` | The pipeline worker instance               |
 | `frame`   | `Frame`        | The frame that reached the pipeline sink |
 
 ### on_idle_timeout
@@ -355,7 +355,7 @@ async def on_idle_timeout(task):
 
 | Parameter | Type           | Description                |
 | --------- | -------------- | -------------------------- |
-| `task`    | `PipelineWorker` | The pipeline task instance |
+| `task`    | `PipelineWorker` | The pipeline worker instance |
 
 <Note>
   If `cancel_on_idle_timeout` is `True` (the default), the pipeline will be

--- a/api-reference/server/rtvi/google-rtvi-observer.mdx
+++ b/api-reference/server/rtvi/google-rtvi-observer.mdx
@@ -51,7 +51,7 @@ pipeline = Pipeline([
     # Other processors...
 ])
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     rtvi_processor=GoogleRTVIProcessor(),
 )

--- a/api-reference/server/rtvi/introduction.mdx
+++ b/api-reference/server/rtvi/introduction.mdx
@@ -26,10 +26,10 @@ RTVI operates with two primary components:
    - Performance metrics
 
 <Note>
-  RTVI is enabled by default. When you create a `PipelineWorker`, it automatically
-  adds `RTVIProcessor` to the start of your pipeline and registers an
-  `RTVIObserver`. The default `on_client_ready` handler calls `set_bot_ready()`
-  automatically.
+  RTVI is enabled by default. When you create a `PipelineWorker`, it
+  automatically adds `RTVIProcessor` to the start of your pipeline and registers
+  an `RTVIObserver`. The default `on_client_ready` handler calls
+  `set_bot_ready()` automatically.
 </Note>
 
 ## Basic Example
@@ -50,7 +50,7 @@ pipeline = Pipeline(
 )
 
 # Add the RTVIObserver to your pipeline worker
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         enable_metrics=True,
@@ -58,20 +58,20 @@ task = PipelineWorker(
     ),
 )
 
-# Access the RTVI processor via task.rtvi
-@task.rtvi.event_handler("on_client_ready")
+# Access the RTVI processor via worker.rtvi
+@worker.rtvi.event_handler("on_client_ready")
 async def on_client_ready(rtvi):
     # set_bot_ready() is called automatically, add custom logic here
-    await task.queue_frames([LLMRunFrame()])
+    await worker.queue_frames([LLMRunFrame()])
 
 # Handle participant disconnection
 @transport.event_handler("on_participant_left")
 async def on_participant_left(transport, participant, reason):
-    await task.cancel()
+    await worker.cancel()
 
 # Run the pipeline
 runner = WorkerRunner()
-await runner.run(task)
+await runner.run(worker)
 ```
 
 ## Customizing RTVI
@@ -81,7 +81,7 @@ You can customize RTVI behavior through `PipelineWorker` parameters:
 ```python
 from pipecat.processors.frameworks.rtvi import RTVIProcessor, RTVIObserverParams
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     rtvi_processor=RTVIProcessor(),  # Provide your own processor
     rtvi_observer_params=RTVIObserverParams(...),  # Customize observer
@@ -91,7 +91,7 @@ task = PipelineWorker(
 To disable RTVI entirely:
 
 ```python
-task = PipelineWorker(pipeline, enable_rtvi=False)
+worker = PipelineWorker(pipeline, enable_rtvi=False)
 ```
 
 ## Protocol Flow

--- a/api-reference/server/rtvi/introduction.mdx
+++ b/api-reference/server/rtvi/introduction.mdx
@@ -49,7 +49,7 @@ pipeline = Pipeline(
     ]
 )
 
-# Add the RTVIObserver to your pipeline task
+# Add the RTVIObserver to your pipeline worker
 task = PipelineWorker(
     pipeline,
     params=PipelineParams(

--- a/api-reference/server/rtvi/rtvi-observer.mdx
+++ b/api-reference/server/rtvi/rtvi-observer.mdx
@@ -13,12 +13,12 @@ The `RTVIObserver` primarily serves to convert internal pipeline frames into to 
 
 `RTVIObserver` is automatically created and attached when you create a `PipelineWorker`. No manual setup is required for standard usage.
 
-To customize the observer's behavior, pass `RTVIObserverParams` to the task:
+To customize the observer's behavior, pass `RTVIObserverParams` to the worker:
 
 ```python
 from pipecat.processors.frameworks.rtvi import RTVIObserverParams
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     rtvi_observer_params=RTVIObserverParams(
         bot_llm_enabled=False,
@@ -136,7 +136,7 @@ from pipecat.processors.frameworks.rtvi import (
     RTVIObserverParams,
 )
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     rtvi_observer_params=RTVIObserverParams(
         function_call_report_level={

--- a/api-reference/server/rtvi/rtvi-processor.mdx
+++ b/api-reference/server/rtvi/rtvi-processor.mdx
@@ -7,7 +7,7 @@ The `RTVIProcessor` manages bidirectional communication between clients and your
 
 ## Initialization
 
-`RTVIProcessor` is automatically added to your pipeline when you create a `PipelineWorker`. Access it via `task.rtvi`:
+`RTVIProcessor` is automatically added to your pipeline when you create a `PipelineWorker`. Access it via `worker.rtvi`:
 
 ```python
 pipeline = Pipeline([
@@ -17,10 +17,10 @@ pipeline = Pipeline([
     transport.output()
 ])
 
-task = PipelineWorker(pipeline)
+worker = PipelineWorker(pipeline)
 
 # Access the processor
-rtvi = task.rtvi
+rtvi = worker.rtvi
 ```
 
 To provide a custom processor (e.g., for [Google RTVI](./google-rtvi-observer)):
@@ -28,7 +28,7 @@ To provide a custom processor (e.g., for [Google RTVI](./google-rtvi-observer)):
 ```python
 from pipecat.services.google.rtvi import GoogleRTVIProcessor
 
-task = PipelineWorker(pipeline, rtvi_processor=GoogleRTVIProcessor())
+worker = PipelineWorker(pipeline, rtvi_processor=GoogleRTVIProcessor())
 ```
 
 To disable RTVI entirely, set `enable_rtvi=False`.
@@ -45,7 +45,7 @@ async def on_client_ready(rtvi):
     # Handle client ready state
     await rtvi.set_bot_ready()
     # Initialize conversation
-    await task.queue_frames([...])
+    await worker.queue_frames([...])
 ```
 
 <Note>

--- a/api-reference/server/services/llm/anthropic.mdx
+++ b/api-reference/server/services/llm/anthropic.mdx
@@ -181,7 +181,7 @@ Model settings can be changed mid-conversation using `LLMUpdateSettingsFrame`:
 from pipecat.frames.frames import LLMUpdateSettingsFrame
 from pipecat.services.anthropic.llm import AnthropicLLMSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=AnthropicLLMSettings(
             temperature=0.3,

--- a/api-reference/server/services/llm/aws.mdx
+++ b/api-reference/server/services/llm/aws.mdx
@@ -189,7 +189,7 @@ Model settings can be changed mid-conversation using `LLMUpdateSettingsFrame`:
 from pipecat.frames.frames import LLMUpdateSettingsFrame
 from pipecat.services.aws.llm import AWSBedrockLLMSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=AWSBedrockLLMSettings(
             temperature=0.3,

--- a/api-reference/server/services/llm/azure.mdx
+++ b/api-reference/server/services/llm/azure.mdx
@@ -145,7 +145,7 @@ Model settings can be changed mid-conversation using `LLMUpdateSettingsFrame`:
 from pipecat.frames.frames import LLMUpdateSettingsFrame
 from pipecat.services.openai.base_llm import OpenAILLMSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=OpenAILLMSettings(
             temperature=0.3,

--- a/api-reference/server/services/llm/google.mdx
+++ b/api-reference/server/services/llm/google.mdx
@@ -205,7 +205,7 @@ Model settings can be changed mid-conversation using `LLMUpdateSettingsFrame`:
 from pipecat.frames.frames import LLMUpdateSettingsFrame
 from pipecat.services.google.llm import GoogleLLMSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=GoogleLLMSettings(
             temperature=0.3,

--- a/api-reference/server/services/llm/mistral.mdx
+++ b/api-reference/server/services/llm/mistral.mdx
@@ -116,7 +116,7 @@ llm = MistralLLMService(
 from pipecat.frames.frames import LLMUpdateSettingsFrame
 from pipecat.services.mistral.llm import MistralLLMSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=MistralLLMSettings(
             temperature=0.3,

--- a/api-reference/server/services/llm/nebius.mdx
+++ b/api-reference/server/services/llm/nebius.mdx
@@ -78,14 +78,14 @@ Before using Nebius LLM services, you need:
 
 Runtime-configurable settings passed via the `settings` constructor argument using `NebiusLLMService.Settings(...)`. These can be updated mid-conversation with `LLMUpdateSettingsFrame`. See [Service Settings](/guides/fundamentals/service-settings) for details.
 
-| Parameter           | Type    | Default                 | Description                                                                            |
-| ------------------- | ------- | ----------------------- | -------------------------------------------------------------------------------------- |
+| Parameter           | Type    | Default                              | Description                                                                            |
+| ------------------- | ------- | ------------------------------------ | -------------------------------------------------------------------------------------- |
 | `model`             | `str`   | `"Qwen/Qwen3-30B-A3B-Instruct-2507"` | Nebius model identifier. Check Nebius Token Factory for available models.              |
-| `temperature`       | `float` | `NOT_GIVEN`             | Sampling temperature (0.0 to 2.0). Lower values are more focused, higher are creative. |
-| `max_tokens`        | `int`   | `NOT_GIVEN`             | Maximum tokens to generate.                                                            |
-| `top_p`             | `float` | `NOT_GIVEN`             | Top-p (nucleus) sampling (0.0 to 1.0). Controls diversity of output.                   |
-| `frequency_penalty` | `float` | `NOT_GIVEN`             | Penalty for frequent tokens (-2.0 to 2.0). Positive values discourage repetition.      |
-| `presence_penalty`  | `float` | `NOT_GIVEN`             | Penalty for new topics (-2.0 to 2.0). Positive values encourage new topics.            |
+| `temperature`       | `float` | `NOT_GIVEN`                          | Sampling temperature (0.0 to 2.0). Lower values are more focused, higher are creative. |
+| `max_tokens`        | `int`   | `NOT_GIVEN`                          | Maximum tokens to generate.                                                            |
+| `top_p`             | `float` | `NOT_GIVEN`                          | Top-p (nucleus) sampling (0.0 to 1.0). Controls diversity of output.                   |
+| `frequency_penalty` | `float` | `NOT_GIVEN`                          | Penalty for frequent tokens (-2.0 to 2.0). Positive values discourage repetition.      |
+| `presence_penalty`  | `float` | `NOT_GIVEN`                          | Penalty for new topics (-2.0 to 2.0). Positive values encourage new topics.            |
 
 <Note>
   `NOT_GIVEN` values are omitted from the API request entirely, letting the
@@ -130,7 +130,7 @@ Model settings can be changed mid-conversation using `LLMUpdateSettingsFrame`:
 from pipecat.frames.frames import LLMUpdateSettingsFrame
 from pipecat.services.nebius.llm import NebiusLLMSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=NebiusLLMSettings(
             temperature=0.3,

--- a/api-reference/server/services/llm/openai-responses.mdx
+++ b/api-reference/server/services/llm/openai-responses.mdx
@@ -220,7 +220,7 @@ Model settings can be changed mid-conversation using `LLMUpdateSettingsFrame`:
 ```python
 from pipecat.frames.frames import LLMUpdateSettingsFrame
 
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=OpenAIResponsesLLMService.Settings(
             temperature=0.3,

--- a/api-reference/server/services/llm/openai-responses.mdx
+++ b/api-reference/server/services/llm/openai-responses.mdx
@@ -255,7 +255,7 @@ print(response)  # "The capital of France is Paris."
 - **Incremental context optimization**: The WebSocket variant uses `previous_response_id` to send only incremental context when the conversation prefix hasn't changed, reducing latency and costs. This works with `store=False` (no server-side storage) via a connection-local cache.
 - **Responses API vs Chat Completions API**: The Responses API has a different request/response structure compared to the Chat Completions API. Use `OpenAILLMService` for the Chat Completions API and `OpenAIResponsesLLMService` or `OpenAIResponsesHttpLLMService` for the Responses API.
 - **Universal LLM Context**: Both services work with the universal `LLMContext` and `LLMContextAggregatorPair`, making it easy to switch between different LLM providers.
-- **Function calling**: Supports OpenAI's tool/function calling format. Register function handlers on the pipeline task to handle tool calls automatically.
+- **Function calling**: Supports OpenAI's tool/function calling format. Register function handlers on the pipeline worker to handle tool calls automatically.
 - **Usage metrics**: Automatically tracks token usage, including cached tokens and reasoning tokens.
 - **Service tiers**: Supports OpenAI's service tier system for prioritizing requests.
 

--- a/api-reference/server/services/llm/openai.mdx
+++ b/api-reference/server/services/llm/openai.mdx
@@ -170,7 +170,7 @@ Model settings can be changed mid-conversation using `LLMUpdateSettingsFrame`:
 from pipecat.frames.frames import LLMUpdateSettingsFrame
 from pipecat.services.openai.base_llm import OpenAILLMSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=OpenAILLMSettings(
             temperature=0.3,

--- a/api-reference/server/services/llm/openai.mdx
+++ b/api-reference/server/services/llm/openai.mdx
@@ -190,7 +190,7 @@ await task.queue_frame(
 
 - **OpenAI-compatible providers**: Many third-party LLM providers offer OpenAI-compatible APIs. You can use `OpenAILLMService` with them by setting `base_url` to the provider's endpoint.
 - **Retry behavior**: When `retry_on_timeout=True`, the first attempt uses the `retry_timeout_secs` timeout. If it times out, a second attempt is made with no timeout limit.
-- **Function calling**: Supports OpenAI's tool/function calling format. Register function handlers on the pipeline task to handle tool calls automatically.
+- **Function calling**: Supports OpenAI's tool/function calling format. Register function handlers on the pipeline worker to handle tool calls automatically.
 - **System instruction precedence**: If both `system_instruction` (from the constructor) and a system message in the context are set, the constructor's `system_instruction` takes precedence and a warning is logged.
 
 ## Event Handlers

--- a/api-reference/server/services/llm/sarvam.mdx
+++ b/api-reference/server/services/llm/sarvam.mdx
@@ -134,7 +134,7 @@ Model settings can be changed mid-conversation using `LLMUpdateSettingsFrame`:
 from pipecat.frames.frames import LLMUpdateSettingsFrame
 from pipecat.services.sarvam.llm import SarvamLLMSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=SarvamLLMSettings(
             temperature=0.3,

--- a/api-reference/server/services/s2s/grok.mdx
+++ b/api-reference/server/services/s2s/grok.mdx
@@ -110,11 +110,11 @@ _Deprecated in v0.0.105. Use `settings=GrokRealtimeLLMService.Settings(session_p
 
 Runtime-configurable settings passed via the `settings` constructor argument using `GrokRealtimeLLMService.Settings(...)`. These can be updated mid-conversation with `LLMUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter            | Type                | Default                        | Description                                                     |
-| -------------------- | ------------------- | ------------------------------ | --------------------------------------------------------------- |
+| Parameter            | Type                | Default                       | Description                                                                                          |
+| -------------------- | ------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `model`              | `str`               | `"grok-voice-think-fast-1.0"` | Model identifier. Defaults to xAI's recommended Voice Agent model. _(Inherited from base settings.)_ |
-| `system_instruction` | `str`               | `NOT_GIVEN`                    | System instruction/prompt. _(Inherited from base settings.)_    |
-| `session_properties` | `SessionProperties` | `NOT_GIVEN`                    | Session-level configuration (voice, audio config, tools, etc.). |
+| `system_instruction` | `str`               | `NOT_GIVEN`                   | System instruction/prompt. _(Inherited from base settings.)_                                         |
+| `session_properties` | `SessionProperties` | `NOT_GIVEN`                   | Session-level configuration (voice, audio config, tools, etc.).                                      |
 
 <Note>
   `NOT_GIVEN` values are omitted, letting the service use its own defaults. Only
@@ -235,7 +235,7 @@ from pipecat.frames.frames import LLMUpdateSettingsFrame
 from pipecat.services.xai.realtime.llm import GrokRealtimeLLMSettings
 from pipecat.services.xai.realtime.events import SessionProperties
 
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=GrokRealtimeLLMSettings(
             session_properties=SessionProperties(

--- a/api-reference/server/services/s2s/inworld.mdx
+++ b/api-reference/server/services/s2s/inworld.mdx
@@ -96,7 +96,8 @@ Before using Inworld Realtime services, you need:
 <ParamField path="tts_model" type="str" default="inworld-tts-2">
   TTS model to use. Defaults to Realtime TTS-2 (`inworld-tts-2`). Other options:
   Realtime TTS-1.5-Max (`inworld-tts-1.5-max`), Realtime TTS-1.5-Mini
-  (`inworld-tts-1.5-mini`). Shorthand for `session_properties.audio.output.model`.
+  (`inworld-tts-1.5-mini`). Shorthand for
+  `session_properties.audio.output.model`.
 </ParamField>
 
 <ParamField path="stt_model" type="str" default="inworld/inworld-stt-1">
@@ -282,7 +283,7 @@ don't need to resend a full `SessionProperties` config:
 from pipecat.frames.frames import LLMUpdateSettingsFrame
 from pipecat.services.inworld.realtime.llm import InworldRealtimeLLMSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=InworldRealtimeLLMSettings(
             system_instruction="Now speak in Spanish.",
@@ -304,7 +305,7 @@ from pipecat.services.inworld.realtime.events import (
     PCMAudioFormat,
 )
 
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=InworldRealtimeLLMSettings(
             session_properties=SessionProperties(

--- a/api-reference/server/services/s2s/openai.mdx
+++ b/api-reference/server/services/s2s/openai.mdx
@@ -127,12 +127,13 @@ _Deprecated in v0.0.105. Use `settings=OpenAIRealtimeLLMService.Settings(session
 </ParamField>
 
 <ParamField path="user_audio_preroll_secs" type="float | None" default="None">
-  In manual turn-detection mode (`turn_detection=False`, locally-driven turns), how much recent
-  audio to replay after an interruption clears the input audio buffer, so the speech onset isn't lost.
-  Defaults to `None`: auto-sized to the upstream VAD's `start_secs` plus a small margin, falling
-  back to `0.5` seconds when no VAD is present. Auto-sizing assumes VAD drives turn starts (the
-  default `VADUserTurnStartStrategy`); set this explicitly if you use a non-VAD turn-start strategy.
-  No effect when server-side turn detection is enabled.
+  In manual turn-detection mode (`turn_detection=False`, locally-driven turns),
+  how much recent audio to replay after an interruption clears the input audio
+  buffer, so the speech onset isn't lost. Defaults to `None`: auto-sized to the
+  upstream VAD's `start_secs` plus a small margin, falling back to `0.5` seconds
+  when no VAD is present. Auto-sizing assumes VAD drives turn starts (the
+  default `VADUserTurnStartStrategy`); set this explicitly if you use a non-VAD
+  turn-start strategy. No effect when server-side turn detection is enabled.
 </ParamField>
 
 <ParamField path="**kwargs" type="Any">
@@ -174,12 +175,12 @@ The `audio` field in `SessionProperties` accepts an `AudioConfiguration` with `i
 
 **AudioInput** (`audio.input`):
 
-| Parameter         | Type                                             | Default | Description                                                                                                                                           |
-| ----------------- | ------------------------------------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `format`          | `AudioFormat`                                    | `None`  | Input audio format (`PCMAudioFormat`, `PCMUAudioFormat`, or `PCMAAudioFormat`).                                                                       |
+| Parameter         | Type                                             | Default | Description                                                                                                                                                   |
+| ----------------- | ------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `format`          | `AudioFormat`                                    | `None`  | Input audio format (`PCMAudioFormat`, `PCMUAudioFormat`, or `PCMAAudioFormat`).                                                                               |
 | `transcription`   | `InputAudioTranscription`                        | `None`  | Transcription settings: `model` (e.g. `"gpt-realtime-whisper"`, `"gpt-4o-transcribe"`), `language`, and `prompt` (not supported by `"gpt-realtime-whisper"`). |
-| `noise_reduction` | `InputAudioNoiseReduction`                       | `None`  | Noise reduction type: `"near_field"` or `"far_field"`.                                                                                                |
-| `turn_detection`  | `TurnDetection \| SemanticTurnDetection \| bool` | `None`  | Turn detection config, or `False` to disable server-side turn detection.                                                                              |
+| `noise_reduction` | `InputAudioNoiseReduction`                       | `None`  | Noise reduction type: `"near_field"` or `"far_field"`.                                                                                                        |
+| `turn_detection`  | `TurnDetection \| SemanticTurnDetection \| bool` | `None`  | Turn detection config, or `False` to disable server-side turn detection.                                                                                      |
 
 **AudioOutput** (`audio.output`):
 
@@ -324,7 +325,7 @@ from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
 from pipecat.services.openai.realtime.events import SessionProperties, Reasoning
 
 # Update system instruction and max tokens
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=OpenAIRealtimeLLMService.Settings(
             system_instruction="Now speak in Spanish.",
@@ -336,7 +337,7 @@ await task.queue_frame(
 )
 
 # Update reasoning effort (gpt-realtime-2 only)
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=OpenAIRealtimeLLMService.Settings(
             session_properties=SessionProperties(

--- a/api-reference/server/services/s2s/ultravox.mdx
+++ b/api-reference/server/services/s2s/ultravox.mdx
@@ -228,7 +228,7 @@ from pipecat.frames.frames import LLMUpdateSettingsFrame
 from pipecat.services.ultravox.llm import UltravoxRealtimeLLMService
 
 # Switch to text-only output
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=UltravoxRealtimeLLMService.Settings(
             output_medium="text",
@@ -237,7 +237,7 @@ await task.queue_frame(
 )
 
 # Switch back to voice output
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=UltravoxRealtimeLLMService.Settings(
             output_medium="voice",

--- a/api-reference/server/services/serializers/genesys.mdx
+++ b/api-reference/server/services/serializers/genesys.mdx
@@ -153,7 +153,7 @@ disconnect_msg = serializer.create_disconnect_message(
     action="transfer",
     output_variables={"intent": "resolved"},
 )
-await task.queue_frame(OutputTransportMessageUrgentFrame(message=disconnect_msg))
+await worker.queue_frame(OutputTransportMessageUrgentFrame(message=disconnect_msg))
 ```
 
 ### Event Handlers

--- a/api-reference/server/services/stt/deepgram.mdx
+++ b/api-reference/server/services/stt/deepgram.mdx
@@ -367,7 +367,7 @@ from pipecat.services.deepgram.flux import DeepgramFluxSTTService
 from pipecat.transcriptions.language import Language
 
 # During pipeline execution, update settings without reconnecting
-await task.queue_frame(
+await worker.queue_frame(
     STTUpdateSettingsFrame(
         delta=DeepgramFluxSTTService.Settings(
             eot_threshold=0.8,
@@ -377,7 +377,7 @@ await task.queue_frame(
 )
 
 # Detect-then-lock: narrow language hints mid-stream
-await task.queue_frame(
+await worker.queue_frame(
     STTUpdateSettingsFrame(
         delta=DeepgramFluxSTTService.Settings(
             language_hints=[Language.ES],
@@ -627,7 +627,7 @@ from pipecat.services.deepgram.flux.sagemaker.stt import DeepgramFluxSageMakerST
 from pipecat.transcriptions.language import Language
 
 # Update settings without reconnecting
-await task.queue_frame(
+await worker.queue_frame(
     STTUpdateSettingsFrame(
         delta=DeepgramFluxSageMakerSTTService.Settings(
             eot_threshold=0.8,

--- a/api-reference/server/services/stt/google.mdx
+++ b/api-reference/server/services/stt/google.mdx
@@ -179,7 +179,7 @@ Google STT supports dynamic settings updates via `STTUpdateSettingsFrame`:
 from pipecat.frames.frames import STTUpdateSettingsFrame
 from pipecat.transcriptions.language import Language
 
-await task.queue_frame(
+await worker.queue_frame(
     STTUpdateSettingsFrame(
         delta=GoogleSTTService.Settings(
             languages=[Language.FR],

--- a/api-reference/server/services/stt/smallest.mdx
+++ b/api-reference/server/services/stt/smallest.mdx
@@ -124,7 +124,7 @@ Transcription settings can be changed mid-conversation using `STTUpdateSettingsF
 from pipecat.frames.frames import STTUpdateSettingsFrame
 from pipecat.services.smallest.stt import SmallestSTTSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     STTUpdateSettingsFrame(
         delta=SmallestSTTSettings(
             language=Language.FR,

--- a/api-reference/server/services/transport/daily.mdx
+++ b/api-reference/server/services/transport/daily.mdx
@@ -471,7 +471,7 @@ Fired when the first participant (other than the bot) joins the room. This is co
 ```python
 @transport.event_handler("on_first_participant_joined")
 async def on_first_participant_joined(transport, participant):
-    await task.queue_frame(TTSSpeakFrame("Hello! How can I help you today?"))
+    await worker.queue_frame(TTSSpeakFrame("Hello! How can I help you today?"))
 ```
 
 **Parameters:**

--- a/api-reference/server/services/transport/livekit.mdx
+++ b/api-reference/server/services/transport/livekit.mdx
@@ -214,7 +214,7 @@ Fired when the first participant (other than the bot) joins the room. This is co
 ```python
 @transport.event_handler("on_first_participant_joined")
 async def on_first_participant_joined(transport, participant_id):
-    await task.queue_frame(TTSSpeakFrame("Hello! How can I help you today?"))
+    await worker.queue_frame(TTSSpeakFrame("Hello! How can I help you today?"))
 ```
 
 **Parameters:**

--- a/api-reference/server/services/transport/vonage.mdx
+++ b/api-reference/server/services/transport/vonage.mdx
@@ -362,7 +362,7 @@ Fired when the first participant stream is received in the session. Commonly use
 @transport.event_handler("on_first_participant_joined")
 async def on_first_participant_joined(transport, data):
     print(f"First participant joined stream: {data['streamId']}")
-    await task.queue_frames([LLMRunFrame()])
+    await worker.queue_frames([LLMRunFrame()])
 ```
 
 **Parameters:**
@@ -432,7 +432,7 @@ Fired when the transport successfully connects to a participant's stream — at 
 @transport.event_handler("on_client_connected")
 async def on_client_connected(transport, data):
     print(f"Client connected to stream: {data['streamId']}")
-    await task.queue_frames([LLMRunFrame()])
+    await worker.queue_frames([LLMRunFrame()])
 ```
 
 **Parameters:**

--- a/api-reference/server/services/tts/elevenlabs.mdx
+++ b/api-reference/server/services/tts/elevenlabs.mdx
@@ -208,7 +208,7 @@ Voice settings can be changed mid-conversation using `TTSUpdateSettingsFrame`:
 from pipecat.frames.frames import TTSUpdateSettingsFrame
 from pipecat.services.elevenlabs.tts import ElevenLabsTTSSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     TTSUpdateSettingsFrame(
         delta=ElevenLabsTTSSettings(
             stability=0.3,

--- a/api-reference/server/services/tts/hume.mdx
+++ b/api-reference/server/services/tts/hume.mdx
@@ -141,7 +141,7 @@ Voice and synthesis parameters can be changed mid-conversation using `TTSUpdateS
 from pipecat.frames.frames import TTSUpdateSettingsFrame
 from pipecat.services.hume.tts import HumeTTSSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     TTSUpdateSettingsFrame(
         delta=HumeTTSSettings(
             speed=1.3,

--- a/api-reference/server/services/tts/openai.mdx
+++ b/api-reference/server/services/tts/openai.mdx
@@ -156,7 +156,7 @@ Voice settings can be changed mid-conversation using `TTSUpdateSettingsFrame`:
 from pipecat.frames.frames import TTSUpdateSettingsFrame
 from pipecat.services.openai.tts import OpenAITTSSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     TTSUpdateSettingsFrame(
         delta=OpenAITTSSettings(
             instructions="Now speak more formally.",

--- a/api-reference/server/services/tts/smallest.mdx
+++ b/api-reference/server/services/tts/smallest.mdx
@@ -125,7 +125,7 @@ Voice settings can be changed mid-conversation using `TTSUpdateSettingsFrame`:
 from pipecat.frames.frames import TTSUpdateSettingsFrame
 from pipecat.services.smallest.tts import SmallestTTSSettings
 
-await task.queue_frame(
+await worker.queue_frame(
     TTSUpdateSettingsFrame(
         delta=SmallestTTSSettings(
             voice="new_voice",

--- a/api-reference/server/services/tts/xai.mdx
+++ b/api-reference/server/services/tts/xai.mdx
@@ -246,7 +246,7 @@ from pipecat.frames.frames import TTSUpdateSettingsFrame
 from pipecat.services.xai.tts import XAITTSSettings
 from pipecat.transcriptions.language import Language
 
-await task.queue_frame(
+await worker.queue_frame(
     TTSUpdateSettingsFrame(
         delta=XAITTSSettings(
             language=Language.FR,

--- a/api-reference/server/utilities/audio/aic-filter.mdx
+++ b/api-reference/server/utilities/audio/aic-filter.mdx
@@ -117,10 +117,10 @@ vad_ctx.set_parameter(VadParameter.Sensitivity, 8.0)
 from pipecat.frames.frames import FilterEnableFrame
 
 # Disable speech enhancement
-await task.queue_frame(FilterEnableFrame(False))
+await worker.queue_frame(FilterEnableFrame(False))
 
 # Re-enable speech enhancement
-await task.queue_frame(FilterEnableFrame(True))
+await worker.queue_frame(FilterEnableFrame(True))
 ```
 
 </ParamField>

--- a/api-reference/server/utilities/audio/koala-filter.mdx
+++ b/api-reference/server/utilities/audio/koala-filter.mdx
@@ -35,10 +35,10 @@ Specific control frame to toggle filtering on/off
 from pipecat.frames.frames import FilterEnableFrame
 
 # Disable noise reduction
-await task.queue_frame(FilterEnableFrame(False))
+await worker.queue_frame(FilterEnableFrame(False))
 
 # Re-enable noise reduction
-await task.queue_frame(FilterEnableFrame(True))
+await worker.queue_frame(FilterEnableFrame(True))
 ```
 
 </ParamField>

--- a/api-reference/server/utilities/audio/krisp-viva-filter.mdx
+++ b/api-reference/server/utilities/audio/krisp-viva-filter.mdx
@@ -33,7 +33,8 @@ You can set the `model_path` directly. Alternatively, you can set the `KRISP_VIV
 </ParamField>
 
 <ParamField path="api_key" type="str" default='""'>
-  Krisp SDK API key for licensing (required for SDK v1.6.1+). If empty, falls back to the `KRISP_VIVA_API_KEY` environment variable.
+  Krisp SDK API key for licensing (required for SDK v1.6.1+). If empty, falls
+  back to the `KRISP_VIVA_API_KEY` environment variable.
 </ParamField>
 
 ## Supported Sample Rates
@@ -56,10 +57,10 @@ The filter supports the following sample rates:
 from pipecat.frames.frames import FilterEnableFrame
 
 # Disable voice isolation
-await task.queue_frame(FilterEnableFrame(False))
+await worker.queue_frame(FilterEnableFrame(False))
 
 # Re-enable voice isolation
-await task.queue_frame(FilterEnableFrame(True))
+await worker.queue_frame(FilterEnableFrame(True))
 ```
 
 </ParamField>

--- a/api-reference/server/utilities/audio/rnnoise-filter.mdx
+++ b/api-reference/server/utilities/audio/rnnoise-filter.mdx
@@ -35,10 +35,10 @@ uv add "pipecat-ai[rnnoise]"
 from pipecat.frames.frames import FilterEnableFrame
 
 # Disable noise suppression
-await task.queue_frame(FilterEnableFrame(False))
+await worker.queue_frame(FilterEnableFrame(False))
 
 # Re-enable noise suppression
-await task.queue_frame(FilterEnableFrame(True))
+await worker.queue_frame(FilterEnableFrame(True))
 ```
 
 </ParamField>

--- a/api-reference/server/utilities/audio/soundfile-mixer.mdx
+++ b/api-reference/server/utilities/audio/soundfile-mixer.mdx
@@ -93,9 +93,9 @@ transport = DailyTransport(
 )
 
 # Control mixer at runtime
-await task.queue_frame(MixerUpdateSettingsFrame({"volume": 0.5}))
-await task.queue_frame(MixerEnableFrame(False))  # Disable mixing
-await task.queue_frame(MixerEnableFrame(True))   # Enable mixing
+await worker.queue_frame(MixerUpdateSettingsFrame({"volume": 0.5}))
+await worker.queue_frame(MixerEnableFrame(False))  # Disable mixing
+await worker.queue_frame(MixerEnableFrame(True))   # Enable mixing
 ```
 
 ## Notes

--- a/api-reference/server/utilities/extensions/ivr.mdx
+++ b/api-reference/server/utilities/extensions/ivr.mdx
@@ -189,7 +189,7 @@ async def handle_conversation(processor, conversation_history):
         {"role": "assistant", "content": "How can I help you today?"}
     ]
 
-    await task.queue_frame(LLMMessagesUpdateFrame(messages=enhanced_context, run_llm=True))
+    await worker.queue_frame(LLMMessagesUpdateFrame(messages=enhanced_context, run_llm=True))
 ```
 
 ### VAD Parameter Management
@@ -200,7 +200,7 @@ async def handle_conversation(processor, conversation_history):
 async def optimize_for_conversation(processor, conversation_history):
     # Reduce response delay for natural conversation flow
     conversation_vad = VADParams(stop_secs=0.8)
-    await task.queue_frame(VADParamsUpdateFrame(params=conversation_vad))
+    await worker.queue_frame(VADParamsUpdateFrame(params=conversation_vad))
 ```
 
 ## Integration Examples

--- a/api-reference/server/utilities/observers/debug-observer.mdx
+++ b/api-reference/server/utilities/observers/debug-observer.mdx
@@ -23,7 +23,7 @@ Log all frames passing through the pipeline:
 ```python
 from pipecat.observers.loggers.debug_log_observer import DebugLogObserver
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         observers=[DebugLogObserver()],
@@ -39,7 +39,7 @@ Log only specific frame types:
 from pipecat.frames.frames import TranscriptionFrame, InterimTranscriptionFrame
 from pipecat.observers.loggers.debug_log_observer import DebugLogObserver
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         observers=[
@@ -62,7 +62,7 @@ from pipecat.observers.loggers.debug_log_observer import DebugLogObserver, Frame
 from pipecat.transports.base_output_transport import BaseOutputTransport
 from pipecat.services.stt_service import STTService
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         observers=[

--- a/api-reference/server/utilities/observers/llm-observer.mdx
+++ b/api-reference/server/utilities/observers/llm-observer.mdx
@@ -22,7 +22,7 @@ The observer tracks the following frame types (only from/to LLM service):
 ```python
 from pipecat.observers.loggers.llm_log_observer import LLMLogObserver
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         observers=[LLMLogObserver()],

--- a/api-reference/server/utilities/observers/observer-pattern.mdx
+++ b/api-reference/server/utilities/observers/observer-pattern.mdx
@@ -55,7 +55,10 @@ class CustomObserver(BaseObserver):
 ```
 
 <Note>
-  If you give your observer a custom `__init__`, you must call `super().__init__()`. Skipping it leaves the observer partially initialized and raises errors such as `'CustomObserver' object has no attribute '_name'` at runtime.
+  If you give your observer a custom `__init__`, you must call
+  `super().__init__()`. Skipping it leaves the observer partially initialized
+  and raises errors such as `'CustomObserver' object has no attribute '_name'`
+  at runtime.
 </Note>
 
 ## Available Observers
@@ -74,7 +77,7 @@ Pipecat provides several built-in observers:
 You can attach multiple observers to a pipeline worker. Each observer will be notified of all frames:
 
 ```python
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         observers=[LLMLogObserver(), TranscriptionLogObserver(), CustomObserver()],

--- a/api-reference/server/utilities/observers/observer-pattern.mdx
+++ b/api-reference/server/utilities/observers/observer-pattern.mdx
@@ -71,7 +71,7 @@ Pipecat provides several built-in observers:
 
 ## Using Multiple Observers
 
-You can attach multiple observers to a pipeline task. Each observer will be notified of all frames:
+You can attach multiple observers to a pipeline worker. Each observer will be notified of all frames:
 
 ```python
 task = PipelineWorker(

--- a/api-reference/server/utilities/observers/startup-timing-observer.mdx
+++ b/api-reference/server/utilities/observers/startup-timing-observer.mdx
@@ -39,7 +39,7 @@ async def on_transport_timing_report(observer, report):
         print(f"Bot connected: {report.bot_connected_secs:.3f}s")
     print(f"Client connected: {report.client_connected_secs:.3f}s")
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     observers=[observer],
 )

--- a/api-reference/server/utilities/observers/transcription-observer.mdx
+++ b/api-reference/server/utilities/observers/transcription-observer.mdx
@@ -18,7 +18,7 @@ The observer tracks the following frame types (only from STT service):
 ```python
 from pipecat.observers.loggers.transcription_log_observer import TranscriptionLogObserver
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         observers=[TranscriptionLogObserver()],

--- a/api-reference/server/utilities/observers/turn-tracking-observer.mdx
+++ b/api-reference/server/utilities/observers/turn-tracking-observer.mdx
@@ -29,13 +29,13 @@ The observer emits two main events:
 The observer is automatically created when you initialize a `PipelineWorker` with `enable_turn_tracking=True` (which is the default):
 
 ```python
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     # Turn tracking is enabled by default
 )
 
 # Access the observer
-turn_observer = task.turn_tracking_observer
+turn_observer = worker.turn_tracking_observer
 
 # Register event handlers
 @turn_observer.event_handler("on_turn_started")
@@ -61,7 +61,7 @@ custom_turn_tracker = TurnTrackingObserver(
 )
 
 # Add it as a regular observer
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     observers=[custom_turn_tracker],
     # Disable the default one if adding your own

--- a/api-reference/server/utilities/observers/user-bot-latency-observer.mdx
+++ b/api-reference/server/utilities/observers/user-bot-latency-observer.mdx
@@ -33,7 +33,7 @@ latency_observer = UserBotLatencyObserver()
 async def on_latency_measured(observer, latency):
     print(f"User-to-bot latency: {latency:.3f}s")
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(observers=[latency_observer]),
 )
@@ -54,7 +54,7 @@ async def on_latency_breakdown(observer, breakdown):
     for event in breakdown.chronological_events():
         print(f"  {event}")
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         observers=[latency_observer],

--- a/api-reference/server/utilities/opentelemetry.mdx
+++ b/api-reference/server/utilities/opentelemetry.mdx
@@ -63,13 +63,13 @@ setup_tracing(
 )
 
 # Step 2: Enable tracing in your PipelineWorker
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         enable_metrics=True,                              # Required for some service metrics
     ),
-    enable_tracing=True,                                  # Enable tracing for this task
-    enable_turn_tracking=True,                            # Enable turn tracking for this task
+    enable_tracing=True,                                  # Enable tracing for this worker
+    enable_turn_tracking=True,                            # Enable turn tracking for this worker
     conversation_id="customer-123",                       # Optional - will auto-generate if not provided
     additional_span_attributes={"session.id": "abc-123"} # Optional - additional attributes to attach to the otel span
 )
@@ -397,7 +397,7 @@ pipeline = Pipeline([
 ])
 
 # Create pipeline worker with tracing enabled
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         enable_metrics=True,
@@ -411,7 +411,7 @@ task = PipelineWorker(
 
 # Run the pipeline
 runner = WorkerRunner()
-await runner.run(task)
+await runner.run(worker)
 ```
 
 ## Troubleshooting

--- a/api-reference/server/utilities/opentelemetry.mdx
+++ b/api-reference/server/utilities/opentelemetry.mdx
@@ -396,7 +396,7 @@ pipeline = Pipeline([
     context_aggregator.assistant(),
 ])
 
-# Create pipeline task with tracing enabled
+# Create pipeline worker with tracing enabled
 task = PipelineWorker(
     pipeline,
     params=PipelineParams(

--- a/api-reference/server/utilities/runner/guide.mdx
+++ b/api-reference/server/utilities/runner/guide.mdx
@@ -67,7 +67,7 @@ async def run_bot(transport: BaseTransport):
     # Define STT, LLM, TTS...
     # ...
     # Run your pipeline
-    await runner.run(task)
+    await runner.run(worker)
 
 async def bot(runner_args: RunnerArguments):
     """Main bot entry point compatible for local dev and Pipecat Cloud."""
@@ -169,7 +169,10 @@ All runner arguments also include:
 - **`handle_sigterm`**: Whether the bot should handle SIGTERM signals (managed automatically)
 
 <Note>
-For WhatsApp connections, `SmallWebRTCRunnerArguments.body` contains a `WhatsAppConnectCall` object with caller metadata (phone number, call ID, direction, timestamp). This allows your bot to access caller information without additional API calls.
+  For WhatsApp connections, `SmallWebRTCRunnerArguments.body` contains a
+  `WhatsAppConnectCall` object with caller metadata (phone number, call ID,
+  direction, timestamp). This allows your bot to access caller information
+  without additional API calls.
 </Note>
 
 <Warning>
@@ -522,7 +525,15 @@ Telephony connections use `/ws`; plain WebSocket clients use `/ws-client` (and a
 ```json
 {
   "status": "ready",
-  "transports": ["webrtc", "daily", "twilio", "telnyx", "plivo", "exotel", "websocket"]
+  "transports": [
+    "webrtc",
+    "daily",
+    "twilio",
+    "telnyx",
+    "plivo",
+    "exotel",
+    "websocket"
+  ]
 }
 ```
 
@@ -563,9 +574,9 @@ await client.connect({ endpoint: "http://localhost:7860/start" });
 ```
 
 <Info>
-  The `/start` endpoint serves every transport. The client SDK's transport
-  (e.g. `DailyTransport`, `SmallWebRTCTransport`) determines the `"transport"`
-  value sent in the request.
+  The `/start` endpoint serves every transport. The client SDK's transport (e.g.
+  `DailyTransport`, `SmallWebRTCTransport`) determines the `"transport"` value
+  sent in the request.
 </Info>
 
 ## Daily Dial-In Webhook
@@ -673,6 +684,7 @@ The development runner includes built-in error handling to help debug issues wit
 When FastAPI receives a malformed request that fails Pydantic validation (HTTP 422 Unprocessable Entity), the runner automatically logs both the validation errors and the raw request body. This makes it much easier to debug malformed payloads from any transport — WhatsApp webhooks, WebRTC signaling, telephony providers, or RTVI clients.
 
 The runner logs:
+
 - The request URL path where the error occurred
 - Detailed validation error messages from Pydantic
 - The raw request body (up to 5000 characters)
@@ -688,19 +700,19 @@ This automatic logging applies to all runner endpoints and helps identify issues
 
 All transports are available from `python bot.py`; the `-t` form below restricts the server to one. Access columns assume the default `localhost:7860`.
 
-| Transport     | Command                                             | Access                       | Environment Variables                               |
-| ------------- | --------------------------------------------------- | ---------------------------- | --------------------------------------------------- |
-| All (default) | `python bot.py`                                     | http://localhost:7860/client | Per transport (see below)                           |
-| WebRTC        | `python bot.py -t webrtc`                           | http://localhost:7860/client | None                                                |
-| Daily         | `python bot.py -t daily`                            | `GET /daily`, `POST /start`  | `DAILY_API_KEY`, `DAILY_SAMPLE_ROOM_URL` (Optional) |
-| Daily Direct  | `python bot.py -d`                                  | Direct connection            | `DAILY_API_KEY`, `DAILY_SAMPLE_ROOM_URL` (Optional) |
-| Daily Dial-In | `python bot.py --dialin`                            | Phone calls via Daily PSTN   | `DAILY_API_KEY` (Required)                          |
-| Twilio        | `python bot.py -t twilio -x proxy.ngrok.io`         | Phone calls                  | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`           |
-| Telnyx        | `python bot.py -t telnyx -x proxy.ngrok.io`         | Phone calls                  | `TELNYX_API_KEY`                                    |
-| Plivo         | `python bot.py -t plivo -x proxy.ngrok.io`          | Phone calls                  | `PLIVO_AUTH_ID`, `PLIVO_AUTH_TOKEN`                 |
-| Exotel        | `python bot.py -t exotel`                           | Phone calls                  | None                                                |
-| WebSocket     | `python bot.py`                                     | `ws://localhost:7860/ws-client` | None                                             |
-| ESP32 WebRTC  | `python bot.py --esp32 --host <ESP32_IP>`           | ESP32 WebRTC connection      | None                                                |
+| Transport     | Command                                     | Access                          | Environment Variables                               |
+| ------------- | ------------------------------------------- | ------------------------------- | --------------------------------------------------- |
+| All (default) | `python bot.py`                             | http://localhost:7860/client    | Per transport (see below)                           |
+| WebRTC        | `python bot.py -t webrtc`                   | http://localhost:7860/client    | None                                                |
+| Daily         | `python bot.py -t daily`                    | `GET /daily`, `POST /start`     | `DAILY_API_KEY`, `DAILY_SAMPLE_ROOM_URL` (Optional) |
+| Daily Direct  | `python bot.py -d`                          | Direct connection               | `DAILY_API_KEY`, `DAILY_SAMPLE_ROOM_URL` (Optional) |
+| Daily Dial-In | `python bot.py --dialin`                    | Phone calls via Daily PSTN      | `DAILY_API_KEY` (Required)                          |
+| Twilio        | `python bot.py -t twilio -x proxy.ngrok.io` | Phone calls                     | `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`           |
+| Telnyx        | `python bot.py -t telnyx -x proxy.ngrok.io` | Phone calls                     | `TELNYX_API_KEY`                                    |
+| Plivo         | `python bot.py -t plivo -x proxy.ngrok.io`  | Phone calls                     | `PLIVO_AUTH_ID`, `PLIVO_AUTH_TOKEN`                 |
+| Exotel        | `python bot.py -t exotel`                   | Phone calls                     | None                                                |
+| WebSocket     | `python bot.py`                             | `ws://localhost:7860/ws-client` | None                                                |
+| ESP32 WebRTC  | `python bot.py --esp32 --host <ESP32_IP>`   | ESP32 WebRTC connection         | None                                                |
 
 ## Examples
 

--- a/api-reference/server/utilities/service-switchers/llm-switcher.mdx
+++ b/api-reference/server/utilities/service-switchers/llm-switcher.mdx
@@ -174,5 +174,5 @@ pipeline = Pipeline([
 ])
 
 # Switch to cheaper model for simple tasks
-await task.queue_frame(ManuallySwitchServiceFrame(service=gpt35))
+await worker.queue_frame(ManuallySwitchServiceFrame(service=gpt35))
 ```

--- a/api-reference/server/utilities/service-switchers/service-switcher.mdx
+++ b/api-reference/server/utilities/service-switchers/service-switcher.mdx
@@ -115,7 +115,7 @@ pipeline = Pipeline([
 ])
 
 # Later, switch to Cartesia
-await task.queue_frame(ManuallySwitchServiceFrame(service=cartesia))
+await worker.queue_frame(ManuallySwitchServiceFrame(service=cartesia))
 ```
 
 ## Event Handlers

--- a/api-reference/server/utilities/text/pattern-pair-aggregator.mdx
+++ b/api-reference/server/utilities/text/pattern-pair-aggregator.mdx
@@ -250,7 +250,7 @@ from pipecat.processors.frameworks.rtvi import RTVIObserverParams
 def obfuscate_credit_card(text: str, type: str) -> str:
     return "XXXX-XXXX-XXXX-" + text[-4:]
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,  # llm -> llm_text_processor -> tts
     rtvi_observer_params=RTVIObserverParams(
         bot_output_transforms=[("credit_card", obfuscate_credit_card)],

--- a/client/guides/custom-messaging.mdx
+++ b/client/guides/custom-messaging.mdx
@@ -4,24 +4,28 @@ description: "Send and receive arbitrary messages between your client and Pipeca
 ---
 
 <View title="React" icon="react">
-<Callout icon="react" color="#FFC107">
-You are currently viewing the React version of this page. Use the dropdown to the right to customize this page for your client framework.
-</Callout>
+  <Callout icon="react" color="#FFC107">
+    You are currently viewing the React version of this page. Use the dropdown
+    to the right to customize this page for your client framework.
+  </Callout>
 </View>
 <View title="JavaScript" icon="js">
-<Callout icon="js" color="#FFC107">
-You are currently viewing the JavaScript version of this page. Use the dropdown to the right to customize this page for your client framework.
-</Callout>
+  <Callout icon="js" color="#FFC107">
+    You are currently viewing the JavaScript version of this page. Use the
+    dropdown to the right to customize this page for your client framework.
+  </Callout>
 </View>
 <View title="React Native" icon="mobile">
-<Callout icon="mobile" color="#FFC107">
-You are currently viewing the React Native version of this page. Use the dropdown to the right to customize this page for your client framework.
-</Callout>
+  <Callout icon="mobile" color="#FFC107">
+    You are currently viewing the React Native version of this page. Use the
+    dropdown to the right to customize this page for your client framework.
+  </Callout>
 </View>
 <View title="iOS" icon="apple">
-<Callout icon="apple" color="#FFC107">
-You are currently viewing the iOS version of this page. Use the dropdown to the right to customize this page for your client framework.
-</Callout>
+  <Callout icon="apple" color="#FFC107">
+    You are currently viewing the iOS version of this page. Use the dropdown to
+    the right to customize this page for your client framework.
+  </Callout>
 </View>
 
 The Pipecat client can send and receive arbitrary messages to and from the server running the bot. This is useful for passing configuration at startup, triggering actions mid-session, querying server state, and receiving notifications from the bot.
@@ -137,7 +141,8 @@ async def start(request: Request) -> Dict[Any, Any]:
     bot_procs[proc.pid] = (proc, room_url)
 
     return {"url": room_url, "token": token}
-```
+
+````
 
 ```python bot
 def extract_arguments():
@@ -158,7 +163,8 @@ async def main():
             language=args.language,
         ),
     )
-```
+````
+
 </CodeGroup>
 
 ---
@@ -212,7 +218,7 @@ On the server, handle it via the `on_client_message` event handler or from insid
 async def on_client_message(rtvi, msg):
     if msg.type == "set-language":
         language = msg.data.get("language", "en-US")
-        await task.queue_frames([STTUpdateSettingsFrame(language=language)])
+        await worker.queue_frames([STTUpdateSettingsFrame(language=language)])
 ```
 
 ```python FrameProcessor
@@ -226,6 +232,7 @@ class CustomFrameProcessor(FrameProcessor):
                 return
         await self.push_frame(frame, direction)
 ```
+
 </CodeGroup>
 
 ---
@@ -326,6 +333,7 @@ class CustomFrameProcessor(FrameProcessor):
                 )
         await self.push_frame(frame, direction)
 ```
+
 </CodeGroup>
 
 ---
@@ -355,7 +363,7 @@ function LanguageListener() {
       if (data.msg === "language-updated") {
         console.log("Language updated to:", data.language);
       }
-    }, [])
+    }, []),
   );
 }
 ```
@@ -446,6 +454,7 @@ class CustomFrameProcessor(FrameProcessor):
                     )
         await self.push_frame(frame, direction)
 ```
+
 </CodeGroup>
 
 ---
@@ -453,10 +462,18 @@ class CustomFrameProcessor(FrameProcessor):
 ## API reference
 
 <CardGroup cols={2}>
-  <Card title="Client Methods" icon="js" href="/api-reference/client/js/client-methods#messages">
+  <Card
+    title="Client Methods"
+    icon="js"
+    href="/api-reference/client/js/client-methods#messages"
+  >
     `sendClientMessage`, `sendClientRequest`, `registerFunctionCallHandler`
   </Card>
-  <Card title="Callbacks & Events" icon="bell" href="/api-reference/client/js/callbacks#messages-and-errors">
+  <Card
+    title="Callbacks & Events"
+    icon="bell"
+    href="/api-reference/client/js/callbacks#messages-and-errors"
+  >
     `onServerMessage`, `onMessageError`, and related events
   </Card>
 </CardGroup>

--- a/pipecat-cloud/guides/session-api.mdx
+++ b/pipecat-cloud/guides/session-api.mdx
@@ -86,7 +86,7 @@ Most Session API use cases require your endpoint to interact with the running pi
 from pipecatcloud_system import app
 from pipecat.pipeline.worker import PipelineWorker
 
-# Module-level reference to the running pipeline task
+# Module-level reference to the running pipeline worker
 pipeline_task: PipelineWorker | None = None
 
 async def bot(args):

--- a/pipecat-cloud/guides/session-api.mdx
+++ b/pipecat-cloud/guides/session-api.mdx
@@ -94,10 +94,10 @@ async def bot(args):
 
     # ... set up your pipeline ...
 
-    pipeline_worker = task
+    pipeline_worker = worker
 
     runner = WorkerRunner()
-    await runner.run(task)
+    await runner.run(worker)
 
     pipeline_worker = None
 
@@ -159,10 +159,10 @@ async def bot(args):
 
     # ... set up your pipeline ...
 
-    pipeline_worker = task
+    pipeline_worker = worker
 
     runner = WorkerRunner()
-    await runner.run(task)
+    await runner.run(worker)
 
     pipeline_worker = None
 ```
@@ -207,10 +207,10 @@ async def bot(args):
 
     # ... set up your pipeline ...
 
-    pipeline_worker = task
+    pipeline_worker = worker
 
     runner = WorkerRunner()
-    await runner.run(task)
+    await runner.run(worker)
 
     pipeline_worker = None
 ```

--- a/pipecat-cloud/guides/session-api.mdx
+++ b/pipecat-cloud/guides/session-api.mdx
@@ -87,25 +87,25 @@ from pipecatcloud_system import app
 from pipecat.pipeline.worker import PipelineWorker
 
 # Module-level reference to the running pipeline worker
-pipeline_task: PipelineWorker | None = None
+pipeline_worker: PipelineWorker | None = None
 
 async def bot(args):
-    global pipeline_task
+    global pipeline_worker
 
     # ... set up your pipeline ...
 
-    pipeline_task = task
+    pipeline_worker = task
 
     runner = WorkerRunner()
     await runner.run(task)
 
-    pipeline_task = None
+    pipeline_worker = None
 
 @app.post("/context")
 async def update_context(data: dict):
-    if not pipeline_task:
+    if not pipeline_worker:
         return {"error": "No active pipeline"}, 503
-    # Use pipeline_task.queue_frame() to inject frames
+    # Use pipeline_worker.queue_frame() to inject frames
     # ...
 ```
 
@@ -127,7 +127,7 @@ from pipecat.pipeline.worker import PipelineWorker
 from pipecat.workers.runner import WorkerRunner
 from pipecat.frames.frames import LLMMessagesAppendFrame
 
-pipeline_task: PipelineWorker | None = None
+pipeline_worker: PipelineWorker | None = None
 
 class ContextUpdate(BaseModel):
     user_name: str
@@ -135,11 +135,11 @@ class ContextUpdate(BaseModel):
 
 @app.post("/context")
 async def update_context(update: ContextUpdate):
-    if not pipeline_task:
+    if not pipeline_worker:
         return {"error": "No active pipeline"}, 503
 
     # Inject a developer message into the conversation
-    await pipeline_task.queue_frame(
+    await pipeline_worker.queue_frame(
         LLMMessagesAppendFrame(
             messages=[{
                 "role": "developer",
@@ -155,16 +155,16 @@ async def update_context(update: ContextUpdate):
     return {"status": "context updated", "user_name": update.user_name}
 
 async def bot(args):
-    global pipeline_task
+    global pipeline_worker
 
     # ... set up your pipeline ...
 
-    pipeline_task = task
+    pipeline_worker = task
 
     runner = WorkerRunner()
     await runner.run(task)
 
-    pipeline_task = None
+    pipeline_worker = None
 ```
 
 Call the endpoint:
@@ -188,31 +188,31 @@ from pipecat.pipeline.worker import PipelineWorker
 from pipecat.workers.runner import WorkerRunner
 from pipecat.frames.frames import TTSSpeakFrame
 
-pipeline_task: PipelineWorker | None = None
+pipeline_worker: PipelineWorker | None = None
 
 class SpeakRequest(BaseModel):
     message: str
 
 @app.post("/speak")
 async def trigger_speech(req: SpeakRequest):
-    if not pipeline_task:
+    if not pipeline_worker:
         return {"error": "No active pipeline"}, 503
 
-    await pipeline_task.queue_frame(TTSSpeakFrame(text=req.message))
+    await pipeline_worker.queue_frame(TTSSpeakFrame(text=req.message))
 
     return {"queued": True, "message": req.message}
 
 async def bot(args):
-    global pipeline_task
+    global pipeline_worker
 
     # ... set up your pipeline ...
 
-    pipeline_task = task
+    pipeline_worker = task
 
     runner = WorkerRunner()
     await runner.run(task)
 
-    pipeline_task = None
+    pipeline_worker = None
 ```
 
 Call the endpoint:

--- a/pipecat-cloud/guides/telephony/daily-dial-in.mdx
+++ b/pipecat-cloud/guides/telephony/daily-dial-in.mdx
@@ -128,7 +128,7 @@ async def bot(runner_args: RunnerArguments):
     # Start speaking when caller joins
     @transport.event_handler("on_first_participant_joined")
     async def on_first_participant_joined(transport, participant):
-        await task.queue_frames([LLMRunFrame()])
+        await worker.queue_frames([LLMRunFrame()])
 
     # Your bot pipeline setup...
 ```

--- a/pipecat-flows/guides/context-strategies.mdx
+++ b/pipecat-flows/guides/context-strategies.mdx
@@ -36,7 +36,7 @@ from pipecat_flows import ContextStrategy, ContextStrategyConfig
 
 # Global strategy configuration
 flow_manager = FlowManager(
-    task=task,
+    worker=worker,
     llm=llm,
     context_aggregator=context_aggregator,
     context_strategy=ContextStrategyConfig(

--- a/pipecat/deployment/platforms/cerebrium.mdx
+++ b/pipecat/deployment/platforms/cerebrium.mdx
@@ -134,7 +134,7 @@ async def main(room_url: str, token: str):
         ]
     )
 
-    task = PipelineWorker(
+    worker = PipelineWorker(
         pipeline,
         params=PipelineParams(
             enable_metrics=True,
@@ -145,19 +145,19 @@ async def main(room_url: str, token: str):
     @transport.event_handler("on_first_participant_joined")
     async def on_first_participant_joined(transport, participant):
         context.add_message({"role": "user", "content": "Introduce yourself."})
-        await task.queue_frames([LLMRunFrame()])
+        await worker.queue_frames([LLMRunFrame()])
 
     @transport.event_handler("on_participant_left")
     async def on_participant_left(transport, participant, reason):
-        await task.queue_frame(EndFrame())
+        await worker.queue_frame(EndFrame())
 
     @transport.event_handler("on_call_state_updated")
     async def on_call_state_updated(transport, state):
         if state == "left":
-            await task.queue_frame(EndFrame())
+            await worker.queue_frame(EndFrame())
 
     runner = WorkerRunner()
-    await runner.run(task)
+    await runner.run(worker)
 ```
 
 First, the `main` function initializes the Daily transport to send and receive audio for the Daily room we'll connect to. We pass in the `room_url` we want to join and a `token` that authenticates the bot.

--- a/pipecat/fundamentals/detecting-user-idle.mdx
+++ b/pipecat/fundamentals/detecting-user-idle.mdx
@@ -86,7 +86,7 @@ class IdleHandler:
             await aggregator.push_frame(
                 TTSSpeakFrame("It seems like you're busy. Have a nice day!")
             )
-            await aggregator.push_frame(EndTaskFrame(), FrameDirection.UPSTREAM)
+            await aggregator.push_frame(EndWorkerFrame(), FrameDirection.UPSTREAM)
 
 # Use the handler
 idle_handler = IdleHandler()
@@ -120,7 +120,7 @@ This is useful when you want to enable idle detection only at certain points in 
 
 - **Set appropriate timeouts**: Shorter timeouts (5-10 seconds) work well for voice conversations
 - **Use escalating responses**: Start with gentle reminders and gradually become more direct
-- **Limit retry attempts**: After 2-3 unsuccessful attempts, consider [ending the conversation](/pipecat/learn/pipeline-termination) gracefully by pushing an `EndTaskFrame`
+- **Limit retry attempts**: After 2-3 unsuccessful attempts, consider [ending the conversation](/pipecat/learn/pipeline-termination) gracefully by pushing an `EndWorkerFrame`
 - **Reset on user activity**: Use the `on_user_turn_started` event to reset your retry counter when the user speaks
 - **Let the LLM respond naturally**: Use developer messages to prompt the LLM rather than hardcoded TTS responses for more natural interactions
 

--- a/pipecat/fundamentals/detecting-user-idle.mdx
+++ b/pipecat/fundamentals/detecting-user-idle.mdx
@@ -108,10 +108,10 @@ You can enable, disable, or change the idle timeout at runtime by pushing a `Use
 from pipecat.frames.frames import UserIdleTimeoutUpdateFrame
 
 # Enable idle detection (or change timeout)
-await task.queue_frame(UserIdleTimeoutUpdateFrame(timeout=10.0))
+await worker.queue_frame(UserIdleTimeoutUpdateFrame(timeout=10.0))
 
 # Disable idle detection
-await task.queue_frame(UserIdleTimeoutUpdateFrame(timeout=0))
+await worker.queue_frame(UserIdleTimeoutUpdateFrame(timeout=0))
 ```
 
 This is useful when you want to enable idle detection only at certain points in the conversation, or adjust the timeout based on context.

--- a/pipecat/fundamentals/ivr.mdx
+++ b/pipecat/fundamentals/ivr.mdx
@@ -37,10 +37,10 @@ async def handle_ivr_status(processor, status):
         # Start conversation
         # Replace the context with new messages for the upcoming conversation
         messages = [{"role": "developer", "content": "You are a helpful customer service assistant."}]
-        await task.queue_frame(LLMMessagesUpdateFrame(messages))
+        await worker.queue_frame(LLMMessagesUpdateFrame(messages))
         # Adjust VAD stop_secs for conversation
         vad_params = VADParams(stop_secs=0.8)
-        await task.queue_frame(VADParamsUpdateFrame(vad_params))
+        await worker.queue_frame(VADParamsUpdateFrame(vad_params))
 ```
 
 ### Stuck ⚠️
@@ -58,7 +58,7 @@ async def handle_ivr_status(processor, status):
         logger.warning("IVR navigation stuck - terminating call")
         # Log the issue and clean up
         await log_navigation_failure()
-        await task.queue_frame(EndFrame())
+        await worker.queue_frame(EndFrame())
 ```
 
 ## Flexible Entry Points
@@ -89,7 +89,7 @@ async def on_conversation_detected(processor, conversation_history):
     if conversation_history:
         messages.extend(conversation_history)
 
-    await task.queue_frame(LLMMessagesUpdateFrame(messages=messages, run_llm=True))
+    await worker.queue_frame(LLMMessagesUpdateFrame(messages=messages, run_llm=True))
 ```
 
 Note that the `on_conversation_detected` event also emits a `conversation_history` parameter that contains the previous conversation history. This allows you to build a prompt that includes your conversation system prompt plus any conversation history up to that point in time.
@@ -155,7 +155,7 @@ async def on_conversation_detected(processor, conversation_history):
     if conversation_history:
         messages.extend(conversation_history)
 
-    await task.queue_frame(LLMMessagesUpdateFrame(messages=messages, run_llm=True))
+    await worker.queue_frame(LLMMessagesUpdateFrame(messages=messages, run_llm=True))
 
 @ivr_navigator.event_handler("on_ivr_status_changed")
 async def on_ivr_status_changed(processor, status):

--- a/pipecat/fundamentals/metrics.mdx
+++ b/pipecat/fundamentals/metrics.mdx
@@ -11,10 +11,10 @@ configuration options.
 
 ## Enabling performance metrics
 
-Set `enable_metrics=True` in `PipelineParams` when creating a task:
+Set `enable_metrics=True` in `PipelineParams` when creating a worker:
 
 ```python Example config
-task = PipelineWorker(
+worker = PipelineWorker(
             pipeline,
             params=PipelineParams(
                 ...
@@ -46,7 +46,7 @@ If you only want the **first** TTFB measurement for each service, you can
 optionally pass `report_only_initial_ttfb=True` in `PipelineParams`:
 
 ```python Example config
-task = PipelineWorker(
+worker = PipelineWorker(
             pipeline,
             params=PipelineParams(
                 ...
@@ -66,7 +66,7 @@ By default, Pipecat sends an initial `MetricsFrame` with zero values for all
 services when the pipeline starts. To disable this behavior:
 
 ```python Example config
-task = PipelineWorker(
+worker = PipelineWorker(
             pipeline,
             params=PipelineParams(
                 ...
@@ -79,10 +79,10 @@ task = PipelineWorker(
 
 ## Enabling LLM/TTS Usage Metrics
 
-Set `enable_usage_metrics=True` in PipelineParams when creating a task:
+Set `enable_usage_metrics=True` in PipelineParams when creating a worker:
 
 ```python Example config
-task = PipelineWorker(
+worker = PipelineWorker(
             pipeline,
             params=PipelineParams(
                 ...
@@ -127,7 +127,7 @@ The simplest way to log metrics is with the built-in `MetricsLogObserver`. Pass 
 ```python
 from pipecat.observers.loggers.metrics_log_observer import MetricsLogObserver
 
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
     observers=[MetricsLogObserver()],
@@ -286,7 +286,7 @@ latency_observer = UserBotLatencyObserver()
 async def on_latency_measured(observer, latency_seconds):
     print(f"User-to-bot latency: {latency_seconds:.3f}s")
 
-task = PipelineWorker(pipeline, observers=[latency_observer])
+worker = PipelineWorker(pipeline, observers=[latency_observer])
 ```
 
 ### TurnTrackingObserver
@@ -307,5 +307,5 @@ async def on_turn_ended(observer, turn_count, duration, was_interrupted):
     status = "interrupted" if was_interrupted else "completed"
     print(f"Turn {turn_count} {status} after {duration:.2f}s")
 
-task = PipelineWorker(pipeline, observers=[turn_observer])
+worker = PipelineWorker(pipeline, observers=[turn_observer])
 ```

--- a/pipecat/fundamentals/service-settings.mdx
+++ b/pipecat/fundamentals/service-settings.mdx
@@ -57,17 +57,17 @@ Each service type has a base set of settings. Individual services may extend the
 
 ### LLM settings
 
-| Setting              | Type    | Description                                                        |
-| -------------------- | ------- | ------------------------------------------------------------------ |
-| `model`              | `str`   | Model identifier (e.g. `"gpt-4o"`, `"claude-sonnet-4-5-20250929"`) |
+| Setting              | Type    | Description                                                                                                                                                                                                                    |
+| -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `model`              | `str`   | Model identifier (e.g. `"gpt-4o"`, `"claude-sonnet-4-5-20250929"`)                                                                                                                                                             |
 | `system_instruction` | `str`   | System prompt for the model. See [Context Management](/pipecat/learn/context-management#system-instruction-developer-messages-and-system-messages) for how this interacts with developer messages and context system messages. |
-| `temperature`        | `float` | Sampling temperature                                               |
-| `max_tokens`         | `int`   | Maximum tokens to generate                                         |
-| `top_p`              | `float` | Nucleus sampling probability                                       |
-| `top_k`              | `int`   | Top-k sampling parameter                                           |
-| `frequency_penalty`  | `float` | Frequency penalty                                                  |
-| `presence_penalty`   | `float` | Presence penalty                                                   |
-| `seed`               | `int`   | Random seed for reproducibility                                    |
+| `temperature`        | `float` | Sampling temperature                                                                                                                                                                                                           |
+| `max_tokens`         | `int`   | Maximum tokens to generate                                                                                                                                                                                                     |
+| `top_p`              | `float` | Nucleus sampling probability                                                                                                                                                                                                   |
+| `top_k`              | `int`   | Top-k sampling parameter                                                                                                                                                                                                       |
+| `frequency_penalty`  | `float` | Frequency penalty                                                                                                                                                                                                              |
+| `presence_penalty`   | `float` | Presence penalty                                                                                                                                                                                                               |
+| `seed`               | `int`   | Random seed for reproducibility                                                                                                                                                                                                |
 
 ### TTS settings
 
@@ -88,8 +88,8 @@ Each service type has a base set of settings. Individual services may extend the
   Individual services extend these base settings with provider-specific fields.
   For example, Deepgram STT adds `endpointing`, `smart_format`, `diarize`, and
   more. See the individual [service
-  documentation](/api-reference/server/services/supported-services) for the full list of
-  available settings.
+  documentation](/api-reference/server/services/supported-services) for the full
+  list of available settings.
 </Note>
 
 ## Updating settings at runtime
@@ -110,7 +110,7 @@ Only include the fields you want to change. Unspecified fields are left as-is.
 from pipecat.frames.frames import TTSUpdateSettingsFrame
 
 # Change TTS voice mid-conversation
-await task.queue_frame(
+await worker.queue_frame(
     TTSUpdateSettingsFrame(
         delta=CartesiaTTSService.Settings(voice="new-voice-id")
     )
@@ -121,7 +121,7 @@ await task.queue_frame(
 from pipecat.frames.frames import LLMUpdateSettingsFrame
 
 # Lower the temperature for more deterministic responses
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=OpenAILLMService.Settings(temperature=0.2)
     )
@@ -133,7 +133,7 @@ from pipecat.frames.frames import STTUpdateSettingsFrame
 from pipecat.transcriptions.language import Language
 
 # Switch STT language to Spanish
-await task.queue_frame(
+await worker.queue_frame(
     STTUpdateSettingsFrame(
         delta=DeepgramSTTService.Settings(language=Language.ES)
     )
@@ -187,7 +187,7 @@ llm = OpenAILLMService(
 Values in `extra` are passed through to the underlying API call. You can also update `extra` at runtime:
 
 ```python
-await task.queue_frame(
+await worker.queue_frame(
     LLMUpdateSettingsFrame(
         delta=OpenAILLMService.Settings(
             extra={"logprobs": False},

--- a/pipecat/fundamentals/voicemail.mdx
+++ b/pipecat/fundamentals/voicemail.mdx
@@ -81,7 +81,7 @@ async def handle_voicemail(processor):
     )
 
     # Optionally end the call after leaving the message
-    await processor.push_frame(EndTaskFrame(), FrameDirection.UPSTREAM)
+    await processor.push_frame(EndWorkerFrame(), FrameDirection.UPSTREAM)
 ```
 
 ## Detecting a Conversation

--- a/pipecat/get-started/quickstart.mdx
+++ b/pipecat/get-started/quickstart.mdx
@@ -281,7 +281,7 @@ The pipeline is managed by a PipelineWorker:
 
 ```python
 # Create a PipelineWorker to manage the pipeline execution
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         enable_metrics=True,
@@ -290,7 +290,7 @@ task = PipelineWorker(
 )
 ```
 
-The task handles pipeline execution, collects metrics, and manages RTVI events through [observers](/api-reference/server/utilities/observers/observer-pattern).
+The worker handles pipeline execution, collects metrics, and manages RTVI events through [observers](/api-reference/server/utilities/observers/observer-pattern).
 
 ### Event Handlers
 
@@ -304,30 +304,30 @@ async def on_client_connected(transport, client):
     # Add a greeting message to the context
     context.add_message("developer", "Say hello and briefly introduce yourself.")
     # Prompt the bot to start talking when the client connects
-    await task.queue_frames([LLMRunFrame()])
+    await worker.queue_frames([LLMRunFrame()])
 
 # Event handler for when a client disconnects
 @transport.event_handler("on_client_disconnected")
 async def on_client_disconnected(transport, client):
     logger.info(f"Client disconnected")
-    # Cancel the task when the client disconnects
+    # Cancel the worker when the client disconnects
     # This stops the pipeline and all processors, cleaning up resources
-    await task.cancel()
+    await worker.cancel()
 ```
 
-When a client connects, the bot adds a greeting instruction and queues a context frame to initiate the conversation. When disconnecting, it properly cancels the task to clean up resources.
+When a client connects, the bot adds a greeting instruction and queues a context frame to initiate the conversation. When disconnecting, it properly cancels the worker to clean up resources.
 
 ### Running the Pipeline
 
 Finally, the pipeline is executed by a WorkerRunner:
 
 ```python
-# Create a WorkerRunner to run the task
+# Create a WorkerRunner to run the worker
 runner = WorkerRunner(handle_sigint=False)
 
-# Finally, run the task using the runner
+# Finally, run the worker using the runner
 # This will start the pipeline and begin processing frames
-await runner.run(task)
+await runner.run(worker)
 ```
 
 The runner manages the pipeline's execution lifecycle. Note that `handle_sigint=False` because the main runner handles system signals.

--- a/pipecat/learn/context-management.mdx
+++ b/pipecat/learn/context-management.mdx
@@ -230,7 +230,7 @@ You can programmatically add new messages to the context by pushing or queueing 
 ```python
 # Add a new user message to context and trigger a response
 new_message = {"role": "user", "content": "Tell me about your capabilities."}
-await task.queue_frames([
+await worker.queue_frames([
     LLMMessagesAppendFrame([new_message], run_llm=True), # Optionally trigger bot response, too
 ])
 ```
@@ -279,13 +279,13 @@ You may want to manually trigger the bot to speak in two scenarios:
 @transport.event_handler("on_client_connected")
 async def on_client_connected(transport, client):
     # Trigger a response
-    await task.queue_frames([LLMRunFrame()])
+    await worker.queue_frames([LLMRunFrame()])
 ```
 
 ```python
 # Example: Bot speaks after context is edited
 new_message = {"role": "user", "content": "Tell me a fun fact."}
-await task.queue_frames([
+await worker.queue_frames([
     LLMMessagesAppendFrame([new_message], run_llm=True), # Trigger bot response
 ])
 ```

--- a/pipecat/learn/pipeline-termination.mdx
+++ b/pipecat/learn/pipeline-termination.mdx
@@ -51,7 +51,7 @@ Push an `EndFrame` from outside your pipeline:
 # From outside the pipeline
 from pipecat.frames.frames import EndFrame, TTSSpeakFrame
 
-await task.queue_frame(EndFrame())
+await worker.queue_frame(EndFrame())
 ```
 
 Push an `EndWorkerFrame` downstream from inside your pipeline:
@@ -64,7 +64,7 @@ from pipecat.processors.frame_processor import FrameDirection
 async def end_conversation(params: FunctionCallParams):
     await params.llm.push_frame(TTSSpeakFrame("Have a nice day!"))
 
-    # Signal that the task should end after processing this frame
+    # Signal that the worker should end after processing this frame
     await params.llm.push_frame(EndWorkerFrame(), FrameDirection.DOWNSTREAM)
 ```
 
@@ -98,13 +98,13 @@ Use event handlers to detect disconnections and trigger cancellation:
 @transport.event_handler("on_client_disconnected")
 async def on_client_disconnected(transport, client):
     logger.info("Client disconnected - terminating pipeline")
-    await task.cancel()
+    await worker.cancel()
 ```
 
 **How immediate termination works:**
 
 1. An event triggers the cancellation (like client disconnection)
-2. `task.cancel()` pushes a `CancelFrame` downstream from the PipelineWorker
+2. `worker.cancel()` pushes a `CancelFrame` downstream from the PipelineWorker
 3. `CancelFrame`s are `SystemFrame`s, so they use the high-priority input queue and are processed before queued non-system frames
 4. Processors handle the `CancelFrame` and shut down without waiting for pending non-system work to drain
 5. Any pending frames are discarded during shutdown
@@ -129,7 +129,7 @@ Pipecat includes automatic idle detection to prevent hanging pipelines. This fea
 **Configuration:**
 
 ```python
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     # Configure idle detection timeout
     cancel_on_idle_timeout=True, # Default is True
@@ -163,16 +163,16 @@ Connect termination to transport events for automatic cleanup:
 @transport.event_handler("on_client_connected")
 async def on_client_connected(transport, client):
     logger.info("Client connected - starting conversation")
-    await task.queue_frames([LLMRunFrame()])
+    await worker.queue_frames([LLMRunFrame()])
 
 @transport.event_handler("on_client_disconnected")
 async def on_client_disconnected(transport, client):
     logger.info("Client disconnected - immediate termination")
-    await task.cancel()
+    await worker.cancel()
 
 # Run the pipeline
 runner = WorkerRunner(handle_sigint=False)
-await runner.run(task)
+await runner.run(worker)
 ```
 
 ### Conditional Termination
@@ -198,11 +198,11 @@ Ensure pipelines can terminate properly even when exceptions occur:
 ```python
 try:
     runner = WorkerRunner(handle_sigint=False)
-    await runner.run(task)
+    await runner.run(worker)
 except Exception as e:
     logger.error(f"Pipeline error: {e}")
     # Ensure cleanup happens even on errors
-    await task.cancel()
+    await worker.cancel()
 ```
 
 ## Troubleshooting

--- a/pipecat/learn/pipeline-termination.mdx
+++ b/pipecat/learn/pipeline-termination.mdx
@@ -54,18 +54,18 @@ from pipecat.frames.frames import EndFrame, TTSSpeakFrame
 await task.queue_frame(EndFrame())
 ```
 
-Push an `EndTaskFrame` downstream from inside your pipeline:
+Push an `EndWorkerFrame` downstream from inside your pipeline:
 
 ```python
 # From inside a function call
-from pipecat.frames.frames import EndTaskFrame, TTSSpeakFrame
+from pipecat.frames.frames import EndWorkerFrame, TTSSpeakFrame
 from pipecat.processors.frame_processor import FrameDirection
 
 async def end_conversation(params: FunctionCallParams):
     await params.llm.push_frame(TTSSpeakFrame("Have a nice day!"))
 
     # Signal that the task should end after processing this frame
-    await params.llm.push_frame(EndTaskFrame(), FrameDirection.DOWNSTREAM)
+    await params.llm.push_frame(EndWorkerFrame(), FrameDirection.DOWNSTREAM)
 ```
 
 **How graceful termination works:**
@@ -186,7 +186,7 @@ async def check_conversation_complete(params: FunctionCallParams):
 
     if conversation_complete:
         await params.llm.push_frame(TTSSpeakFrame("Thank you for using our service!"))
-        await params.llm.push_frame(EndTaskFrame(), FrameDirection.DOWNSTREAM)
+        await params.llm.push_frame(EndWorkerFrame(), FrameDirection.DOWNSTREAM)
 
     await params.result_callback({"status": "complete" if conversation_complete else "continuing"})
 ```
@@ -232,16 +232,16 @@ async def process_frame(self, frame: Frame, direction: FrameDirection):
 **Solution:** Use the appropriate frame type and direction:
 
 ```python
-await self.push_frame(EndTaskFrame(), FrameDirection.DOWNSTREAM)
-await self.push_frame(CancelTaskFrame(), FrameDirection.DOWNSTREAM)
+await self.push_frame(EndWorkerFrame(), FrameDirection.DOWNSTREAM)
+await self.push_frame(CancelWorkerFrame(), FrameDirection.DOWNSTREAM)
 
 # The pipeline source will then convert these to proper termination frames
 # and push them downstream through the entire pipeline
 ```
 
 <Note>
-  The pipeline source automatically converts `EndTaskFrame` to `EndFrame` and
-  `CancelTaskFrame` to `CancelFrame` when pushing downstream, ensuring proper
+  The pipeline source automatically converts `EndWorkerFrame` to `EndFrame` and
+  `CancelWorkerFrame` to `CancelFrame` when pushing downstream, ensuring proper
   termination handling throughout the pipeline.
 </Note>
 

--- a/pipecat/learn/pipeline.mdx
+++ b/pipecat/learn/pipeline.mdx
@@ -109,7 +109,7 @@ LLMFullResponseStartFrame  # LLM response boundaries
 from pipecat.frames.frames import EndFrame, TTSSpeakFrame
 
 # These will execute in order: speak first, then end pipeline
-await task.queue_frames([
+await worker.queue_frames([
     TTSSpeakFrame("Goodbye!"),
     EndFrame()
 ])

--- a/pipecat/learn/session-initialization.mdx
+++ b/pipecat/learn/session-initialization.mdx
@@ -147,7 +147,7 @@ async def on_client_connected(transport, client):
         "role": "developer",
         "content": "Say hello and introduce yourself."
     })
-    await task.queue_frames([LLMRunFrame()])
+    await worker.queue_frames([LLMRunFrame()])
 ```
 
 ### Handshake Required (Client/Server Room-based WebRTC)
@@ -159,7 +159,7 @@ For client/server applications using room-based WebRTC, a handshake ensures both
 async def on_client_ready(rtvi):
     await rtvi.set_bot_ready()  # Confirm readiness to client
     # Start the conversation
-    await task.queue_frames([LLMRunFrame()])
+    await worker.queue_frames([LLMRunFrame()])
 ```
 
 <Note>

--- a/pipecat/learn/speech-input.mdx
+++ b/pipecat/learn/speech-input.mdx
@@ -190,7 +190,7 @@ user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
     user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer()),
 )
 
-task = PipelineWorker(pipeline)
+worker = PipelineWorker(pipeline)
 ```
 
 The defaults use `TurnAnalyzerUserTurnStopStrategy` with `LocalSmartTurnAnalyzerV3` for turn detection and `SileroVADAnalyzer` with `stop_secs=0.2` for voice activity detection.

--- a/pipecat/learn/speech-to-text.mdx
+++ b/pipecat/learn/speech-to-text.mdx
@@ -67,7 +67,11 @@ Pipecat supports a wide range of STT providers to fit different needs and budget
 Popular options include:
 
 <CardGroup cols={3}>
-  <Card title="Deepgram" icon="microphone" href="/api-reference/server/services/stt/deepgram">
+  <Card
+    title="Deepgram"
+    icon="microphone"
+    href="/api-reference/server/services/stt/deepgram"
+  >
     Fast, accurate streaming STT with excellent real-time performance
   </Card>
   <Card
@@ -77,13 +81,25 @@ Popular options include:
   >
     Advanced speech recognition with strong accent and dialect handling
   </Card>
-  <Card title="AssemblyAI" icon="brain" href="/api-reference/server/services/stt/assemblyai">
+  <Card
+    title="AssemblyAI"
+    icon="brain"
+    href="/api-reference/server/services/stt/assemblyai"
+  >
     AI-powered transcription with speaker diarization and sentiment analysis
   </Card>
-  <Card title="Gladia" icon="sparkles" href="/api-reference/server/services/stt/gladia">
+  <Card
+    title="Gladia"
+    icon="sparkles"
+    href="/api-reference/server/services/stt/gladia"
+  >
     High-performance STT with multilingual support and custom models
   </Card>
-  <Card title="Azure Speech" icon="microsoft" href="/api-reference/server/services/stt/azure">
+  <Card
+    title="Azure Speech"
+    icon="microsoft"
+    href="/api-reference/server/services/stt/azure"
+  >
     Microsoft's enterprise-grade STT service with extensive language support
   </Card>
   <Card
@@ -160,7 +176,7 @@ stt = YourSTTService(
 Instead of setting sample rates on individual services, configure them pipeline-wide:
 
 ```python
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         audio_in_sample_rate=16000,   # All input processors use this rate

--- a/pipecat/learn/text-to-speech.mdx
+++ b/pipecat/learn/text-to-speech.mdx
@@ -122,7 +122,7 @@ tts = CartesiaTTSService(
 Set consistent audio settings across your entire pipeline:
 
 ```python
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         audio_in_sample_rate=16000,   # Input audio quality
@@ -268,12 +268,12 @@ Use `LLMConfigureOutputFrame` to tell the LLM service to mark **all** subsequent
 from pipecat.frames.frames import LLMConfigureOutputFrame
 
 # Tell the LLM to skip TTS for all output
-await task.queue_frame(LLMConfigureOutputFrame(skip_tts=True))
+await worker.queue_frame(LLMConfigureOutputFrame(skip_tts=True))
 
 # ... LLM responses will not be spoken ...
 
 # Re-enable TTS
-await task.queue_frame(LLMConfigureOutputFrame(skip_tts=False))
+await worker.queue_frame(LLMConfigureOutputFrame(skip_tts=False))
 ```
 
 This is useful when you want to toggle TTS on or off for an entire stretch of conversation, such as switching between voice and text input modes.
@@ -339,7 +339,7 @@ from pipecat.frames.frames import TTSUpdateSettingsFrame
 from pipecat.services.cartesia.tts import CartesiaTTSSettings
 
 # Change voice speed during conversation
-await task.queue_frames([
+await worker.queue_frames([
     TTSUpdateSettingsFrame(delta=CartesiaTTSSettings(speed="fast")),
     TTSSpeakFrame("I'm speaking faster now!")
 ])

--- a/pipecat/migration/migration-1.0.mdx
+++ b/pipecat/migration/migration-1.0.mdx
@@ -296,7 +296,7 @@ Several frame classes were renamed or removed. Update any direct references in y
 | `InputTransportMessageUrgentFrame`   | `InputTransportMessageFrame`                                    |
 | `KeypadEntryFrame`                   | `DTMFFrame`                                                     |
 | `StartInterruptionFrame`             | `InterruptionFrame`                                             |
-| `BotInterruptionFrame`               | `InterruptionTaskFrame`                                         |
+| `BotInterruptionFrame`               | `InterruptionWorkerFrame`                                         |
 | `TranscriptionMessage`               | Use events: `on_user_turn_stopped`, `on_assistant_turn_stopped` |
 | `TranscriptionUpdateFrame`           | Use events: `on_user_turn_stopped`, `on_assistant_turn_stopped` |
 | `DailyTransportMessageFrame`         | `DailyOutputTransportMessageFrame`                              |

--- a/pipecat/telephony/daily-pstn.mdx
+++ b/pipecat/telephony/daily-pstn.mdx
@@ -361,7 +361,7 @@ Your bot should handle transfer-related events to manage the call flow:
 async def on_dialout_answered(transport, data):
     logger.info(f"Transfer successful: {data}")
     # Cold transfer: bot leaves, caller and operator continue
-    await task.queue_frames([EndFrame()])
+    await worker.queue_frames([EndFrame()])
 ```
 
 <Card

--- a/pipecat/telephony/daily-sip.mdx
+++ b/pipecat/telephony/daily-sip.mdx
@@ -164,7 +164,7 @@ async def run_bot(room_url: str, token: str, target_number: str, sip_uri: str):
     @transport.event_handler("on_dialout_stopped")
     async def on_dialout_stopped(transport, data):
         logger.info(f"Dial-out stopped: {data}")
-        await task.cancel()
+        await worker.cancel()
 
     @transport.event_handler("on_dialout_warning")
     async def on_dialout_warning(transport, data):
@@ -198,7 +198,7 @@ Internally, Pipecat also pushes each inbound digit as an `InputDTMFFrame` into t
 
 ### Sending DTMF
 
-To send DTMF tones back to the caller, send them through Daily's native DTMF channel. Use the session id from the inbound event (or the dial-out session id captured in `on_dialout_connected`) as the target. The default `method`to send the DTMF tones is `auto`, determined in the SIP offer/answer negotiation. However, if you already know what the remote party supports, then pick the appropriate option: `telephone-events` which are in-band RTP packets (RFC2833/4733) or as a `sip-info` message. 
+To send DTMF tones back to the caller, send them through Daily's native DTMF channel. Use the session id from the inbound event (or the dial-out session id captured in `on_dialout_connected`) as the target. The default `method`to send the DTMF tones is `auto`, determined in the SIP offer/answer negotiation. However, if you already know what the remote party supports, then pick the appropriate option: `telephone-events` which are in-band RTP packets (RFC2833/4733) or as a `sip-info` message.
 
 ```python bot.py
 @transport.event_handler(“on_dialout_answered”)

--- a/pipecat/telephony/exotel-websockets.mdx
+++ b/pipecat/telephony/exotel-websockets.mdx
@@ -286,7 +286,7 @@ To test dial-out functionality:
 Exotel Voice Streaming uses 8kHz mono audio with 16-bit PCM encoding. Configure your pipeline accordingly:
 
 ```python
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         audio_in_sample_rate=8000,

--- a/pipecat/telephony/plivo-websockets.mdx
+++ b/pipecat/telephony/plivo-websockets.mdx
@@ -338,7 +338,7 @@ To test dial-out functionality:
 Plivo Media Streaming uses 8kHz mono audio with μ-law encoding. Configure your pipeline accordingly:
 
 ```python
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         audio_in_sample_rate=8000,

--- a/pipecat/telephony/telnyx-websockets.mdx
+++ b/pipecat/telephony/telnyx-websockets.mdx
@@ -312,7 +312,7 @@ To test dial-out functionality:
 Telnyx Media Streaming uses 8kHz mono audio with 16-bit PCM encoding. Configure your pipeline accordingly:
 
 ```python
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         audio_in_sample_rate=8000,

--- a/pipecat/telephony/twilio-websockets.mdx
+++ b/pipecat/telephony/twilio-websockets.mdx
@@ -279,7 +279,7 @@ To test dial-out functionality:
 Twilio Media Streams uses 8kHz mono audio with 16-bit PCM encoding. To avoid resampling, set the audio input and output sample rate to 8000 Hz:
 
 ```python
-task = PipelineWorker(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(
         audio_in_sample_rate=8000,


### PR DESCRIPTION
## Summary

Aligns the docs with the framework's `Task*` → `Worker*` rename. The old `Task*` names are now deprecated aliases in Pipecat, so the reference and guides should use the new `Worker*` names.

## Changes

- **Frame classes renamed** `*TaskFrame` → `*WorkerFrame`:
  - `TaskFrame` → `WorkerFrame`, `EndTaskFrame` → `EndWorkerFrame`, `StopTaskFrame` → `StopWorkerFrame`, `CancelTaskFrame` → `CancelWorkerFrame`, `InterruptionTaskFrame` → `InterruptionWorkerFrame`
  - Base class `TaskSystemFrame` → `WorkerSystemFrame`
- **Section headings/prose** "Task Frames" → "Pipeline Worker Frames" (workers can exist without a pipeline, so this reads more accurately).
- **"pipeline task" → "pipeline worker"** across prose, code comments, and event-handler tables (matching the `PipelineTask` → `PipelineWorker` rename).
- **Example variable** `pipeline_task` → `pipeline_worker` in the Session API guide.

## Intentionally left unchanged

- `migration/migration-1.0.mdx` before/after examples and rename tables, which document the deprecated `PipelineTask`/`*TaskFrame` names.
- Deprecation notices that explicitly explain `PipelineTask` is a deprecated alias of `PipelineWorker`.

## Verification

`mint broken-links` passes with no broken links.
