### PR TITLE
docs: update for pipecat PR #4775

### DIFF
--- a/api-reference/server/services/transport/daily.mdx
+++ b/api-reference/server/services/transport/daily.mdx
@@ -64,7 +64,7 @@ Before using DailyTransport, you need:
 
 - **Hosted WebRTC**: No infrastructure setup required - Daily handles all WebRTC complexity
 - **Multi-participant Support**: Handle multiple participants with individual audio/video tracks
-- **Multi-track Audio/Video**: Publish multiple custom audio and video tracks simultaneously with per-track configuration, including built-in support for Daily's `screenVideo` destination
+- **Multi-track Audio/Video**: Publish multiple custom audio and video tracks simultaneously with per-track configuration, including built-in support for Daily's `screenAudio` and `screenVideo` destinations
 - **Built-in Transcription**: Real-time speech-to-text with Deepgram integration
 - **Telephony Integration**: [Dial-in/dial-out support for phone numbers via [SIP](/pipecat/telephony/twilio-daily-sip)/[PSTN](/pipecat/telephony/daily-pstn)
 - **Recording & Streaming**: Built-in call recording and live streaming capabilities
@@ -277,6 +277,41 @@ See the [complete example](https://github.com/pipecat-ai/pipecat/blob/main/examp
 - Advanced features like recording and dial-out
 
 ## Notes
+
+### Screen Audio Destination
+
+DailyTransport includes built-in support for Daily's `screenAudio` destination. When `"screenAudio"` is included in the `audio_out_destinations` parameter, a dedicated screen audio track is automatically created at join time:
+
+```python
+params = DailyParams(
+    audio_out_enabled=True,
+    audio_out_destinations=["screenAudio"]
+)
+
+# Route frames to the screen audio track
+frame = OutputAudioRawFrame(...)
+frame.transport_destination = "screenAudio"
+```
+
+Optionally configure the `screenAudio` track with custom parameters:
+
+```python
+params = DailyParams(
+    audio_out_enabled=True,
+    audio_out_destinations=["screenAudio"],
+    custom_audio_track_params={
+        "screenAudio": DailyCustomAudioTrackParams(
+            sample_rate=48000,
+            channels=2,
+            send_settings={"maxBitrate": 128000}
+        )
+    }
+)
+```
+
+<Note>
+  Requires `daily-python>=0.29.0`.
+</Note>
 
 ### Screen Video Destination
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4775](https://github.com/pipecat-ai/pipecat/pull/4775).

## Changes

### Updated API reference pages

- **api-reference/server/services/transport/daily.mdx**
  - Updated Key Features to mention `screenAudio` alongside `screenVideo` for multi-track audio/video support
  - Added new "Screen Audio Destination" section documenting how to use the `screenAudio` output track
  - Included usage examples showing basic configuration and custom track parameters
  - Documented requirement for `daily-python>=0.29.0`

## Gaps identified

None. The `audio_out_destinations` parameter is already documented in the inherited TransportParams, and all relevant Daily transport functionality has been covered.