### PR TITLE
docs: update for pipecat-flows PR #282

### DIFF
--- a/api-reference/pipecat-flows/overview.mdx
+++ b/api-reference/pipecat-flows/overview.mdx
@@ -91,7 +91,7 @@ Create transitions between conversation states, optionally processing data first
 
 ### Direct Functions
 
-Functions passed directly to NodeConfig with automatic metadata extraction from signatures and docstrings. See [`flows_direct_function`](/api-reference/pipecat-flows/types#flows_direct_function-decorator) and [`FlowsDirectFunction`](/api-reference/pipecat-flows/types#flowsdirectfunction).
+Functions passed directly to NodeConfig with automatic metadata extraction from signatures and docstrings. See [`flows_tool_options`](/api-reference/pipecat-flows/types#flows_tool_options-decorator) and [`FlowsDirectFunction`](/api-reference/pipecat-flows/types#flowsdirectfunction).
 
 ## LLM Provider Support
 

--- a/api-reference/pipecat-flows/types.mdx
+++ b/api-reference/pipecat-flows/types.mdx
@@ -274,12 +274,12 @@ config = ContextStrategyConfig(
 )
 ```
 
-## flows_direct_function Decorator
+## flows_tool_options Decorator
 
-Decorator that attaches metadata to a Pipecat direct function for use in Flows.
+Decorator that configures call options for a Pipecat direct function in Flows.
 
 ```python
-@flows_direct_function(*, cancel_on_interruption: bool = False, timeout_secs: float | None = None)
+@flows_tool_options(*, cancel_on_interruption: bool = False, timeout_secs: float | None = None)
 ```
 
 | Parameter                | Type    | Default | Description                                                                               |
@@ -287,16 +287,16 @@ Decorator that attaches metadata to a Pipecat direct function for use in Flows.
 | `cancel_on_interruption` | `bool`  | `False` | Whether to cancel the function call when the user interrupts.                             |
 | `timeout_secs`           | `float` | `None`  | Optional per-tool timeout in seconds, overriding the global `function_call_timeout_secs`. |
 
-Direct functions have their schema automatically extracted from the function signature and docstring. The first parameter must be `flow_manager: FlowManager`, and all other parameters become the function's properties. The docstring provides the function description and parameter descriptions (Google-style).
+This decorator is optional; use it to override the defaults for a Flows direct function. Direct functions have their schema automatically extracted from the function signature and docstring. The first parameter must be `flow_manager: FlowManager`, and all other parameters become the function's properties. The docstring provides the function description and parameter descriptions (Google-style).
 
 Direct functions must return a [`ConsolidatedFunctionResult`](#consolidatedfunctionresult) tuple.
 
 ### Example
 
 ```python
-from pipecat_flows import FlowManager, flows_direct_function, ConsolidatedFunctionResult
+from pipecat_flows import FlowManager, flows_tool_options, ConsolidatedFunctionResult
 
-@flows_direct_function(cancel_on_interruption=False)
+@flows_tool_options(cancel_on_interruption=False)
 async def lookup_order(
     flow_manager: FlowManager, order_id: str
 ) -> ConsolidatedFunctionResult:
@@ -320,6 +320,12 @@ node_config: NodeConfig = {
     "functions": [lookup_order],
 }
 ```
+
+### Deprecated: flows_direct_function
+
+<Warning>
+  **Deprecated.** The `@flows_direct_function` decorator has been renamed to `@flows_tool_options`. The old name still works but emits a `DeprecationWarning` and will be removed in a future version. Update your code to use `@flows_tool_options` instead.
+</Warning>
 
 ## FlowsDirectFunction
 

--- a/pipecat-flows/guides/functions.mdx
+++ b/pipecat-flows/guides/functions.mdx
@@ -86,12 +86,12 @@ node_config = {
 
 This approach eliminates the need for separate `FlowsFunctionSchema` definitions while maintaining the same functionality.
 
-To control interruption behavior, use the `@flows_direct_function` decorator:
+To control interruption behavior and other call options, use the `@flows_tool_options` decorator:
 
 ```python
-from pipecat_flows import flows_direct_function
+from pipecat_flows import flows_tool_options
 
-@flows_direct_function(cancel_on_interruption=False)
+@flows_tool_options(cancel_on_interruption=False)
 async def long_running_lookup(
     flow_manager: FlowManager,
     order_id: str
@@ -104,3 +104,7 @@ async def long_running_lookup(
     order = await db.get_order(order_id)
     return {"status": "success", "order": order}, create_order_node(order)
 ```
+
+<Note>
+  The `@flows_direct_function` decorator is deprecated. Use `@flows_tool_options` instead. The old decorator name still works but will be removed in a future version.
+</Note>


### PR DESCRIPTION
Automated documentation update for [pipecat-flows PR #282](https://github.com/pipecat-ai/pipecat-flows/pull/282).

## Changes

### Updated API reference pages
- `api-reference/pipecat-flows/types.mdx` — Renamed "flows_direct_function Decorator" section to "flows_tool_options Decorator", updated examples to use the new decorator name, and added deprecation warning for the old name
- `api-reference/pipecat-flows/overview.mdx` — Updated link reference from `flows_direct_function` to `flows_tool_options`

### Updated guide pages
- `pipecat-flows/guides/functions.mdx` — Updated example code to use `@flows_tool_options` instead of `@flows_direct_function`, and added a note about the deprecation

## Summary

PR #282 introduced a new `@flows_tool_options` decorator that replaces the existing `@flows_direct_function` decorator. The old decorator is now deprecated but still works as an alias. All documentation has been updated to:

1. Use the new `@flows_tool_options` decorator as the primary/recommended approach
2. Include deprecation warnings for `@flows_direct_function`
3. Maintain accuracy with the source code changes

## Gaps identified

None