### PR TITLE
docs: update for pipecat PR #4718

### DIFF
--- a/api-reference/server/services/stt/nvidia.mdx
+++ b/api-reference/server/services/stt/nvidia.mdx
@@ -250,17 +250,19 @@ Batch/segmented transcription using NVIDIA Nemotron Speech's Canary models. Proc
 
 Runtime-configurable settings passed via the `settings` constructor argument using `NvidiaSegmentedSTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter               | Type              | Default          | Description                                                              |
-| ----------------------- | ----------------- | ---------------- | ------------------------------------------------------------------------ |
-| `model`                 | `str`             | `None`           | STT model identifier. _(Inherited from base STT settings.)_              |
-| `language`              | `Language \| str` | `Language.EN_US` | Target language for transcription. _(Inherited from base STT settings.)_ |
-| `profanity_filter`      | `bool`            | `False`          | Whether to filter profanity from results.                                |
-| `automatic_punctuation` | `bool`            | `True`           | Whether to add automatic punctuation.                                    |
-| `verbatim_transcripts`  | `bool`            | `False`          | Whether to return verbatim transcripts.                                  |
-| `boosted_lm_words`      | `list[str]`       | `None`           | List of words to boost in the language model.                            |
-| `boosted_lm_score`      | `float`           | `4.0`            | Score boost for specified words.                                         |
-| `max_alternatives`      | `int`             | `1`              | Maximum number of recognition alternatives.                              |
-| `word_time_offsets`     | `bool`            | `False`          | Whether to include word-level time offsets.                              |
+| Parameter                  | Type              | Default          | Description                                                              |
+| -------------------------- | ----------------- | ---------------- | ------------------------------------------------------------------------ |
+| `model`                    | `str`             | `None`           | STT model identifier. _(Inherited from base STT settings.)_              |
+| `language`                 | `Language \| str` | `Language.EN_US` | Target language for transcription. _(Inherited from base STT settings.)_ |
+| `profanity_filter`         | `bool`            | `False`          | Whether to filter profanity from results.                                |
+| `automatic_punctuation`    | `bool`            | `True`           | Whether to add automatic punctuation.                                    |
+| `verbatim_transcripts`     | `bool`            | `False`          | Whether to return verbatim transcripts.                                  |
+| `boosted_lm_words`         | `list[str]`       | `None`           | List of words to boost in the language model.                            |
+| `boosted_lm_score`         | `float`           | `4.0`            | Score boost for specified words.                                         |
+| `max_alternatives`         | `int`             | `1`              | Maximum number of recognition alternatives.                              |
+| `word_time_offsets`        | `bool`            | `False`          | Whether to include word-level time offsets.                              |
+| `speaker_diarization`      | `bool`            | `False`          | Whether to enable speaker diarization.                                   |
+| `diarization_max_speakers` | `int`             | `0`              | Maximum number of speakers for diarization.                              |
 
 ### Usage
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4718](https://github.com/pipecat-ai/pipecat/pull/4718).

## Changes

- **`api-reference/server/services/stt/nvidia.mdx`** — Added `speaker_diarization` and `diarization_max_speakers` parameters to the `NvidiaSegmentedSTTService` Settings table.

## Context

PR #4718 fixed a bug where `NvidiaSegmentedSTTService` was not initializing `speaker_diarization` and `diarization_max_speakers` defaults in its constructor, leaving both fields as `NOT_GIVEN`. The fix added these parameters to `default_settings` with values `False` and `0` respectively.

These parameters were already documented for `NvidiaSTTService` but were missing from the `NvidiaSegmentedSTTService` Settings table. This update adds them to maintain consistency and accurately reflect the service's capabilities.

## Gaps identified

None