### PR TITLE
docs: update for pipecat PR #4712

### DIFF
--- a/api-reference/server/services/stt/assemblyai.mdx
+++ b/api-reference/server/services/stt/assemblyai.mdx
@@ -162,33 +162,39 @@ Connection-level parameters previously passed via the `connection_params` constr
 | `min_end_of_turn_silence_when_confident` | `int`       | `None`        | **DEPRECATED**. Use `min_turn_silence` instead. Will be removed in a future version.                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `max_turn_silence`                       | `int`       | `None`        | Maximum silence duration (ms) before forcing end-of-turn.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `keyterms_prompt`                        | `List[str]` | `None`        | List of key terms to guide transcription. Will be JSON serialized before sending.                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `prompt`                                 | `str`       | `None`        | **BETA**: Optional text prompt to guide transcription. Only used when `speech_model` is `"u3-rt-pro"`. Cannot be used with `keyterms_prompt`. We suggest starting with no prompt. See [AssemblyAI prompting best practices](https://www.assemblyai.com/docs/streaming/universal-3-pro/prompting) for guidance.                                                                                                                                                                            |
-| `speech_model`                           | `Literal`   | `"u3-rt-pro"` | **Required**. Speech model to use. Options: `"universal-streaming-english"`, `"universal-streaming-multilingual"`, `"u3-rt-pro"`. Defaults to `"u3-rt-pro"` if not specified.                                                                                                                                                                                                                                                                                                             |
+| `prompt`                                 | `str`       | `None`        | **BETA**: Optional text prompt to guide transcription. Only used with U3 Pro models. Cannot be used with `keyterms_prompt`. We suggest starting with no prompt. See [AssemblyAI prompting best practices](https://www.assemblyai.com/docs/streaming/universal-3-pro/prompting) for guidance.                                                                                                                                                                                               |
+| `speech_model`                           | `Literal`   | `"u3-rt-pro"` | **Required**. Speech model to use. Options: `"universal-streaming-english"`, `"universal-streaming-multilingual"`, `"u3-rt-pro"`, `"u3-rt-pro-beta-1"`, `"universal-3-5-pro"`. Defaults to `"u3-rt-pro"` if not specified. The U3 Pro family (`u3-rt-pro`, `u3-rt-pro-beta-1`, `universal-3-5-pro`) supports built-in turn detection, prompting, continuous partials, context carryover, and voice focus.                                                                                 |
 | `language_detection`                     | `bool`      | `None`        | Enable automatic language detection. Only applicable to `universal-streaming-multilingual`. Turn messages include language information.                                                                                                                                                                                                                                                                                                                                                   |
 | `format_turns`                           | `bool`      | `True`        | Whether to format transcript turns. Only applicable to `universal-streaming-english` and `universal-streaming-multilingual` models. For `u3-rt-pro`, formatting is automatic and built-in.                                                                                                                                                                                                                                                                                                |
 | `speaker_labels`                         | `bool`      | `None`        | Enable speaker diarization. Final transcripts include a speaker field (e.g., "Speaker A", "Speaker B").                                                                                                                                                                                                                                                                                                                                                                                   |
-| `vad_threshold`                          | `float`     | `None`        | Voice activity detection confidence threshold. Only applicable to `u3-rt-pro`. The confidence threshold (0.0 to 1.0) for classifying audio frames as silence. Frames with VAD confidence below this value are considered silent. Increase for noisy environments to reduce false speech detection. Defaults to 0.3 (API default). For best performance when using with external VAD (e.g., Silero), align this value with your VAD's activation threshold. Defaults to `None` (not sent). |
+| `vad_threshold`                          | `float`     | `None`        | Voice activity detection confidence threshold. Only applicable to U3 Pro models. The confidence threshold (0.0 to 1.0) for classifying audio frames as silence. Frames with VAD confidence below this value are considered silent. Increase for noisy environments to reduce false speech detection. Defaults to 0.3 (API default). For best performance when using with external VAD (e.g., Silero), align this value with your VAD's activation threshold. Defaults to `None` (not sent). |
 
 ### Settings
 
 Runtime-configurable settings passed via the `settings` constructor argument using `AssemblyAISTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter                          | Type              | Default       | Description                                                                                |
-| ---------------------------------- | ----------------- | ------------- | ------------------------------------------------------------------------------------------ |
-| `model`                            | `str`             | `None`        | STT model identifier. _(Inherited from base STT settings.)_                                |
-| `language`                         | `Language \| str` | `Language.EN` | Language for speech recognition. _(Inherited from base STT settings.)_                     |
-| `formatted_finals`                 | `bool`            | `True`        | Whether to enable transcript formatting.                                                   |
-| `word_finalization_max_wait_time`  | `int`             | `None`        | Maximum time to wait for word finalization in milliseconds.                                |
-| `end_of_turn_confidence_threshold` | `float`           | `None`        | Confidence threshold for end-of-turn detection.                                            |
-| `min_turn_silence`                 | `int`             | `None`        | Minimum silence duration (ms) when confident about end-of-turn.                            |
-| `max_turn_silence`                 | `int`             | `None`        | Maximum silence duration (ms) before forcing end-of-turn.                                  |
-| `keyterms_prompt`                  | `List[str]`       | `None`        | List of key terms to guide transcription.                                                  |
-| `prompt`                           | `str`             | `None`        | Optional text prompt to guide transcription (u3-rt-pro only).                              |
-| `language_detection`               | `bool`            | `None`        | Enable automatic language detection.                                                       |
-| `format_turns`                     | `bool`            | `True`        | Whether to format transcript turns.                                                        |
-| `speaker_labels`                   | `bool`            | `None`        | Enable speaker diarization.                                                                |
-| `vad_threshold`                    | `float`           | `None`        | VAD confidence threshold (0.0–1.0) for classifying audio frames as silence.                |
-| `domain`                           | `str`             | `None`        | Optional domain for specialized recognition modes (e.g., `"medical-v1"` for Medical Mode). |
+| Parameter                          | Type                                   | Default       | Description                                                                                                                                                                              |
+| ---------------------------------- | -------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model`                            | `str`                                  | `None`        | STT model identifier. _(Inherited from base STT settings.)_                                                                                                                              |
+| `language`                         | `Language \| str`                      | `Language.EN` | Language for speech recognition. _(Inherited from base STT settings.)_                                                                                                                   |
+| `formatted_finals`                 | `bool`                                 | `True`        | Whether to enable transcript formatting.                                                                                                                                                 |
+| `word_finalization_max_wait_time`  | `int`                                  | `None`        | Maximum time to wait for word finalization in milliseconds.                                                                                                                              |
+| `end_of_turn_confidence_threshold` | `float`                                | `None`        | Confidence threshold for end-of-turn detection.                                                                                                                                          |
+| `min_turn_silence`                 | `int`                                  | `None`        | Minimum silence duration (ms) when confident about end-of-turn.                                                                                                                          |
+| `max_turn_silence`                 | `int`                                  | `None`        | Maximum silence duration (ms) before forcing end-of-turn.                                                                                                                                |
+| `keyterms_prompt`                  | `List[str]`                            | `None`        | List of key terms to guide transcription.                                                                                                                                                |
+| `prompt`                           | `str`                                  | `None`        | Optional text prompt to guide transcription (U3 Pro only).                                                                                                                               |
+| `language_detection`               | `bool`                                 | `None`        | Enable automatic language detection.                                                                                                                                                     |
+| `format_turns`                     | `bool`                                 | `True`        | Whether to format transcript turns.                                                                                                                                                      |
+| `speaker_labels`                   | `bool`                                 | `None`        | Enable speaker diarization.                                                                                                                                                              |
+| `vad_threshold`                    | `float`                                | `None`        | VAD confidence threshold (0.0–1.0) for classifying audio frames as silence (U3 Pro only).                                                                                                |
+| `domain`                           | `str`                                  | `None`        | Optional domain for specialized recognition modes (e.g., `"medical-v1"` for Medical Mode).                                                                                               |
+| `continuous_partials`              | `bool`                                 | `True`        | Emit partial transcripts continuously during long turns (U3 Pro only).                                                                                                                   |
+| `interruption_delay`               | `int`                                  | `None`        | Override for how soon the first partial is emitted, in milliseconds (0–1000). U3 Pro only.                                                                                              |
+| `agent_context`                    | `str`                                  | `None`        | Context carryover seed — the agent's most recent spoken reply. Improves transcription of the user's next turn (U3 Pro only). Clipped to ~1500 characters.                               |
+| `previous_context_n_turns`         | `int`                                  | `None`        | Maximum prior conversation entries (0–100) carried forward as context. Set to 0 to disable context carryover (U3 Pro only). Defaults to server default (3).                             |
+| `voice_focus`                      | `Literal["near-field", "far-field"]`   | `None`        | Isolate primary voice and suppress background noise. Set to `"near-field"` for close mics or `"far-field"` for distant capture (U3 Pro only).                                           |
+| `voice_focus_threshold`            | `float`                                | `None`        | How aggressively background audio is suppressed (0.0–1.0). Only takes effect when `voice_focus` is set (U3 Pro only).                                                                   |
 
 ## Usage
 
@@ -250,16 +256,91 @@ stt = AssemblyAISTTService(
 )
 ```
 
+### With Context Carryover
+
+Context carryover (U3 Pro only) improves transcription by giving the model memory of recent conversation turns:
+
+```python
+from pipecat.services.assemblyai.stt import AssemblyAISTTService
+
+stt = AssemblyAISTTService(
+    api_key=os.getenv("ASSEMBLYAI_API_KEY"),
+    settings=AssemblyAISTTService.Settings(
+        model="universal-3-5-pro",
+        agent_context="Welcome! May I take your order?",  # Seed with opening line
+        previous_context_n_turns=5,  # Keep last 5 turns (default: 3)
+    ),
+)
+
+# Update context mid-session when the agent speaks
+await stt.update_agent_context("Your order total is $42.50.")
+```
+
+Context carryover helps with short answers, spelled-out entities (emails, IDs), and similar-sounding words. Set `previous_context_n_turns=0` to disable automatic carryover.
+
+### With Voice Focus
+
+Voice focus (U3 Pro only) isolates the primary speaker and suppresses background noise:
+
+```python
+from pipecat.services.assemblyai.stt import AssemblyAISTTService
+
+stt = AssemblyAISTTService(
+    api_key=os.getenv("ASSEMBLYAI_API_KEY"),
+    settings=AssemblyAISTTService.Settings(
+        voice_focus="near-field",  # Or "far-field" for distant capture
+        voice_focus_threshold=0.5,  # 0.0-1.0, higher suppresses more
+    ),
+)
+```
+
+Use `"near-field"` for close-talking mics (headsets, handsets) or `"far-field"` for distant capture (conference rooms, laptop mics).
+
+## Methods
+
+### update_agent_context()
+
+```python
+async def update_agent_context(text: str)
+```
+
+Send the agent's latest spoken reply to AssemblyAI as carryover context (U3 Pro only). Improves transcription of the user's next turn — short answers, spelled-out entities, disambiguation. No-op for non-U3 Pro models.
+
+**Parameters:**
+
+- `text` (str): The agent's spoken reply text. Clipped to ~1500 characters.
+
+**Example:**
+
+```python
+# After the agent finishes speaking
+await stt.update_agent_context("Your order total is $42.50.")
+```
+
+### process_assistant_turn()
+
+```python
+async def process_assistant_turn(text: str) -> None
+```
+
+Feed the assistant's completed reply to AssemblyAI as carryover context. Called automatically when the assistant's turn ends. Delegates to `update_agent_context()`. No-op for non-U3 Pro models or when `previous_context_n_turns` is 0 (carryover explicitly disabled).
+
+**Parameters:**
+
+- `text` (str): The assistant's aggregated spoken text for this turn.
+
 ## Notes
 
-- **u3-rt-pro model**: The default model is now `u3-rt-pro`, which provides the best performance and supports built-in turn detection.
+- **U3 Pro models**: The default model is `u3-rt-pro`. The U3 Pro family includes `u3-rt-pro`, `u3-rt-pro-beta-1`, and `universal-3-5-pro`, all supporting built-in turn detection, prompting, continuous partials, context carryover, and voice focus.
 - **Turn detection modes**:
   - **Pipecat mode** (`vad_force_turn_endpoint=True`, default): Forces AssemblyAI to return finals ASAP so Pipecat's turn detection (e.g., Smart Turn) decides when the user is done. The service sends a `ForceEndpoint` message when VAD detects the user has stopped speaking.
-  - **AssemblyAI mode** (`vad_force_turn_endpoint=False`, u3-rt-pro only): AssemblyAI's model controls turn endings using built-in turn detection. The service emits `UserStartedSpeakingFrame` and `UserStoppedSpeakingFrame` based on AssemblyAI's detection.
+  - **AssemblyAI mode** (`vad_force_turn_endpoint=False`, U3 Pro only): AssemblyAI's model controls turn endings using built-in turn detection. The service emits `UserStartedSpeakingFrame` and `UserStoppedSpeakingFrame` based on AssemblyAI's detection.
+- **Context carryover** (U3 Pro only): Set `agent_context` to seed the agent's most recent reply, improving transcription of the user's next turn — short answers, spelled-out entities, disambiguation. Use `update_agent_context()` to update mid-session. Control the window size with `previous_context_n_turns` (0–100, default 3); set to 0 to disable carryover entirely.
+- **Voice focus** (U3 Pro only): Set `voice_focus` to `"near-field"` or `"far-field"` to isolate the primary voice and suppress background noise. Tune suppression strength with `voice_focus_threshold` (0.0–1.0, higher values suppress more).
 - **Speaker diarization**: Enable `speaker_labels=True` in Settings to automatically identify different speakers. Final transcripts will include a speaker field (e.g., "Speaker A", "Speaker B"). Use the `speaker_format` parameter to format transcripts with speaker labels.
 - **Language detection**: When using `universal-streaming-multilingual` with `language_detection=True`, Turn messages include `language_code` and `language_confidence` fields for automatic language detection.
-- **Prompting**: The `prompt` parameter (u3-rt-pro only) allows you to guide transcription for specific names, terms, or domain vocabulary. This is a beta feature - AssemblyAI recommends testing without a prompt first. Cannot be used with `keyterms_prompt`.
-- **Dynamic settings updates**: You can update `keyterms_prompt`, `prompt`, `min_turn_silence`, and `max_turn_silence` at runtime using `STTUpdateSettingsFrame` without reconnecting.
+- **Prompting**: The `prompt` parameter (U3 Pro only) allows you to guide transcription for specific names, terms, or domain vocabulary. This is a beta feature - AssemblyAI recommends testing without a prompt first. Cannot be used with `keyterms_prompt`.
+- **Dynamic settings updates**: Most settings can be updated at runtime using `STTUpdateSettingsFrame`. `agent_context` is hot-updatable without reconnecting; other settings require a reconnect.
 
 <Tip>
   The `connection_params=` / `InputParams` / `params=` pattern is deprecated as

--- a/api-reference/server/services/stt/assemblyai.mdx
+++ b/api-reference/server/services/stt/assemblyai.mdx
@@ -267,13 +267,9 @@ stt = AssemblyAISTTService(
     api_key=os.getenv("ASSEMBLYAI_API_KEY"),
     settings=AssemblyAISTTService.Settings(
         model="universal-3-5-pro",
-        agent_context="Welcome! May I take your order?",  # Seed with opening line
-        previous_context_n_turns=5,  # Keep last 5 turns (default: 3)
+        previous_context_n_turns=5,  # Keep last 5 turns (if None, server default is 3)
     ),
 )
-
-# Update context mid-session when the agent speaks
-await stt.update_agent_context("Your order total is $42.50.")
 ```
 
 Context carryover helps with short answers, spelled-out entities (emails, IDs), and similar-sounding words. Set `previous_context_n_turns=0` to disable automatic carryover.
@@ -317,17 +313,7 @@ Send the agent's latest spoken reply to AssemblyAI as carryover context (U3 Pro 
 await stt.update_agent_context("Your order total is $42.50.")
 ```
 
-### process_assistant_turn()
-
-```python
-async def process_assistant_turn(text: str) -> None
-```
-
-Feed the assistant's completed reply to AssemblyAI as carryover context. Called automatically when the assistant's turn ends. Delegates to `update_agent_context()`. No-op for non-U3 Pro models or when `previous_context_n_turns` is 0 (carryover explicitly disabled).
-
-**Parameters:**
-
-- `text` (str): The assistant's aggregated spoken text for this turn.
+> It is automatically invoked each time an assistant turn is completed.
 
 ## Notes
 
@@ -335,7 +321,7 @@ Feed the assistant's completed reply to AssemblyAI as carryover context. Called 
 - **Turn detection modes**:
   - **Pipecat mode** (`vad_force_turn_endpoint=True`, default): Forces AssemblyAI to return finals ASAP so Pipecat's turn detection (e.g., Smart Turn) decides when the user is done. The service sends a `ForceEndpoint` message when VAD detects the user has stopped speaking.
   - **AssemblyAI mode** (`vad_force_turn_endpoint=False`, U3 Pro only): AssemblyAI's model controls turn endings using built-in turn detection. The service emits `UserStartedSpeakingFrame` and `UserStoppedSpeakingFrame` based on AssemblyAI's detection.
-- **Context carryover** (U3 Pro only): Set `agent_context` to seed the agent's most recent reply, improving transcription of the user's next turn — short answers, spelled-out entities, disambiguation. Use `update_agent_context()` to update mid-session. Control the window size with `previous_context_n_turns` (0–100, default 3); set to 0 to disable carryover entirely.
+- **Context carryover** (U3 Pro only): Seed the agent's most recent reply, improving transcription of the user's next turn — short answers, spelled-out entities, disambiguation. `update_agent_context()` is automatically invoked each time an assistant turn is completed. Control the window size with `previous_context_n_turns` (0–100, default 3); set to 0 to disable carryover entirely.
 - **Voice focus** (U3 Pro only): Set `voice_focus` to `"near-field"` or `"far-field"` to isolate the primary voice and suppress background noise. Tune suppression strength with `voice_focus_threshold` (0.0–1.0, higher values suppress more).
 - **Speaker diarization**: Enable `speaker_labels=True` in Settings to automatically identify different speakers. Final transcripts will include a speaker field (e.g., "Speaker A", "Speaker B"). Use the `speaker_format` parameter to format transcripts with speaker labels.
 - **Language detection**: When using `universal-streaming-multilingual` with `language_detection=True`, Turn messages include `language_code` and `language_confidence` fields for automatic language detection.


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4712](https://github.com/pipecat-ai/pipecat/pull/4712).

## Changes
- **api-reference/server/services/stt/assemblyai.mdx** — Added new U3 Pro models (`universal-3-5-pro`, `u3-rt-pro-beta-1`), documented context carryover settings (`agent_context`, `previous_context_n_turns`), voice focus settings (`voice_focus`, `voice_focus_threshold`), added missing settings to table (`continuous_partials`, `interruption_delay`), documented new methods (`update_agent_context()`, `process_assistant_turn()`), added usage examples for context carryover and voice focus, updated notes to reflect U3 Pro family features.

## Gaps identified
None