### PR TITLE
Lead with direct functions in Pipecat Flows docs

### DIFF
--- a/api-reference/pipecat-flows/flow-manager.mdx
+++ b/api-reference/pipecat-flows/flow-manager.mdx
@@ -227,10 +227,10 @@ flow_manager.register_action("notify_slack", notify_slack)
 Once registered, the action can be used in node `pre_actions` or `post_actions`:
 
 ```python
-node_config: NodeConfig = {
-    "task_messages": [...],
-    "pre_actions": [{"type": "notify_slack", "channel": "#support", "text": "New session started"}],
-}
+node_config = NodeConfig(
+    task_messages=[...],
+    pre_actions=[{"type": "notify_slack", "channel": "#support", "text": "New session started"}],
+)
 ```
 
 ## Usage
@@ -241,12 +241,12 @@ node_config: NodeConfig = {
 from pipecat_flows import FlowManager, FlowResult, NodeConfig
 
 async def create_initial_node() -> NodeConfig:
-    return {
-        "task_messages": [
+    return NodeConfig(
+        task_messages=[
             {"role": "developer", "content": "Greet the user and ask how you can help."}
         ],
-        "functions": [help_function],
-    }
+        functions=[help_function],
+    )
 
 flow_manager = FlowManager(
     worker=worker,

--- a/api-reference/pipecat-flows/flow-manager.mdx
+++ b/api-reference/pipecat-flows/flow-manager.mdx
@@ -260,20 +260,16 @@ await flow_manager.initialize(initial_node=await create_initial_node())
 ### Using Global Functions
 
 ```python
-from pipecat_flows import FlowManager, FlowsFunctionSchema
+from pipecat_flows import FlowManager, NodeConfig
 
-transfer_function = FlowsFunctionSchema(
-    name="transfer_to_human",
-    description="Transfer the conversation to a human agent",
-    properties={},
-    required=[],
-    handler=handle_transfer,
-)
+async def transfer_to_human(flow_manager: FlowManager) -> tuple[None, NodeConfig]:
+    """Transfer the conversation to a human agent."""
+    return None, create_human_agent_node()
 
 flow_manager = FlowManager(
     worker=worker,
     llm=llm,
     context_aggregator=context_aggregator,
-    global_functions=[transfer_function],
+    global_functions=[transfer_to_human],  # available at every node
 )
 ```

--- a/api-reference/pipecat-flows/overview.mdx
+++ b/api-reference/pipecat-flows/overview.mdx
@@ -81,17 +81,17 @@ uv add "pipecat-ai[daily,openai,deepgram,cartesia,silero]"
 
 ## Function Types
 
+A node's functions either do work within the current node or transition to another node:
+
 ### Node Functions
 
-Execute operations within a single conversation state without switching nodes. Return `(FlowResult, None)`.
+Do work within the current conversation state without switching nodes. Return `(result, None)`.
 
 ### Edge Functions
 
-Create transitions between conversation states, optionally processing data first. Return `(FlowResult, NodeConfig)`.
+Transition to another conversation state, optionally doing work first. Return `(result, next_node)`.
 
-### Direct Functions
-
-Functions passed directly to NodeConfig with automatic metadata extraction from signatures and docstrings. See [`flows_tool_options`](/api-reference/pipecat-flows/types#flows_tool_options-decorator) and [`FlowsDirectFunction`](/api-reference/pipecat-flows/types#flowsdirectfunction).
+Define either kind as a direct function, or — for explicit schema control — with a [`FlowsFunctionSchema`](/api-reference/pipecat-flows/types#flowsfunctionschema). See the [Functions guide](/pipecat-flows/guides/functions).
 
 ## LLM Provider Support
 

--- a/api-reference/pipecat-flows/overview.mdx
+++ b/api-reference/pipecat-flows/overview.mdx
@@ -83,15 +83,10 @@ uv add "pipecat-ai[daily,openai,deepgram,cartesia,silero]"
 
 A node's functions either do work within the current node or transition to another node:
 
-### Node Functions
+- **Node functions** do work within the current conversation state without switching nodes. They return `(result, None)`.
+- **Edge functions** transition to another conversation state, optionally doing work first. They return `(result, next_node)`.
 
-Do work within the current conversation state without switching nodes. Return `(result, None)`.
-
-### Edge Functions
-
-Transition to another conversation state, optionally doing work first. Return `(result, next_node)`.
-
-Define either kind as a direct function, or — for explicit schema control — with a [`FlowsFunctionSchema`](/api-reference/pipecat-flows/types#flowsfunctionschema). See the [Functions guide](/pipecat-flows/guides/functions).
+Define either kind as a direct function, or — for advanced usage — with a [`FlowsFunctionSchema`](/api-reference/pipecat-flows/types#flowsfunctionschema). See the [Functions guide](/pipecat-flows/guides/functions).
 
 ## LLM Provider Support
 

--- a/api-reference/pipecat-flows/types.mdx
+++ b/api-reference/pipecat-flows/types.mdx
@@ -118,7 +118,7 @@ Dataclass for defining function call schemas with Flows-specific properties. Pro
   List of required parameter names from `properties`.
 </ParamField>
 
-<ParamField path="handler" type="FunctionHandler" default="None">
+<ParamField path="handler" type="FunctionHandler" required>
   Function handler to process the function call. Can be a modern handler `(args,
   flow_manager)`, legacy handler `(args)`, or zero-arg handler `()`. Legacy and
   zero-arg handlers are deprecated. The handler returns any JSON-serializable
@@ -276,7 +276,9 @@ config = ContextStrategyConfig(
 
 ## flows_tool_options Decorator
 
-Decorator that configures call options for a Pipecat direct function in Flows.
+Decorator that overrides a function's default call options. It's optional — a
+function works without it; use it only to change `cancel_on_interruption` or
+`timeout_secs`.
 
 ```python
 @flows_tool_options(*, cancel_on_interruption: bool = False, timeout_secs: float | None = None)
@@ -287,16 +289,22 @@ Decorator that configures call options for a Pipecat direct function in Flows.
 | `cancel_on_interruption` | `bool`  | `False` | Whether to cancel the function call when the user interrupts.                             |
 | `timeout_secs`           | `float` | `None`  | Optional per-tool timeout in seconds, overriding the global `function_call_timeout_secs`. |
 
-This decorator is optional; use it to override the defaults for a Flows direct function. Direct functions have their schema automatically extracted from the function signature and docstring. The first parameter must be `flow_manager: FlowManager`, and all other parameters become the function's properties. The docstring provides the function description and parameter descriptions (Google-style).
+A direct function's schema is automatically extracted from its signature and docstring. The first parameter must be `flow_manager: FlowManager`, and all other parameters become the function's properties. The docstring provides the function description and parameter descriptions (Google-style).
 
-Direct functions must return a [`ConsolidatedFunctionResult`](#consolidatedfunctionresult) tuple.
+A direct function must return a [`ConsolidatedFunctionResult`](#consolidatedfunctionresult) tuple.
+
+<Note>
+  `@flows_direct_function` is a deprecated alias of `@flows_tool_options`. It
+  still works but emits a `DeprecationWarning`; use `@flows_tool_options`
+  instead.
+</Note>
 
 ### Example
 
 ```python
 from pipecat_flows import FlowManager, flows_tool_options, ConsolidatedFunctionResult
 
-@flows_tool_options(cancel_on_interruption=False)
+@flows_tool_options(cancel_on_interruption=True)
 async def lookup_order(
     flow_manager: FlowManager, order_id: str
 ) -> ConsolidatedFunctionResult:
@@ -324,7 +332,10 @@ node_config: NodeConfig = {
 ### Deprecated: flows_direct_function
 
 <Warning>
-  **Deprecated.** The `@flows_direct_function` decorator has been renamed to `@flows_tool_options`. The old name still works but emits a `DeprecationWarning` and will be removed in a future version. Update your code to use `@flows_tool_options` instead.
+  **Deprecated.** The `@flows_direct_function` decorator has been renamed to
+  `@flows_tool_options`. The old name still works but emits a
+  `DeprecationWarning` and will be removed in a future version. Update your code
+  to use `@flows_tool_options` instead.
 </Warning>
 
 ## FlowsDirectFunction

--- a/api-reference/pipecat-flows/types.mdx
+++ b/api-reference/pipecat-flows/types.mdx
@@ -210,15 +210,15 @@ TypedDict for configuring actions that execute during node transitions.
 ### Example
 
 ```python
-node_config: NodeConfig = {
-    "task_messages": [{"role": "developer", "content": "Help the user."}],
-    "pre_actions": [
+node_config = NodeConfig(
+    task_messages=[{"role": "developer", "content": "Help the user."}],
+    pre_actions=[
         {"type": "tts_say", "text": "Welcome! Let me help you with that."},
     ],
-    "post_actions": [
+    post_actions=[
         {"type": "end_conversation", "text": "Goodbye!"},
     ],
-}
+)
 ```
 
 ## ContextStrategy
@@ -276,9 +276,7 @@ config = ContextStrategyConfig(
 
 ## flows_tool_options Decorator
 
-Decorator that overrides a function's default call options. It's optional — a
-function works without it; use it only to change `cancel_on_interruption` or
-`timeout_secs`.
+Decorator that overrides a function's default call options. It's optional — a function works without it.
 
 ```python
 @flows_tool_options(*, cancel_on_interruption: bool = False, timeout_secs: float | None = None)
@@ -288,10 +286,6 @@ function works without it; use it only to change `cancel_on_interruption` or
 | ------------------------ | ------- | ------- | ----------------------------------------------------------------------------------------- |
 | `cancel_on_interruption` | `bool`  | `False` | Whether to cancel the function call when the user interrupts.                             |
 | `timeout_secs`           | `float` | `None`  | Optional per-tool timeout in seconds, overriding the global `function_call_timeout_secs`. |
-
-A direct function's schema is automatically extracted from its signature and docstring. The first parameter must be `flow_manager: FlowManager`, and all other parameters become the function's properties. The docstring provides the function description and parameter descriptions (Google-style).
-
-A direct function must return a [`ConsolidatedFunctionResult`](#consolidatedfunctionresult) tuple.
 
 <Note>
   `@flows_direct_function` is a deprecated alias of `@flows_tool_options`. It
@@ -323,10 +317,10 @@ async def lookup_order(
 The function can then be passed directly in a node's `functions` list:
 
 ```python
-node_config: NodeConfig = {
-    "task_messages": [{"role": "developer", "content": "Ask for the order ID."}],
-    "functions": [lookup_order],
-}
+node_config = NodeConfig(
+    task_messages=[{"role": "developer", "content": "Ask for the order ID."}],
+    functions=[lookup_order],
+)
 ```
 
 ### Deprecated: flows_direct_function

--- a/pipecat-flows/guides/context-strategies.mdx
+++ b/pipecat-flows/guides/context-strategies.mdx
@@ -49,12 +49,12 @@ Or on a per-node basis:
 
 ```python
 # Per-node strategy configuration
-node_config = {
-    "task_messages": [...],
-    "functions": [...],
-    "context_strategy": ContextStrategyConfig(
+node_config = NodeConfig(
+    task_messages=[...],
+    functions=[...],
+    context_strategy=ContextStrategyConfig(
         strategy=ContextStrategy.RESET_WITH_SUMMARY,
-        summary_prompt="Provide a concise summary of the customer's order details and preferences."
-    )
-}
+        summary_prompt="Provide a concise summary of the customer's order details and preferences.",
+    ),
+)
 ```

--- a/pipecat-flows/guides/functions.mdx
+++ b/pipecat-flows/guides/functions.mdx
@@ -70,18 +70,19 @@ By default, a function is not cancelled when the user interrupts, and it uses th
 ```python
 from pipecat_flows import flows_tool_options
 
-@flows_tool_options(timeout_secs=120)
-async def long_running_task(
+# This lookup is only useful for the current turn, so cancel it if the user
+# interrupts and the conversation moves on.
+@flows_tool_options(cancel_on_interruption=True)
+async def check_weather(
     flow_manager: FlowManager,
-    query: str,
-) -> tuple[dict, NodeConfig | None]:
-    """Perform a long-running task.
+    city: str,
+) -> tuple[dict, None]:
+    """Look up the current weather for a city.
 
     Args:
-        query: The search query to run.
+        city: The city to look up.
     """
-    result = await run_long_query(query)
-    return {"status": "complete", "result": result}, None
+    return {"weather": await get_weather(city)}, None
 ```
 
 ## Advanced: Defining a Function with `FlowsFunctionSchema`

--- a/pipecat-flows/guides/functions.mdx
+++ b/pipecat-flows/guides/functions.mdx
@@ -19,56 +19,16 @@ For example, if your node's job is to collect a user's favorite color:
 3. The LLM calls the function with the answer
 4. The function processes the data and determines the next node
 
-## Function Definition
+## Defining a Function
 
-Flows provides a universal `FlowsFunctionSchema` that works across all LLM providers:
+The preferred way to define a function is with a **direct function**: a single async function that is _both_ the handler and the schema. Flows auto-derives the function's metadata — name, description, parameter properties (with their descriptions), and which parameters are required — from the function's signature and docstring.
 
-```python
-from pipecat_flows import FlowsFunctionSchema
-
-record_favorite_color_func = FlowsFunctionSchema(
-    name="record_favorite_color_func",
-    description="Record the color the user said is their favorite.",
-    required=["color"],
-    handler=record_favorite_color_and_set_next_node,
-    properties={"color": {"type": "string"}},
-)
-```
-
-## Function Handlers
-
-Each function has a corresponding `handler` where you implement your application logic and specify the next node:
-
-```python
-async def record_favorite_color_and_set_next_node(
-    args: FlowArgs, flow_manager: FlowManager
-) -> tuple[str, NodeConfig]:
-    """Function handler that records the color then sets the next node.
-
-    Here "record" means print to the console, but any logic could go here:
-    Write to a database, make an API call, etc.
-    """
-    print(f"Your favorite color is: {args['color']}")
-    return args["color"], create_end_node()
-```
-
-## Handler Return Values
-
-Function handlers can return any JSON-serializable value (string, dict, list, etc.) that gets passed to the LLM. To also specify the next node, return a tuple:
-
-- **Result**: Data provided to the LLM for context in subsequent completions, or `None`. Any JSON-serializable value is accepted.
-- **Next Node**: The `NodeConfig` for Flows to transition to next, or `None`
-
-Some handlers may not want to transition conversational state, in which case you can return `None` for the next node. Other handlers may _only_ want to transition conversational state without doing other work, in which case you can return `None` for the result.
-
-## Direct Functions
-
-For more concise code, you can optionally use Direct Functions where the function definition and handler are combined in a single function. The function signature and docstring are automatically used to generate the function schema:
+The first parameter is always `flow_manager` (a `FlowManager`); the function's own parameters follow. Document each parameter in a Google-style docstring.
 
 ```python
 async def record_favorite_color(
     flow_manager: FlowManager,
-    color: str
+    color: str,
 ) -> tuple[str, NodeConfig]:
     """Record the color the user said is their favorite.
 
@@ -78,33 +38,82 @@ async def record_favorite_color(
     print(f"Your favorite color is: {color}")
     return color, create_end_node()
 
-# Use directly in NodeConfig
+# List the function in a node's `functions`
 node_config = {
-    "functions": [record_favorite_color]
+    "functions": [record_favorite_color],
 }
 ```
 
-This approach eliminates the need for separate `FlowsFunctionSchema` definitions while maintaining the same functionality.
+<Note>
+  The direct-function schema generator doesn't yet map `Literal` types to a
+  JSON-schema `enum`. Express enum-like constraints in the docstring prose
+  instead (e.g. _'Must be one of "red", "green", or "blue"'_). If you need a
+  strict `enum` in the schema, use the
+  [`FlowsFunctionSchema`](#advanced-defining-a-function-with-flowsfunctionschema)
+  pattern.
+</Note>
 
-To control interruption behavior and other call options, use the `@flows_tool_options` decorator:
+## Return Values
+
+A function can return any JSON-serializable value (string, dict, list, etc.) that gets passed to the LLM. To also specify the next node, return a tuple:
+
+- **Result**: Data provided to the LLM for context in subsequent completions, or `None`. Any JSON-serializable value is accepted.
+- **Next Node**: The `NodeConfig` for Flows to transition to next, or `None`.
+
+A function that doesn't need to change conversational state can return `None` for the next node. One that _only_ changes conversational state, without doing other work, can return `None` for the result.
+
+## Per-Function Call Options
+
+By default, a direct function is not cancelled when the user interrupts, and it uses the LLM service's global timeout. To override either, decorate the function with `@flows_tool_options`. The decorator only attaches call options — the schema is still auto-derived — so decorated functions can stay at module level.
 
 ```python
 from pipecat_flows import flows_tool_options
 
-@flows_tool_options(cancel_on_interruption=False)
-async def long_running_lookup(
+@flows_tool_options(cancel_on_interruption=True, timeout_secs=10)
+async def check_inventory(
     flow_manager: FlowManager,
-    order_id: str
-) -> tuple[dict, NodeConfig]:
-    """Look up an order that should not be cancelled if the user speaks.
+    sku: str,
+) -> tuple[dict, NodeConfig | None]:
+    """Check whether an item is in stock.
 
     Args:
-        order_id: The order ID to look up.
+        sku: The product SKU to check.
     """
-    order = await db.get_order(order_id)
-    return {"status": "success", "order": order}, create_order_node(order)
+    in_stock = await inventory.check(sku)
+    return {"in_stock": in_stock}, None
 ```
 
-<Note>
-  The `@flows_direct_function` decorator is deprecated. Use `@flows_tool_options` instead. The old decorator name still works but will be removed in a future version.
-</Note>
+## Advanced: Defining a Function with `FlowsFunctionSchema`
+
+Direct functions cover most cases. Reach for `FlowsFunctionSchema` when you need explicit control over the schema — for example a strict `enum` constraint or a numeric `minimum`/`maximum` — that a direct function can't yet express.
+
+A `FlowsFunctionSchema` spells out the function's name, description, and parameters by hand, and takes the `handler` that runs when the LLM calls the function:
+
+```python
+from pipecat_flows import FlowsFunctionSchema
+
+async def record_favorite_color(
+    args: FlowArgs, flow_manager: FlowManager
+) -> tuple[str, NodeConfig]:
+    """Record the color, then set the next node."""
+    print(f"Your favorite color is: {args['color']}")
+    return args["color"], create_end_node()
+
+record_favorite_color_func = FlowsFunctionSchema(
+    name="record_favorite_color",
+    description="Record the color the user said is their favorite.",
+    properties={
+        # A strict enum — the kind of explicit control a direct function can't yet express.
+        "color": {"type": "string", "enum": ["red", "green", "blue"]},
+    },
+    required=["color"],
+    handler=record_favorite_color,
+)
+
+# List the schema in a node's `functions`
+node_config = {
+    "functions": [record_favorite_color_func],
+}
+```
+
+The `handler` is required. It receives the LLM-supplied arguments and returns the same [result and next-node values](#return-values) as a direct function. To override its call options, decorate it with `@flows_tool_options`, the same decorator direct functions use.

--- a/pipecat-flows/guides/functions.mdx
+++ b/pipecat-flows/guides/functions.mdx
@@ -21,9 +21,9 @@ For example, if your node's job is to collect a user's favorite color:
 
 ## Defining a Function
 
-The preferred way to define a function is with a **direct function**: a single async function that is _both_ the handler and the schema. Flows auto-derives the function's metadata — name, description, parameter properties (with their descriptions), and which parameters are required — from the function's signature and docstring.
+The preferred way to define a function is with a **direct function**: a single async function that is _both_ the handler (the code that runs) and the schema (what is advertised to the LLM). Flows auto-derives the function's metadata — name, description, parameter properties (with their descriptions), and which parameters are required — from the function's signature and docstring.
 
-The first parameter is always `flow_manager` (a `FlowManager`); the function's own parameters follow. Document each parameter in a Google-style docstring.
+The first parameter is always `flow_manager` (a [`FlowManager`](/api-reference/pipecat-flows/flow-manager)); the function's own parameters follow. Document each parameter in a Google-style docstring.
 
 ```python
 async def record_favorite_color(
@@ -38,10 +38,11 @@ async def record_favorite_color(
     print(f"Your favorite color is: {color}")
     return color, create_end_node()
 
-# List the function in a node's `functions`
-node_config = {
-    "functions": [record_favorite_color],
-}
+# List the function in a node
+node_config = NodeConfig(
+    # ...
+    functions=[record_favorite_color],
+)
 ```
 
 <Note>
@@ -64,23 +65,23 @@ A function that doesn't need to change conversational state can return `None` fo
 
 ## Per-Function Call Options
 
-By default, a direct function is not cancelled when the user interrupts, and it uses the LLM service's global timeout. To override either, decorate the function with `@flows_tool_options`. The decorator only attaches call options — the schema is still auto-derived — so decorated functions can stay at module level.
+By default, a function is not cancelled when the user interrupts, and it uses the LLM service's global timeout. To override either, decorate the function with `@flows_tool_options`:
 
 ```python
 from pipecat_flows import flows_tool_options
 
-@flows_tool_options(cancel_on_interruption=True, timeout_secs=10)
-async def check_inventory(
+@flows_tool_options(timeout_secs=120)
+async def long_running_task(
     flow_manager: FlowManager,
-    sku: str,
+    query: str,
 ) -> tuple[dict, NodeConfig | None]:
-    """Check whether an item is in stock.
+    """Perform a long-running task.
 
     Args:
-        sku: The product SKU to check.
+        query: The search query to run.
     """
-    in_stock = await inventory.check(sku)
-    return {"in_stock": in_stock}, None
+    result = await run_long_query(query)
+    return {"status": "complete", "result": result}, None
 ```
 
 ## Advanced: Defining a Function with `FlowsFunctionSchema`
@@ -110,10 +111,11 @@ record_favorite_color_func = FlowsFunctionSchema(
     handler=record_favorite_color,
 )
 
-# List the schema in a node's `functions`
-node_config = {
-    "functions": [record_favorite_color_func],
-}
+# List the schema in a node
+node_config = NodeConfig(
+    # ...
+    functions=[record_favorite_color_func],
+)
 ```
 
 The `handler` is required. It receives the LLM-supplied arguments and returns the same [result and next-node values](#return-values) as a direct function. To override its call options, decorate it with `@flows_tool_options`, the same decorator direct functions use.

--- a/pipecat-flows/guides/quickstart.mdx
+++ b/pipecat-flows/guides/quickstart.mdx
@@ -35,20 +35,12 @@ A flow is a graph of nodes. Each node gives the LLM a task and the functions it 
 
 ### Initial Node
 
-The initial node sets the bot's personality via `role_message`, gives it a task via `task_messages`, and provides a function the LLM will call when the user answers:
+The initial node sets the bot's personality via `role_message`, gives it a task via `task_messages`, and lists the function the LLM will call when the user answers:
 
 ```python
-from pipecat_flows import FlowArgs, FlowManager, FlowsFunctionSchema, NodeConfig
+from pipecat_flows import FlowManager, NodeConfig
 
 def create_initial_node() -> NodeConfig:
-    record_favorite_color_func = FlowsFunctionSchema(
-        name="record_favorite_color_func",
-        description="Record the color the user said is their favorite.",
-        required=["color"],
-        handler=record_favorite_color_and_set_next_node,
-        properties={"color": {"type": "string"}},
-    )
-
     return {
         "name": "initial",
         "role_message": "You are an inquisitive child. Use very simple language. Ask simple questions. You must ALWAYS use one of the available functions to progress the conversation. Your responses will be converted to audio. Avoid outputting special characters and emojis.",
@@ -58,7 +50,7 @@ def create_initial_node() -> NodeConfig:
                 "content": "Say 'Hello world' and ask what is the user's favorite color.",
             }
         ],
-        "functions": [record_favorite_color_func],
+        "functions": [record_favorite_color],
     }
 ```
 
@@ -85,19 +77,25 @@ def create_end_node() -> NodeConfig:
   identically. This example uses both styles to show you the options.
 </Tip>
 
-## Write the Function Handler
+## Write the Function
 
-When the LLM calls the function, the handler processes the result and returns the next node:
+When the LLM calls the function, it processes the result and returns the next node. `record_favorite_color` is a **direct function**: its first parameter is `flow_manager`, the rest (here, `color`) become the function's parameters, and Flows derives the schema from the signature and docstring:
 
 ```python
-async def record_favorite_color_and_set_next_node(
-    args: FlowArgs, flow_manager: FlowManager
+async def record_favorite_color(
+    flow_manager: FlowManager,
+    color: str,
 ) -> tuple[str, NodeConfig]:
-    print(f"Your favorite color is: {args['color']}")
-    return args["color"], create_end_node()
+    """Record the color the user said is their favorite.
+
+    Args:
+        color: The user's favorite color.
+    """
+    print(f"Your favorite color is: {color}")
+    return color, create_end_node()
 ```
 
-The handler returns a tuple of `(result, next_node)`. The result is provided to the LLM as context, and the next node is where the conversation transitions to.
+The function returns a tuple of `(result, next_node)`. The result is provided to the LLM as context, and the next node is where the conversation transitions to.
 
 ## Build the Pipeline and FlowManager
 
@@ -170,7 +168,7 @@ That's it! When a user connects, the bot greets them, asks for their favorite co
     Learn about node configuration and message types
   </Card>
   <Card title="Functions" icon="code" href="/pipecat-flows/guides/functions">
-    Understand node functions, edge functions, and direct functions
+    Understand node and edge functions
   </Card>
   <Card title="Examples" icon="rocket" href="/pipecat-flows/examples">
     Explore more complex examples

--- a/pipecat-flows/guides/quickstart.mdx
+++ b/pipecat-flows/guides/quickstart.mdx
@@ -41,17 +41,17 @@ The initial node sets the bot's personality via `role_message`, gives it a task 
 from pipecat_flows import FlowManager, NodeConfig
 
 def create_initial_node() -> NodeConfig:
-    return {
-        "name": "initial",
-        "role_message": "You are an inquisitive child. Use very simple language. Ask simple questions. You must ALWAYS use one of the available functions to progress the conversation. Your responses will be converted to audio. Avoid outputting special characters and emojis.",
-        "task_messages": [
+    return NodeConfig(
+        name="initial",
+        role_message="You are an inquisitive child. Use very simple language. Ask simple questions. You must ALWAYS use one of the available functions to progress the conversation. Your responses will be converted to audio. Avoid outputting special characters and emojis.",
+        task_messages=[
             {
                 "role": "developer",
                 "content": "Say 'Hello world' and ask what is the user's favorite color.",
             }
         ],
-        "functions": [record_favorite_color],
-    }
+        functions=[record_favorite_color],
+    )
 ```
 
 ### End Node
@@ -74,12 +74,12 @@ def create_end_node() -> NodeConfig:
 
 <Tip>
   Nodes can be defined as plain dicts or as `NodeConfig` objects — both work
-  identically. This example uses both styles to show you the options.
+  identically.
 </Tip>
 
 ## Write the Function
 
-When the LLM calls the function, it processes the result and returns the next node. `record_favorite_color` is a **direct function**: its first parameter is `flow_manager`, the rest (here, `color`) become the function's parameters, and Flows derives the schema from the signature and docstring:
+When the LLM calls the function, it processes the result and returns the next node. `record_favorite_color` is a **direct function**: its first parameter is `flow_manager`, the rest (here, `color`) become the function's parameters, and Flows derives the schema (advertised to the LLM) from the signature and docstring:
 
 ```python
 async def record_favorite_color(

--- a/pipecat-flows/guides/state-management.mdx
+++ b/pipecat-flows/guides/state-management.mdx
@@ -68,18 +68,9 @@ Here's an example that ties together all the concepts covered in the guides:
 def create_initial_node() -> NodeConfig:
     """Create the initial node of the flow.
 
-    Define the bot's role and task for the node as well as the function for it to call.
-    The function call includes a handler which provides the function call result to
-    Pipecat and then transitions to the next node.
+    Define the bot's role and task for the node, plus the function it can call.
+    The function provides its result to Pipecat and transitions to the next node.
     """
-    record_favorite_color_func = FlowsFunctionSchema(
-        name="record_favorite_color_func",
-        description="Record the color the user said is their favorite.",
-        required=["color"],
-        handler=record_favorite_color_and_set_next_node,
-        properties={"color": {"type": "string"}},
-    )
-
     return {
         "name": "initial",
         "role_message": "You are an inquisitive child. Use very simple language. Ask simple questions. You must ALWAYS use one of the available functions to progress the conversation. Your responses will be converted to audio. Avoid outputting special characters and emojis.",
@@ -89,6 +80,6 @@ def create_initial_node() -> NodeConfig:
                 "content": "Say 'Hello world' and ask what is the user's favorite color.",
             }
         ],
-        "functions": [record_favorite_color_func],
+        "functions": [record_favorite_color],
     }
 ```

--- a/pipecat-flows/guides/state-management.mdx
+++ b/pipecat-flows/guides/state-management.mdx
@@ -71,15 +71,15 @@ def create_initial_node() -> NodeConfig:
     Define the bot's role and task for the node, plus the function it can call.
     The function provides its result to Pipecat and transitions to the next node.
     """
-    return {
-        "name": "initial",
-        "role_message": "You are an inquisitive child. Use very simple language. Ask simple questions. You must ALWAYS use one of the available functions to progress the conversation. Your responses will be converted to audio. Avoid outputting special characters and emojis.",
-        "task_messages": [
+    return NodeConfig(
+        name="initial",
+        role_message="You are an inquisitive child. Use very simple language. Ask simple questions. You must ALWAYS use one of the available functions to progress the conversation. Your responses will be converted to audio. Avoid outputting special characters and emojis.",
+        task_messages=[
             {
                 "role": "developer",
                 "content": "Say 'Hello world' and ask what is the user's favorite color.",
             }
         ],
-        "functions": [record_favorite_color],
-    }
+        functions=[record_favorite_color],
+    )
 ```


### PR DESCRIPTION
## What

Pipecat Flows now favors **direct functions** over `FlowsFunctionSchema`-based tool definitions, with `FlowsFunctionSchema` kept as the explicit-schema option (for property control like `enum` / `minimum`/`maximum`). These docs reflect that shift, following the framing in the [base Pipecat function-calling guide](https://docs.pipecat.ai/pipecat/learn/function-calling).

It also reflects [pipecat-flows#283](https://github.com/pipecat-ai/pipecat-flows/pull/283), which made `FlowsFunctionSchema.handler` required.

## Changes

- **Functions guide** — leads with direct functions as the preferred way to define a function; `FlowsFunctionSchema` moved to an "Advanced" section for explicit schema control.
- **Quickstart & State Management guides** — examples define their function as a direct function.
- **Overview** — "Function Types" reframed (node vs. edge by return value); direct function as the normal definition.
- **FlowManager reference** — global-functions example uses a direct function.
- **Types reference** — `FlowsFunctionSchema.handler` marked required; decorator docs updated to `@flows_tool_options` (with `@flows_direct_function` noted as the deprecated alias).

## Follow-up

The quickstart's runnable example (`examples/quickstart/hello_world.py` in pipecat-flows) still uses `FlowsFunctionSchema`; a separate PR will switch it to a direct function to match this guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
