### PR TITLE
docs: update for pipecat PR #4782

### DIFF
--- a/api-reference/server/utilities/observers/observer-pattern.mdx
+++ b/api-reference/server/utilities/observers/observer-pattern.mdx
@@ -66,6 +66,7 @@ class CustomObserver(BaseObserver):
 Pipecat provides several built-in observers:
 
 - **LLMLogObserver**: Logs LLM activity and responses
+- **MetricsLogObserver**: Logs performance and usage metrics (TTFB, TTFA, processing time, token usage)
 - **TranscriptionLogObserver**: Logs speech-to-text transcription events
 - **RTVIObserver**: Converts internal frames to RTVI protocol messages for server to client messaging
 - **[StartupTimingObserver](/api-reference/server/utilities/observers/startup-timing-observer)**: Measures processor startup times and transport readiness

--- a/pipecat/fundamentals/metrics.mdx
+++ b/pipecat/fundamentals/metrics.mdx
@@ -29,6 +29,7 @@ Once enabled, Pipecat logs the following metrics:
 | Metric           | Description                                                                      |
 | ---------------- | -------------------------------------------------------------------------------- |
 | TTFB             | Time To First Byte in seconds                                                    |
+| TTFA             | Time To First Audio — time to the first audible sample (TTS services only)       |
 | Processing Time  | Time taken by the service to respond in seconds                                  |
 | Text Aggregation | Time from the first LLM token to the first complete sentence (TTS services only) |
 
@@ -112,6 +113,7 @@ AnthropicLLMService#0 prompt tokens: 104, completion tokens: 53
 When metrics are enabled, Pipecat emits a `MetricsFrame` for each interaction. The `MetricsFrame` contains a list of metrics data objects, which can include:
 
 - `TTFBMetricsData` — Time To First Byte
+- `TTFAMetricsData` — Time To First Audio (TTS)
 - `ProcessingMetricsData` — Processing time
 - `LLMUsageMetricsData` — LLM token usage
 - `TTSUsageMetricsData` — TTS character usage
@@ -157,6 +159,7 @@ from pipecat.metrics.metrics import (
     LLMUsageMetricsData,
     ProcessingMetricsData,
     TextAggregationMetricsData,
+    TTFAMetricsData,
     TTFBMetricsData,
     TTSUsageMetricsData,
 )
@@ -170,6 +173,8 @@ class MetricsLogger(FrameProcessor):
             for d in frame.data:
                 if isinstance(d, TTFBMetricsData):
                     print(f"!!! MetricsFrame: {frame}, ttfb: {d.value}")
+                elif isinstance(d, TTFAMetricsData):
+                    print(f"!!! MetricsFrame: {frame}, ttfa: {d.value}")
                 elif isinstance(d, ProcessingMetricsData):
                     print(f"!!! MetricsFrame: {frame}, processing: {d.value}")
                 elif isinstance(d, LLMUsageMetricsData):
@@ -195,6 +200,14 @@ Time To First Byte — measures how long until the first byte of a response is r
 | Field   | Type    | Description                 |
 | ------- | ------- | --------------------------- |
 | `value` | `float` | TTFB measurement in seconds |
+
+### TTFAMetricsData
+
+Time To First Audio — measures the time from a TTS request to the first audible audio sample. This extends TTFB by adding any leading silence padding that many TTS providers include at the start of their responses. Comparing TTFA against TTFB reveals how much perceived latency is silence padding versus service response time.
+
+| Field   | Type    | Description                 |
+| ------- | ------- | --------------------------- |
+| `value` | `float` | TTFA measurement in seconds |
 
 ### ProcessingMetricsData
 


### PR DESCRIPTION
Automated documentation update for [pipecat PR #4782](https://github.com/pipecat-ai/pipecat/pull/4782).

## Changes

### pipecat/fundamentals/metrics.mdx
- Added TTFA (Time To First Audio) metric to the metrics table
- Added `TTFAMetricsData` to the list of metrics data objects
- Added `TTFAMetricsData` reference section explaining that it measures time from TTS request to first audible sample (TTFB + leading silence padding)
- Updated `MetricsLogger` example code to handle `TTFAMetricsData`

### api-reference/server/utilities/observers/observer-pattern.mdx
- Added `MetricsLogObserver` to the list of available observers (was previously missing from the list)

## Gaps identified

None