### PR TITLE
docs: update RTVI documentation for VAD user speaking events

### DIFF
--- a/api-reference/server/rtvi/rtvi-observer.mdx
+++ b/api-reference/server/rtvi/rtvi-observer.mdx
@@ -59,6 +59,10 @@ worker = PipelineWorker(
   Indicates if the user's started/stopped speaking messages should be sent.
 </ParamField>
 
+<ParamField path="vad_user_speaking_enabled" default="False">
+  Indicates if raw VAD user started/stopped speaking messages should be sent. These reflect the VAD signal directly, independent of turn finalization (unlike `user_speaking_enabled`, which a turn strategy may gate or defer).
+</ParamField>
+
 <ParamField path="user_mute_enabled" default="True">
   Indicates if user mute started/stopped messages (`user-mute-started`,
   `user-mute-stopped`) should be sent.
@@ -188,6 +192,8 @@ The observer maps Pipecat's internal frames to RTVI protocol messages:
 | **Speech Events**             |
 | `UserStartedSpeakingFrame`    | `RTVIUserStartedSpeakingMessage`            |
 | `UserStoppedSpeakingFrame`    | `RTVIUserStoppedSpeakingMessage`            |
+| `VADUserStartedSpeakingFrame` | `VADUserStartedSpeakingMessage`             |
+| `VADUserStoppedSpeakingFrame` | `VADUserStoppedSpeakingMessage`             |
 | `BotStartedSpeakingFrame`     | `RTVIBotStartedSpeakingMessage`             |
 | `BotStoppedSpeakingFrame`     | `RTVIBotStoppedSpeakingMessage`             |
 | **User Mute**                 |

--- a/client/rtvi-standard.mdx
+++ b/client/rtvi-standard.mdx
@@ -167,6 +167,30 @@ Emitted when the user stops speaking
 - **type**: `'user-stopped-speaking'`
 - **data**: None
 
+#### vad-user-started-speaking 🤖
+
+<Note>
+  Disabled by default; enable with
+  `RTVIObserverParams(vad_user_speaking_enabled=True)`.
+</Note>
+
+Emitted when the VAD (Voice Activity Detection) detects the user started speaking. This is the raw VAD signal, emitted independently of turn finalization (unlike `user-started-speaking`, which a turn strategy may gate or defer).
+
+- **type**: `'vad-user-started-speaking'`
+- **data**: None
+
+#### vad-user-stopped-speaking 🤖
+
+<Note>
+  Disabled by default; enable with
+  `RTVIObserverParams(vad_user_speaking_enabled=True)`.
+</Note>
+
+Emitted when the VAD (Voice Activity Detection) detects the user stopped speaking. This is the raw VAD signal, emitted independently of turn finalization (unlike `user-stopped-speaking`, which a turn strategy may gate or defer).
+
+- **type**: `'vad-user-stopped-speaking'`
+- **data**: None
+
 #### bot-started-speaking 🤖
 
 Emitted when the bot begins speaking


### PR DESCRIPTION
Update documentation for PR pipecat-ai/pipecat#4785:

- Add vad_user_speaking_enabled parameter to RTVIObserverParams
- Document VADUserStartedSpeakingFrame and VADUserStoppedSpeakingFrame mappings
- Add vad-user-started-speaking and vad-user-stopped-speaking message types