### PR TITLE
docs: split Context Hub into a reference page, slim the agent workflow

### DIFF
--- a/api-reference/cli/init.mdx
+++ b/api-reference/cli/init.mdx
@@ -9,7 +9,7 @@ Write the Pipecat coding-agent guide into a project so an AI coding assistant (C
 
 - **`AGENTS.md`** — the agent-facing guide (how to build Pipecat apps: scaffold first, check APIs against live sources instead of stale training data, verify with the eval harness). Picked up automatically by coding agents.
 - **`CLAUDE.md`** — a one-line import of `AGENTS.md` so Claude Code loads the guide.
-- **`GETTING_STARTED.md`** — developer-facing guidance: how to set up the [Pipecat Context Hub](/pipecat/get-started/ai-tools), write an effective first prompt, and what to expect from a coding session.
+- **`GETTING_STARTED.md`** — developer-facing guidance: how to set up the [Pipecat Context Hub](/api-reference/context-hub), write an effective first prompt, and what to expect from a coding session.
 
 <Note>
   `pipecat init` does **not** scaffold a project — it makes a project

--- a/api-reference/context-hub.mdx
+++ b/api-reference/context-hub.mdx
@@ -1,0 +1,126 @@
+---
+title: "Pipecat Context Hub"
+description: "A local index of Pipecat docs, examples, and API source for AI coding tools — available as a CLI and an MCP server."
+---
+
+[Pipecat Context Hub](https://github.com/pipecat-ai/pipecat-context-hub) indexes Pipecat documentation, code examples, and framework API source into a local vector database on your machine. It's built for coding workflows: queries return the actual source and snippets your AI tool needs to write working code, not synthesized prose.
+
+Pipecat's docs, examples, and API surface change often and span several repositories, so a model working from training data goes stale fast. The hub keeps a fresh local index you query directly. You can also point it at your own repositories (public or private) to index private code alongside the framework.
+
+Every tool runs two ways: as a one-shot CLI command and as an MCP server. Use the CLI for a quick lookup. Add the MCP server when a session needs repeated, exploratory queries.
+
+## Setup
+
+The hub is published to PyPI as `pipecat-ai-context-hub` and runs with [`uv`](https://docs.astral.sh/uv/), no clone required. The examples on this page use `uvx`, uv's one-shot runner, which fetches and runs the hub on demand. Build the local index once:
+
+```bash
+uvx pipecat-ai-context-hub refresh   # build local index (~2 min first run)
+```
+
+<Tip>
+  To install it once instead of fetching on demand, run `uv tool install
+  pipecat-ai-context-hub`. This puts the command on your `PATH`, so you drop the
+  `uvx` prefix and call it directly, using the shorter `pipecat-context-hub`
+  name.
+</Tip>
+
+If the index gets corrupted, you can force a rebuild:
+
+```bash
+uvx pipecat-ai-context-hub refresh --force
+```
+
+If your project targets an older Pipecat version, pin the hub to it so results match what you're running:
+
+```bash
+uvx pipecat-ai-context-hub refresh --framework-version v0.0.96
+```
+
+## Tools
+
+| Tool                | Use it to                                                                                            |
+| ------------------- | ---------------------------------------------------------------------------------------------------- |
+| `search_docs`       | Find guides and conceptual docs ("how do I ...?")                                                    |
+| `search_examples`   | Find working example code by task or component                                                       |
+| `search_api`        | Find class definitions, method signatures, frame types, and inheritance                              |
+| `get_doc`           | Fetch a full doc page by ID or path                                                                  |
+| `get_example`       | Fetch the full source files for an example                                                           |
+| `get_code_snippet`  | Fetch targeted code by symbol, intent, or file and line range                                        |
+| `check_deprecation` | Check whether an import path is deprecated or removed (can evaluate lifecycle at a specific version) |
+| `get_hub_status`    | Report index health, freshness, and the indexed Pipecat version                                      |
+
+The three `search_*` tools return a ranked list of hits, each with a relevance `score`. Each response also carries an evidence report with an overall `confidence`, a `low_confidence` flag, and suggested follow-up queries. The agent triages that list, picks the best fit, then calls a `get_*` tool to pull the full content. The coding agent can pass your `pipecat_version` to score and filter results for compatibility with the version you target. The remaining two tools stand alone: `check_deprecation` reports a symbol's lifecycle, and `get_hub_status` reports index health.
+
+To make your coding agent reach for these tools automatically, add the [recommended CLAUDE.md / AGENTS.md instructions](https://github.com/pipecat-ai/pipecat-context-hub/blob/main/docs/README.md#add-claudemd-instructions-recommended) to your project.
+
+## CLI lookups
+
+Every tool is also a one-shot CLI command, so you can query the index from a shell with no MCP setup. Reach for this when you need a single answer fast, like a deprecation check, an API signature, or an index health check. Each command prints the tool's JSON to stdout:
+
+```bash
+uvx pipecat-ai-context-hub check-deprecation PipelineTask     # is this symbol deprecated?
+uvx pipecat-ai-context-hub search-api "WebsocketServerParams"  # find an API signature
+uvx pipecat-ai-context-hub status                              # index health / freshness
+```
+
+## MCP server
+
+For a longer build or debugging session where the model probes the index repeatedly, add the hub as an MCP server instead of shelling out per query. It keeps the index warm for the whole session and exposes the same tools to your coding tool directly.
+
+<Tabs>
+  <Tab title="Claude Code">
+    ```bash
+    claude mcp add pipecat-context-hub -- uvx pipecat-ai-context-hub serve
+    ```
+  </Tab>
+  <Tab title="Codex">
+    ```bash
+    codex mcp add pipecat-context-hub -- uvx pipecat-ai-context-hub serve
+    ```
+  </Tab>
+  <Tab title="Cursor">
+    Add to your Cursor MCP config:
+
+    ```json
+    {
+      "mcpServers": {
+        "pipecat-context-hub": {
+          "command": "uvx",
+          "args": ["pipecat-ai-context-hub", "serve"]
+        }
+      }
+    }
+    ```
+
+  </Tab>
+  <Tab title="VS Code">
+    Add to `.vscode/mcp.json`:
+
+    ```json
+    {
+      "servers": {
+        "pipecat-context-hub": {
+          "command": "uvx",
+          "args": ["pipecat-ai-context-hub", "serve"]
+        }
+      }
+    }
+    ```
+
+  </Tab>
+</Tabs>
+
+A newly added MCP server loads when your coding tool starts a session, so add it before opening the session you want to use it in.
+
+See the [repo docs](https://github.com/pipecat-ai/pipecat-context-hub) for additional configuration options.
+
+## Next steps
+
+<Card
+  title="Build with a Coding Agent"
+  icon="sparkles"
+  href="/pipecat/get-started/ai-tools"
+>
+  The full agent-driven workflow: `pipecat init`, the Context Hub, and your
+  first coding session
+</Card>

--- a/docs.json
+++ b/docs.json
@@ -847,6 +847,10 @@
                 ]
               }
             ]
+          },
+          {
+            "group": "Pipecat Context Hub",
+            "pages": ["api-reference/context-hub"]
           }
         ]
       }

--- a/pipecat/evals/the-eval-loop.mdx
+++ b/pipecat/evals/the-eval-loop.mdx
@@ -86,7 +86,7 @@ A few practices keep autonomous loops honest:
 
 <CardGroup cols={2}>
   <Card
-    title="AI-Assisted Development"
+    title="Build with a Coding Agent"
     icon="robot"
     iconType="duotone"
     href="/pipecat/get-started/ai-tools"

--- a/pipecat/get-started/ai-tools.mdx
+++ b/pipecat/get-started/ai-tools.mdx
@@ -1,153 +1,78 @@
 ---
-title: "AI-Assisted Development"
-description: "Use AI coding tools with Pipecat documentation and source code."
+title: "Build with a Coding Agent"
+description: "Build your Pipecat agent with Claude Code or Codex, fed live, accurate context."
 ---
 
-Pipecat offers several ways to set up AI coding tools and feed them accurate, up-to-date context, helping you build voice and multimodal applications faster.
+Pipecat works with AI coding tools like Claude Code and Codex to write your agent code. Make your project agent-ready, give the agent live context instead of stale training data, then let it build.
 
-## Make your project agent-ready (`pipecat init`)
+<Steps>
+  <Step title="Make your project agent-ready">
+    Install the CLI and run `pipecat init` in your project:
 
-If you're building with an AI coding assistant, run `pipecat init` in your project first:
-
-```bash
-uv tool install "pipecat-ai[cli]"
-pipecat init
-```
-
-This writes a Pipecat coding-agent guide (`AGENTS.md` + `CLAUDE.md`) and developer guidance (`GETTING_STARTED.md`) into the project. Your agent picks up `AGENTS.md` automatically — it follows Pipecat conventions and scaffolds the app for you with `pipecat create`. Pair it with the Pipecat Context Hub below so the agent works from live API context instead of stale training data.
-
-<Card
-  title="Build Your Next Bot"
-  icon="robot"
-  href="/pipecat/get-started/build-your-next-bot"
->
-  The full agent-driven workflow, start to finish
-</Card>
-
-## Pipecat Context Hub (CLI and MCP)
-
-[Pipecat Context Hub](https://github.com/pipecat-ai/pipecat-context-hub) indexes Pipecat documentation, code examples, and framework API source into a local vector database on your machine. It's built for coding workflows: queries return the actual source and snippets your AI tool needs to write working code, not synthesized prose.
-
-Pipecat's docs, examples, and API surface change often and span several repositories, so a model working from training data goes stale fast. The hub keeps a fresh local index you query directly. You can also point it at your own repositories (public or private) to index private code alongside the framework.
-
-Every tool runs two ways: as a one-shot CLI command and as an MCP server. Use the CLI for a quick lookup. Add the MCP server when a session needs repeated, exploratory queries.
-
-### Setup
-
-The hub is published to PyPI as `pipecat-ai-context-hub` and runs with [`uv`](https://docs.astral.sh/uv/), no clone required. The examples on this page use `uvx`, uv's one-shot runner, which fetches and runs the hub on demand. Build the local index once:
-
-```bash
-uvx pipecat-ai-context-hub refresh   # build local index (~2 min first run)
-```
-
-<Tip>
-  To install it once instead of fetching on demand, run `uv tool install
-  pipecat-ai-context-hub`. This puts the command on your `PATH`, so you drop the
-  `uvx` prefix and call it directly, using the shorter `pipecat-context-hub`
-  name.
-</Tip>
-
-If the index gets corrupted, you can force a rebuild:
-
-```bash
-uvx pipecat-ai-context-hub refresh --force
-```
-
-If your project targets an older Pipecat version, pin the hub to it so results match what you're running:
-
-```bash
-uvx pipecat-ai-context-hub refresh --framework-version v0.0.96
-```
-
-### Tools
-
-| Tool                | Use it to                                                                                            |
-| ------------------- | ---------------------------------------------------------------------------------------------------- |
-| `search_docs`       | Find guides and conceptual docs ("how do I ...?")                                                    |
-| `search_examples`   | Find working example code by task or component                                                       |
-| `search_api`        | Find class definitions, method signatures, frame types, and inheritance                              |
-| `get_doc`           | Fetch a full doc page by ID or path                                                                  |
-| `get_example`       | Fetch the full source files for an example                                                           |
-| `get_code_snippet`  | Fetch targeted code by symbol, intent, or file and line range                                        |
-| `check_deprecation` | Check whether an import path is deprecated or removed (can evaluate lifecycle at a specific version) |
-| `get_hub_status`    | Report index health, freshness, and the indexed Pipecat version                                      |
-
-The three `search_*` tools return a ranked list of hits, each with a relevance `score`. Each response also carries an evidence report with an overall `confidence`, a `low_confidence` flag, and suggested follow-up queries. The agent triages that list, picks the best fit, then calls a `get_*` tool to pull the full content. The coding agent can pass your `pipecat_version` to score and filter results for compatibility with the version you target. The remaining two tools stand alone: `check_deprecation` reports a symbol's lifecycle, and `get_hub_status` reports index health.
-
-To make your coding agent reach for these tools automatically, add the [recommended CLAUDE.md / AGENTS.md instructions](https://github.com/pipecat-ai/pipecat-context-hub/blob/main/docs/README.md#add-claudemd-instructions-recommended) to your project.
-
-### CLI lookups
-
-Every tool is also a one-shot CLI command, so you can query the index from a shell with no MCP setup. Reach for this when you need a single answer fast, like a deprecation check, an API signature, or an index health check. Each command prints the tool's JSON to stdout:
-
-```bash
-uvx pipecat-ai-context-hub check-deprecation PipelineTask     # is this symbol deprecated?
-uvx pipecat-ai-context-hub search-api "WebsocketServerParams"  # find an API signature
-uvx pipecat-ai-context-hub status                              # index health / freshness
-```
-
-### MCP server
-
-For a longer build or debugging session where the model probes the index repeatedly, add the hub as an MCP server instead of shelling out per query. It keeps the index warm for the whole session and exposes the same tools to your coding tool directly.
-
-<Tabs>
-  <Tab title="Claude Code">
     ```bash
-    claude mcp add pipecat-context-hub -- uvx pipecat-ai-context-hub serve
+    uv tool install "pipecat-ai[cli]"
+    pipecat init
     ```
-  </Tab>
-  <Tab title="Codex">
+
+    This writes a Pipecat coding-agent guide (`AGENTS.md` + `CLAUDE.md`) and developer guidance (`GETTING_STARTED.md`). Your agent picks up `AGENTS.md` automatically — it follows Pipecat conventions and scaffolds the app for you with `pipecat create`.
+
+    <Card title="pipecat init reference" icon="robot" href="/api-reference/cli/init">
+      What `init` writes and how the agent flow works
+    </Card>
+
+  </Step>
+  <Step title="Add the Pipecat Context Hub">
+    The Context Hub indexes Pipecat docs, examples, and API source into a local database, so your agent queries live context instead of stale training data. Build the index, then add it as an MCP server:
+
     ```bash
-    codex mcp add pipecat-context-hub -- uvx pipecat-ai-context-hub serve
-    ```
-  </Tab>
-  <Tab title="Cursor">
-    Add to your Cursor MCP config:
-
-    ```json
-    {
-      "mcpServers": {
-        "pipecat-context-hub": {
-          "command": "uvx",
-          "args": ["pipecat-ai-context-hub", "serve"]
-        }
-      }
-    }
+    uvx pipecat-ai-context-hub@latest refresh   # build local index (~2 min first run)
     ```
 
-  </Tab>
-  <Tab title="VS Code">
-    Add to `.vscode/mcp.json`:
+    <Tabs>
+      <Tab title="Claude Code">
+        ```bash
+        claude mcp add pipecat-context-hub -- uvx pipecat-ai-context-hub serve
+        ```
+      </Tab>
+      <Tab title="Codex">
+        ```bash
+        codex mcp add pipecat-context-hub -- uvx pipecat-ai-context-hub serve
+        ```
+      </Tab>
+    </Tabs>
 
-    ```json
-    {
-      "servers": {
-        "pipecat-context-hub": {
-          "command": "uvx",
-          "args": ["pipecat-ai-context-hub", "serve"]
-        }
-      }
-    }
-    ```
+    <Card title="Pipecat Context Hub reference" icon="database" href="/api-reference/context-hub">
+      Full setup, the tool list, CLI lookups, and MCP config for Cursor and VS Code
+    </Card>
 
-  </Tab>
-</Tabs>
+  </Step>
+  <Step title="Start a coding session">
+    Open Claude Code or Codex in your project and prompt it to build. The agent follows `AGENTS.md`, queries the Context Hub for accurate APIs, and scaffolds and iterates on your bot.
+  </Step>
+</Steps>
 
-A newly added MCP server loads when your coding tool starts a session, so add it before opening the session you want to use it in.
+<CardGroup cols={2}>
+  <Card
+    title="Build Your Next Bot"
+    icon="robot"
+    href="/pipecat/get-started/build-your-next-bot"
+  >
+    The full agent-driven workflow, start to finish
+  </Card>
+  <Card
+    title="Pipecat Context Hub"
+    icon="database"
+    href="/api-reference/context-hub"
+  >
+    Everything the Context Hub indexes and exposes to your agent
+  </Card>
+</CardGroup>
 
-See the [repo docs](https://github.com/pipecat-ai/pipecat-context-hub) for additional configuration options.
-
-## CLAUDE.md in the framework repo
-
-Separate from the project guide `pipecat init` writes, the [Pipecat framework repository](https://github.com/pipecat-ai/pipecat) ships its own [`CLAUDE.md`](https://github.com/pipecat-ai/pipecat/blob/main/CLAUDE.md) with architecture guidance, coding conventions, and development patterns for the framework codebase itself. When you work in a cloned copy of the Pipecat repo — for example, contributing to the framework — Claude Code reads it automatically.
-
-## Markdown docs
-
-Every page on this docs site has a **Copy page** button (in the top-right area) that copies the page content as markdown. This is useful for pasting into any AI chat or coding tool to provide context about a specific topic.
-
-## llms.txt
-
-Pipecat docs support the [llms.txt standard](https://llmstxt.org/), which provides a machine-readable index of documentation content. This is useful for tools that can ingest documentation in bulk.
-
-- [`https://docs.pipecat.ai/llms.txt`](https://docs.pipecat.ai/llms.txt) — structured index of all pages
-- [`https://docs.pipecat.ai/llms-full.txt`](https://docs.pipecat.ai/llms-full.txt) — full documentation content in a single file
+<Note>
+  Prefer to feed context by hand? Pipecat docs support the [llms.txt
+  standard](https://llmstxt.org/):
+  [`llms.txt`](https://docs.pipecat.ai/llms.txt) is a structured index of all
+  pages, and [`llms-full.txt`](https://docs.pipecat.ai/llms-full.txt) is the
+  full documentation in a single file — useful for tools that ingest docs in
+  bulk.
+</Note>

--- a/pipecat/get-started/build-your-next-bot.mdx
+++ b/pipecat/get-started/build-your-next-bot.mdx
@@ -27,22 +27,16 @@ pipecat --version
 
 ## Build with an AI coding agent (recommended)
 
-If you're using an AI coding assistant (Claude Code, Codex, …), make your project agent-ready first, then let the agent do the building:
+If you're using an AI coding assistant (Claude Code, Codex, …), make your project agent-ready with `pipecat init` and let the agent do the building — it follows Pipecat conventions, scaffolds the app for you, and verifies its own work. The full workflow lives on Build with a Coding Agent.
 
-```bash
-pipecat init
-```
-
-`pipecat init` writes a Pipecat coding-agent guide (`AGENTS.md` + `CLAUDE.md`) and developer guidance (`GETTING_STARTED.md`) into the project. Open a coding session there and the agent picks up the guide automatically — it follows Pipecat conventions, scaffolds the app for you with `pipecat create`, and verifies its own work with the eval harness.
-
-<CardGroup cols={2}>
-  <Card title="pipecat init reference" icon="robot" href="/api-reference/cli/init">
-    What `init` writes and how the agent flow works
-  </Card>
-  <Card title="AI-Assisted Development" icon="sparkles" href="/pipecat/get-started/ai-tools">
-    Set up the Pipecat Context Hub so your agent has live, accurate context
-  </Card>
-</CardGroup>
+<Card
+  title="Build with a Coding Agent"
+  icon="sparkles"
+  href="/pipecat/get-started/ai-tools"
+>
+  Make your project agent-ready, add the Pipecat Context Hub, and let the agent
+  build
+</Card>
 
 ## Scaffold it yourself
 


### PR DESCRIPTION
- Updates to the AI development pages, reflecting best practices.
- Adds Context Hub reference page