### PR TITLE
Rename Agent Self-Improvement to The Eval Loop

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -102,7 +102,7 @@
               "pipecat/evals/scenarios",
               "pipecat/evals/suites",
               "pipecat/evals/library",
-              "pipecat/evals/agent-self-improvement",
+              "pipecat/evals/the-eval-loop",
               {
                 "group": "Third-party Platforms",
                 "pages": [

--- a/pipecat/evals/overview.mdx
+++ b/pipecat/evals/overview.mdx
@@ -29,7 +29,7 @@ Evals make agent behavior testable the way unit tests make code testable:
 - **Regression safety**: run your scenarios after every prompt, model, or pipeline change and catch breakage before users do.
 - **Fast iteration**: text-mode evals skip STT and TTS entirely, so a full conversation test runs in seconds with no audio service cost.
 - **Semantic assertions**: an LLM judge checks meaning ("the response says the capital is Berlin"), not exact strings, so tests don't break when wording changes.
-- **A feedback signal for AI coding assistants**: evals give a coding assistant a command it can run and a pass/fail result it can read, closing the loop between writing agent code and verifying it. See [Agent Self-Improvement](/pipecat/evals/agent-self-improvement).
+- **A feedback signal for AI coding assistants**: evals give a coding assistant a command it can run and a pass/fail result it can read, closing the loop between writing agent code and verifying it. See [The Eval Loop](/pipecat/evals/the-eval-loop).
 
 Pipecat itself relies on this framework: before every release, an eval suite drives 100+ example agents end to end.
 
@@ -126,39 +126,30 @@ Pipecat's other building blocks feed into any evaluation workflow: [Metrics](/pi
 
 <CardGroup cols={2}>
   <Card
-    title="Quickstart"
-    icon="rocket"
+    title="Writing Scenarios"
+    icon="file-pen"
     iconType="duotone"
-    href="/pipecat/evals/quickstart"
+    href="/pipecat/evals/scenarios"
   >
-    Run your first eval against an existing agent in a few minutes.
+    The full scenario format: turns, expectations, modalities, and the judge.
   </Card>
 
-<Card
-  title="Writing Scenarios"
-  icon="file-pen"
-  iconType="duotone"
-  href="/pipecat/evals/scenarios"
->
-  The full scenario format: turns, expectations, modalities, and the judge.
-</Card>
-
-<Card
-  title="Eval Suites"
-  icon="list-check"
-  iconType="duotone"
-  href="/pipecat/evals/suites"
->
-  Spawn multiple agents and run many scenarios concurrently from a manifest.
-</Card>
+  <Card
+    title="Eval Suites"
+    icon="list-check"
+    iconType="duotone"
+    href="/pipecat/evals/suites"
+  >
+    Spawn multiple agents and run many scenarios concurrently from a manifest.
+  </Card>
 
   <Card
-    title="Agent Self-Improvement"
+    title="The Eval Loop"
     icon="arrows-rotate"
     iconType="duotone"
-    href="/pipecat/evals/agent-self-improvement"
+    href="/pipecat/evals/the-eval-loop"
   >
-    Close the loop: let an AI coding assistant write, run, and fix against
-    evals.
+    Let a coding assistant write agent code, run evals, and iterate
+    automatically until the agent is better.
   </Card>
 </CardGroup>

--- a/pipecat/evals/quickstart.mdx
+++ b/pipecat/evals/quickstart.mdx
@@ -152,4 +152,4 @@ This guide takes an existing agent, starts it with the eval transport, and runs 
 
 - Learn the full scenario format, including multi-turn conversations, function call assertions, interruptions, latency budgets, and text vs audio modes, in [Writing Scenarios](/pipecat/evals/scenarios).
 - Have many scenarios or agents? Let Pipecat spawn the agents for you with [Eval Suites](/pipecat/evals/suites).
-- Want your coding assistant to run these for you? See [Agent Self-Improvement](/pipecat/evals/agent-self-improvement).
+- Want your coding assistant to run these for you? See [The Eval Loop](/pipecat/evals/the-eval-loop).

--- a/pipecat/evals/scenarios.mdx
+++ b/pipecat/evals/scenarios.mdx
@@ -292,14 +292,14 @@ turns:
         eval: "the response says the capital of Germany is Berlin"
 ```
 
-## Seed the conversation context with `reset:`
+## Seed the conversation context with `context:`
 
-Before driving the turns, the harness resets the agent's LLM context. By default the context is cleared; provide `reset:` to seed it with messages instead, which lets a scenario start mid-conversation:
+Provide `context:` to set the messages the agent's LLM context should start from, which lets a scenario start mid-conversation. When given, the harness sends them before driving the turns (replacing the agent's context). Omit it (the default) to leave the agent's own context untouched:
 
 ```yaml
-reset:
-  - role: developer
-    content: "The user has already introduced themselves as Alex."
+context:
+  - role: user
+    content: "My name is Alex."
   - role: assistant
     content: "Nice to meet you, Alex! How can I help?"
 ```
@@ -308,20 +308,12 @@ reset:
 
 <CardGroup cols={2}>
   <Card
-    title="Eval Suites"
-    icon="list-check"
+    title="The Eval Loop"
+    icon="arrows-rotate"
     iconType="duotone"
-    href="/pipecat/evals/suites"
+    href="/pipecat/evals/the-eval-loop"
   >
-    Run many scenarios against many agents concurrently from a manifest.
-  </Card>
-
-  <Card
-    title="Using the Library"
-    icon="code"
-    iconType="duotone"
-    href="/pipecat/evals/library"
-  >
-    Load, build, and run scenarios from Python instead of YAML.
+    Let a coding assistant write agent code, run evals, and iterate
+    automatically until the agent is better.
   </Card>
 </CardGroup>

--- a/pipecat/evals/suites.mdx
+++ b/pipecat/evals/suites.mdx
@@ -96,25 +96,3 @@ The exit code makes suites CI-ready with no extra glue:
 ```
 
 For deterministic, key-free CI runs, prefer text-mode scenarios and an OpenAI-compatible judge endpoint you control. Audio-mode scenarios work in CI too, but need the harness's TTS and STT services available (local models by default, which also need more CPU).
-
-## Next steps
-
-<CardGroup cols={2}>
-  <Card
-    title="Using the Library"
-    icon="code"
-    iconType="duotone"
-    href="/pipecat/evals/library"
-  >
-    Orchestrate suites programmatically with `EvalManifest` and `EvalSuite`.
-  </Card>
-
-  <Card
-    title="Agent Self-Improvement"
-    icon="arrows-rotate"
-    iconType="duotone"
-    href="/pipecat/evals/agent-self-improvement"
-  >
-    Let an AI coding assistant run your suite and iterate until it's green.
-  </Card>
-</CardGroup>

--- a/pipecat/evals/the-eval-loop.mdx
+++ b/pipecat/evals/the-eval-loop.mdx
@@ -1,9 +1,11 @@
 ---
-title: "Agent Self-Improvement"
-description: "Close the loop: let an AI coding assistant write agent code, run evals, and iterate until they pass."
+title: "The Eval Loop"
+description: "Close the loop: evals give an AI coding assistant a pass/fail signal it can read, so it writes agent code, runs evals, and iterates automatically until the agent is better."
 ---
 
-Evals do more than catch regressions. They turn agent quality into a signal that an AI coding assistant can read, which changes how you build: instead of asking an assistant to "improve the prompt" and judging the result by hand, you describe the desired behavior as a scenario and let the assistant iterate until the eval passes.
+Evals turn agent quality into a signal an AI coding assistant can read. That closes the loop: instead of asking an assistant to "improve the prompt" and judging the result by hand, you describe the desired behavior as a scenario and let the assistant iterate until the eval passes, and the agent gets better with every pass.
+
+Think of it as a REPL for agent behavior: the assistant writes a change, evals it, reads a pass/fail result, and loops, except the eval step already contains the judgment, so the cycle can close without a human reading the output.
 
 ## The loop
 


### PR DESCRIPTION
## Summary

Reframes the **Agent Self-Improvement** page as **The Eval Loop**. The old name implied the agent improves itself at runtime; the page is really about a development-time loop where an AI coding assistant writes agent code, runs evals, reads a pass/fail result, and iterates automatically until the agent is better. A REPL analogy is added to the intro to make the mental model land.

## Changes

- Rename `agent-self-improvement.mdx` → `the-eval-loop.mdx`; update title, description, intro, and all cross-references (overview, quickstart, suites, scenarios). No redirect added since the page was never published.
- Trim "Next steps" sections that just duplicated Mintlify's automatic prev/next page footer:
  - Remove the `suites.mdx` section (linked only to the literal next two nav pages).
  - Reduce `scenarios.mdx` to the single Eval Loop card.
  - Drop the redundant Quickstart card on `overview.mdx`.
- Rename the scenario seed key `reset:` → `context:` in `scenarios.mdx`.

## Verification

- `mint broken-links` passes (no broken links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)