### PR TITLE
Mention uv run pipecat eval for project-installed CLI

### DIFF
--- a/api-reference/cli/eval.mdx
+++ b/api-reference/cli/eval.mdx
@@ -5,7 +5,7 @@ description: "Run behavioral evals against a Pipecat agent, individually or as a
 
 Run scenario-based behavioral evals. `pipecat eval run` tests scenarios against an already-running agent; `pipecat eval suite` spawns the agents listed in a manifest and runs their scenarios concurrently. Both exit `0` when everything passes and `1` otherwise.
 
-The same commands are also available as `python -m pipecat.evals`.
+If `pipecat-ai[cli]` is a dependency of your project, run these commands with `uv run pipecat eval`. They're also available as `python -m pipecat.evals`.
 
 See the [Pipecat Evals guide](/pipecat/evals/overview) for concepts, the scenario format, and manifests.
 

--- a/pipecat/evals/overview.mdx
+++ b/pipecat/evals/overview.mdx
@@ -69,7 +69,7 @@ Scenarios are YAML files, so they're easy to write, review, and share. Everythin
 
 ## Requirements
 
-- **Pipecat CLI**: the `pipecat eval` commands ship with the CLI extra: `uv tool install "pipecat-ai[cli]"`. The same commands are available as `python -m pipecat.evals`.
+- **Pipecat CLI**: the `pipecat eval` commands ship with the CLI extra: `uv tool install "pipecat-ai[cli]"`. If you've added `pipecat-ai[cli]` to your project instead, run them with `uv run pipecat eval` (just like `uv run bot.py`). The same commands are also available as `python -m pipecat.evals`.
 - **A judge LLM** (for `eval:` assertions): Ollama by default (`ollama pull gemma2:9b`), or point the scenario's `judge:` block at OpenAI or any OpenAI-compatible endpoint.
 - **Audio services** (audio mode only): the harness needs a TTS to synthesize the user's voice and an STT to transcribe the agent's speech. Both can be local models or HTTP-based services; the defaults are local (Kokoro and Moonshine or Whisper, installed with `uv add "pipecat-ai[kokoro,moonshine]"` or `uv add "pipecat-ai[kokoro,whisper]"`), which download once on first use and run with no keys and no per-run cost. WebSocket-streaming services aren't supported here, which keeps the harness simple.
 - **Your agent's own credentials**: the agent under test is your real agent, so it needs the same service API keys it normally would.

--- a/pipecat/evals/quickstart.mdx
+++ b/pipecat/evals/quickstart.mdx
@@ -9,7 +9,7 @@ This guide takes an existing agent, starts it with the eval transport, and runs 
 ## Prerequisites
 
 - A working Pipecat agent that uses `create_transport()` and the development runner (the standard pattern from the [quickstart](/pipecat/get-started/quickstart) and all Pipecat examples), with its usual service API keys in `.env`.
-- The Pipecat CLI: `uv tool install "pipecat-ai[cli]"`.
+- The Pipecat CLI: `uv tool install "pipecat-ai[cli]"` (or add `pipecat-ai[cli]` to your project and run the commands below with `uv run pipecat eval`).
 - A judge LLM. Either:
   - **Ollama** (local, the default): install [Ollama](https://ollama.com) and run `ollama pull gemma2:9b`, or
   - **OpenAI**: set `OPENAI_API_KEY` and point the scenario's `judge:` block at it (shown below).


### PR DESCRIPTION
## Summary

The evals docs install the CLI globally (`uv tool install "pipecat-ai[cli]"`) and invoke it as a bare `pipecat eval`, while agents are run with `uv run bot.py`. There was no mention of `uv run pipecat eval`, which is the natural invocation when `pipecat-ai[cli]` is a project dependency rather than a global tool.

## Changes

Added the `uv run pipecat eval` form to the three canonical invocation spots (without rewriting every example, since the global-tool path stays valid):

- `pipecat/evals/overview.mdx` (Requirements) — note that if `pipecat-ai[cli]` is in your project, run the commands with `uv run pipecat eval` (just like `uv run bot.py`).
- `api-reference/cli/eval.mdx` (intro) — same note alongside the existing `python -m pipecat.evals` alternative.
- `pipecat/evals/quickstart.mdx` (Prerequisites) — parenthetical pointing at the `uv run pipecat eval` alternative.

## Verification

`mint broken-links` passes with no broken links.
