### PR TITLE
docs: update for pipecat PR #4776

### DIFF
--- a/api-reference/server/services/tts/kokoro.mdx
+++ b/api-reference/server/services/tts/kokoro.mdx
@@ -5,7 +5,7 @@ description: "Local text-to-speech synthesis using Kokoro ONNX"
 
 ## Overview
 
-`KokoroTTSService` provides local, offline text-to-speech synthesis using the [kokoro-onnx](https://github.com/thewh1teagle/kokoro-onnx) engine. It runs entirely on the host machine with no external API calls or authentication required. Model files are automatically downloaded to `~/.cache/kokoro-onnx/` on first use.
+`KokoroTTSService` provides local, offline text-to-speech synthesis using the [kokoro-onnx](https://github.com/thewh1teagle/kokoro-onnx) engine. It runs entirely on the host machine with no external API calls or authentication required. Model files are automatically downloaded to `~/.cache/pipecat/kokoro-onnx/` on first use.
 
 <CardGroup cols={2}>
   <Card
@@ -52,7 +52,7 @@ This installs `kokoro-onnx>=0.5.0` and its dependencies.
 
 ### Local Setup
 
-Kokoro runs locally and does not require an API key or external service. On first use, the service automatically downloads two model files to `~/.cache/kokoro-onnx/`:
+Kokoro runs locally and does not require an API key or external service. On first use, the service automatically downloads two model files to `~/.cache/pipecat/kokoro-onnx/`:
 
 - `kokoro-v1.0.onnx` -- the ONNX speech synthesis model
 - `voices-v1.0.bin` -- the voice data file
@@ -70,12 +70,12 @@ You can also provide custom paths to pre-downloaded model files via the `model_p
 
 <ParamField path="model_path" type="str" default="None">
   Path to a custom ONNX model file. When `None`, the model is automatically
-  downloaded to `~/.cache/kokoro-onnx/kokoro-v1.0.onnx`.
+  downloaded to `~/.cache/pipecat/kokoro-onnx/kokoro-v1.0.onnx`.
 </ParamField>
 
 <ParamField path="voices_path" type="str" default="None">
   Path to a custom voices binary file. When `None`, the file is automatically
-  downloaded to `~/.cache/kokoro-onnx/voices-v1.0.bin`.
+  downloaded to `~/.cache/pipecat/kokoro-onnx/voices-v1.0.bin`.
 </ParamField>
 
 <ParamField path="voice_id" type="str" default="None" deprecated>
@@ -170,7 +170,7 @@ tts = KokoroTTSService(
 ## Notes
 
 - **Fully local**: Kokoro runs entirely on the host machine using ONNX Runtime. No API keys, network access, or external services are required after the initial model download.
-- **Automatic model caching**: Model files are downloaded once to `~/.cache/kokoro-onnx/` and reused on subsequent runs. You can also pre-download models and specify custom paths.
+- **Automatic model caching**: Model files are downloaded once to `~/.cache/pipecat/kokoro-onnx/` and reused on subsequent runs. You can also pre-download models and specify custom paths.
 - **Audio resampling**: Kokoro's native output is automatically resampled to match the pipeline's configured sample rate.
 - **Streaming output**: The service uses kokoro-onnx's async streaming API, delivering audio frames incrementally as they are generated.
 - **Metrics support**: The service supports TTFB (time to first byte) and usage metrics for performance monitoring.


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4776](https://github.com/pipecat-ai/pipecat/pull/4776).

## Changes

Updated **api-reference/server/services/tts/kokoro.mdx**:
- Updated cache directory path from `~/.cache/kokoro-onnx/` to `~/.cache/pipecat/kokoro-onnx/` in all five locations:
  - Overview section
  - Prerequisites section (model download location)
  - `model_path` parameter documentation
  - `voices_path` parameter documentation
  - Notes section (automatic model caching)

## Gaps identified

None