### PR TITLE
docs: update for pipecat-flows PR #283

### DIFF
--- a/api-reference/pipecat-flows/types.mdx
+++ b/api-reference/pipecat-flows/types.mdx
@@ -118,7 +118,7 @@ Dataclass for defining function call schemas with Flows-specific properties. Pro
   List of required parameter names from `properties`.
 </ParamField>
 
-<ParamField path="handler" type="FunctionHandler" default="None">
+<ParamField path="handler" type="FunctionHandler" required>
   Function handler to process the function call. Can be a modern handler `(args,
   flow_manager)`, legacy handler `(args)`, or zero-arg handler `()`. Legacy and
   zero-arg handlers are deprecated. The handler returns any JSON-serializable
@@ -274,18 +274,20 @@ config = ContextStrategyConfig(
 )
 ```
 
-## flows_direct_function Decorator
+## flows_tool_options Decorator
 
-Decorator that attaches metadata to a Pipecat direct function for use in Flows.
+Decorator that configures call options for a Pipecat direct function.
 
 ```python
-@flows_direct_function(*, cancel_on_interruption: bool = False, timeout_secs: float | None = None)
+@flows_tool_options(*, cancel_on_interruption: bool = False, timeout_secs: float | None = None)
 ```
 
 | Parameter                | Type    | Default | Description                                                                               |
 | ------------------------ | ------- | ------- | ----------------------------------------------------------------------------------------- |
 | `cancel_on_interruption` | `bool`  | `False` | Whether to cancel the function call when the user interrupts.                             |
 | `timeout_secs`           | `float` | `None`  | Optional per-tool timeout in seconds, overriding the global `function_call_timeout_secs`. |
+
+This decorator is optional; use it to override the defaults for a Flows direct function (an async function whose first parameter is `flow_manager`).
 
 Direct functions have their schema automatically extracted from the function signature and docstring. The first parameter must be `flow_manager: FlowManager`, and all other parameters become the function's properties. The docstring provides the function description and parameter descriptions (Google-style).
 
@@ -294,9 +296,9 @@ Direct functions must return a [`ConsolidatedFunctionResult`](#consolidatedfunct
 ### Example
 
 ```python
-from pipecat_flows import FlowManager, flows_direct_function, ConsolidatedFunctionResult
+from pipecat_flows import FlowManager, flows_tool_options, ConsolidatedFunctionResult
 
-@flows_direct_function(cancel_on_interruption=False)
+@flows_tool_options(cancel_on_interruption=False, timeout_secs=30)
 async def lookup_order(
     flow_manager: FlowManager, order_id: str
 ) -> ConsolidatedFunctionResult:
@@ -320,6 +322,20 @@ node_config: NodeConfig = {
     "functions": [lookup_order],
 }
 ```
+
+## flows_direct_function Decorator
+
+<Warning>
+  **Deprecated.** Use [`flows_tool_options`](#flows_tool_options-decorator)
+  instead. `flows_direct_function` is an alias for `flows_tool_options` and
+  will be removed in 2.0.0.
+</Warning>
+
+```python
+@flows_direct_function(*, cancel_on_interruption: bool = False, timeout_secs: float | None = None)
+```
+
+This decorator is deprecated. Use `@flows_tool_options` instead for configuring direct function call options.
 
 ## FlowsDirectFunction
 

--- a/pipecat-flows/guides/functions.mdx
+++ b/pipecat-flows/guides/functions.mdx
@@ -19,51 +19,9 @@ For example, if your node's job is to collect a user's favorite color:
 3. The LLM calls the function with the answer
 4. The function processes the data and determines the next node
 
-## Function Definition
+## Direct Functions (Recommended)
 
-Flows provides a universal `FlowsFunctionSchema` that works across all LLM providers:
-
-```python
-from pipecat_flows import FlowsFunctionSchema
-
-record_favorite_color_func = FlowsFunctionSchema(
-    name="record_favorite_color_func",
-    description="Record the color the user said is their favorite.",
-    required=["color"],
-    handler=record_favorite_color_and_set_next_node,
-    properties={"color": {"type": "string"}},
-)
-```
-
-## Function Handlers
-
-Each function has a corresponding `handler` where you implement your application logic and specify the next node:
-
-```python
-async def record_favorite_color_and_set_next_node(
-    args: FlowArgs, flow_manager: FlowManager
-) -> tuple[str, NodeConfig]:
-    """Function handler that records the color then sets the next node.
-
-    Here "record" means print to the console, but any logic could go here:
-    Write to a database, make an API call, etc.
-    """
-    print(f"Your favorite color is: {args['color']}")
-    return args["color"], create_end_node()
-```
-
-## Handler Return Values
-
-Function handlers can return any JSON-serializable value (string, dict, list, etc.) that gets passed to the LLM. To also specify the next node, return a tuple:
-
-- **Result**: Data provided to the LLM for context in subsequent completions, or `None`. Any JSON-serializable value is accepted.
-- **Next Node**: The `NodeConfig` for Flows to transition to next, or `None`
-
-Some handlers may not want to transition conversational state, in which case you can return `None` for the next node. Other handlers may _only_ want to transition conversational state without doing other work, in which case you can return `None` for the result.
-
-## Direct Functions
-
-For more concise code, you can optionally use Direct Functions where the function definition and handler are combined in a single function. The function signature and docstring are automatically used to generate the function schema:
+Direct functions combine the function definition and handler in a single function. The function signature and docstring are automatically used to generate the function schema. This is the recommended way to define functions in Pipecat Flows:
 
 ```python
 async def record_favorite_color(
@@ -80,18 +38,30 @@ async def record_favorite_color(
 
 # Use directly in NodeConfig
 node_config = {
+    "task_messages": [{"role": "developer", "content": "Ask for their favorite color."}],
     "functions": [record_favorite_color]
 }
 ```
 
-This approach eliminates the need for separate `FlowsFunctionSchema` definitions while maintaining the same functionality.
+The function's parameters (excluding `flow_manager`) become the LLM tool's parameters. The docstring provides the function description and parameter descriptions in Google-style format.
 
-To control interruption behavior, use the `@flows_direct_function` decorator:
+### Handler Return Values
+
+Function handlers return a tuple with two elements:
+
+- **Result**: Data provided to the LLM for context in subsequent completions, or `None`. Any JSON-serializable value is accepted.
+- **Next Node**: The `NodeConfig` for Flows to transition to next, or `None`
+
+Some handlers may not want to transition conversational state, in which case you can return `None` for the next node. Other handlers may _only_ want to transition conversational state without doing other work, in which case you can return `None` for the result.
+
+### Controlling Call Options
+
+To control interruption behavior or timeouts, use the `@flows_tool_options` decorator:
 
 ```python
-from pipecat_flows import flows_direct_function
+from pipecat_flows import flows_tool_options
 
-@flows_direct_function(cancel_on_interruption=False)
+@flows_tool_options(cancel_on_interruption=False, timeout_secs=30)
 async def long_running_lookup(
     flow_manager: FlowManager,
     order_id: str
@@ -104,3 +74,39 @@ async def long_running_lookup(
     order = await db.get_order(order_id)
     return {"status": "success", "order": order}, create_order_node(order)
 ```
+
+<Note>
+  `flows_direct_function` is deprecated in favor of `flows_tool_options`.
+  Both names reference the same decorator; `flows_direct_function` will be
+  removed in 2.0.0.
+</Note>
+
+## Advanced: FlowsFunctionSchema
+
+For advanced use cases where you need explicit control over the function schema (e.g., strict `enum` constraints, numeric `minimum`/`maximum` values, or complex nested structures), use `FlowsFunctionSchema`:
+
+```python
+from pipecat_flows import FlowsFunctionSchema, FlowArgs
+
+async def record_favorite_color_and_set_next_node(
+    args: FlowArgs, flow_manager: FlowManager
+) -> tuple[str, NodeConfig]:
+    """Function handler that records the color then sets the next node."""
+    print(f"Your favorite color is: {args['color']}")
+    return args["color"], create_end_node()
+
+record_favorite_color_func = FlowsFunctionSchema(
+    name="record_favorite_color_func",
+    description="Record the color the user said is their favorite.",
+    properties={
+        "color": {
+            "type": "string",
+            "enum": ["red", "blue", "green", "yellow"]  # Strict enum constraint
+        }
+    },
+    required=["color"],
+    handler=record_favorite_color_and_set_next_node,
+)
+```
+
+The `FlowsFunctionSchema` approach gives you precise control over parameter validation that direct functions can only describe in prose. See the `food_ordering_advanced_functionschema.py` example for a complete demonstration.


### PR DESCRIPTION
Automated documentation update for [pipecat-flows PR #283](https://github.com/pipecat-ai/pipecat-flows/pull/283).

## Changes

### api-reference/pipecat-flows/types.mdx
- Updated `FlowsFunctionSchema.handler` parameter to mark it as **required** (no longer optional with default `None`)
- Added `flows_tool_options` as the primary decorator for configuring direct function call options
- Marked `flows_direct_function` decorator as deprecated, with a note pointing to `flows_tool_options` as the replacement

### pipecat-flows/guides/functions.mdx
- Reorganized content to present **direct functions as the recommended approach** (moved section before FlowsFunctionSchema)
- Renamed FlowsFunctionSchema section to "Advanced: FlowsFunctionSchema" to clarify it's for advanced use cases
- Updated decorator examples to use `flows_tool_options` instead of deprecated `flows_direct_function`
- Added clearer guidance on when to use FlowsFunctionSchema (for explicit schema control like strict enums, min/max constraints)

## Gaps identified

None

## Context

PR #283 updated Pipecat Flows to:
- Use Pipecat core's function-handler auto-registration (new in pipecat-ai 1.4.0)
- Make `FlowsFunctionSchema.handler` required (was previously optional)
- Make direct functions the standard across all examples