### PR TITLE
Note that realtime service tool params accept a plain list of tools

### DIFF
--- a/api-reference/server/services/s2s/aws.mdx
+++ b/api-reference/server/services/s2s/aws.mdx
@@ -140,8 +140,9 @@ _Deprecated in v0.0.105. Use `settings=AWSNovaSonicLLMService.Settings(system_in
 
 </ParamField>
 
-<ParamField path="tools" type="ToolsSchema" default="None">
-  Available tools/functions for the model to use.
+<ParamField path="tools" type="ToolsSchema | List[FunctionSchema | DirectFunction]" default="None">
+  Available tools for the model: a `ToolsSchema`, or a plain list of direct
+  functions and/or `FunctionSchema` objects.
 </ParamField>
 
 <ParamField path="session_continuation" type="SessionContinuationParams" default="None">

--- a/api-reference/server/services/s2s/gemini-live-vertex.mdx
+++ b/api-reference/server/services/s2s/gemini-live-vertex.mdx
@@ -124,9 +124,10 @@ _Deprecated in v0.0.105. Use `settings=GeminiLiveVertexLLMService.Settings(voice
   System prompt for the model. Can also be provided via the LLM context.
 </ParamField>
 
-<ParamField path="tools" type="List[dict] | ToolsSchema" default="None">
-  Tools/functions available to the model. Can also be provided via the LLM
-  context.
+<ParamField path="tools" type="ToolsSchema | List[FunctionSchema | DirectFunction] | List[dict]" default="None">
+  Tools available to the model: a `ToolsSchema`, a plain list of direct functions
+  and/or `FunctionSchema` objects, or a list of provider-native tool dicts. Can
+  also be provided via the LLM context.
 </ParamField>
 
 <ParamField path="params" type="InputParams" default="InputParams()" deprecated>

--- a/api-reference/server/services/s2s/gemini-live.mdx
+++ b/api-reference/server/services/s2s/gemini-live.mdx
@@ -105,9 +105,10 @@ _Deprecated in v0.0.105. Use `settings=GeminiLiveLLMService.Settings(voice=...)`
   System prompt for the model. Can also be provided via the LLM context.
 </ParamField>
 
-<ParamField path="tools" type="List[dict] | ToolsSchema" default="None">
-  Tools/functions available to the model. Can also be provided via the LLM
-  context.
+<ParamField path="tools" type="ToolsSchema | List[FunctionSchema | DirectFunction] | List[dict]" default="None">
+  Tools available to the model: a `ToolsSchema`, a plain list of direct functions
+  and/or `FunctionSchema` objects, or a list of provider-native tool dicts. Can
+  also be provided via the LLM context.
 </ParamField>
 
 <ParamField path="params" type="InputParams" default="InputParams()" deprecated>

--- a/api-reference/server/services/s2s/ultravox.mdx
+++ b/api-reference/server/services/s2s/ultravox.mdx
@@ -91,8 +91,9 @@ Before using Ultravox Realtime services, you need:
   Types](#input-parameter-types) below.
 </ParamField>
 
-<ParamField path="one_shot_selected_tools" type="ToolsSchema" default="None">
-  Tools to use with a one-shot call. May only be set when using
+<ParamField path="one_shot_selected_tools" type="ToolsSchema | List[FunctionSchema | DirectFunction]" default="None">
+  Tools to use with a one-shot call: a `ToolsSchema`, or a plain list of direct
+  functions and/or `FunctionSchema` objects. May only be set when using
   `OneShotInputParams`.
 </ParamField>
 


### PR DESCRIPTION
Updates the Speech-to-Speech reference pages to reflect that realtime service tool parameters now accept a plain list of standard tools (direct functions and/or `FunctionSchema` objects), not just a `ToolsSchema` — matching `LLMContext(tools=...)`.

## Pages updated

- `s2s/aws.mdx` — `tools`
- `s2s/gemini-live.mdx` — `tools`
- `s2s/gemini-live-vertex.mdx` — `tools`
- `s2s/ultravox.mdx` — `one_shot_selected_tools`

Each `ParamField` type is widened and its description notes the plain-list option. The OpenAI/Grok/Inworld pages configure tools via `session_properties` (documented only generically), so they need no change.

Documents the API added in pipecat-ai/pipecat#4758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)