### PR TITLE
docs: fix broken RTVI link in System Frames reference

### DIFF
--- a/api-reference/server/frames/system-frames.mdx
+++ b/api-reference/server/frames/system-frames.mdx
@@ -398,7 +398,7 @@ Inherits from `ServiceMetadataFrame`.
 
 ## RTVI
 
-Frames for the [Real-Time Voice Interface (RTVI)](/api-reference/server/rtvi) protocol, which bridges clients and the pipeline. These frames handle custom messaging between the client and server.
+Frames for the [Real-Time Voice Interface (RTVI)](/api-reference/server/rtvi/introduction) protocol, which bridges clients and the pipeline. These frames handle custom messaging between the client and server.
 
 ### RTVIServerMessageFrame
 


### PR DESCRIPTION
## Problem

In `api-reference/server/frames/system-frames.mdx`, the RTVI link points to:

```
/api-reference/server/rtvi
```

That path has **no page and no redirect** — there's no `rtvi/index.mdx`, and `docs.json` has no redirect entry for it (unlike the other legacy `/server/...` paths, which do). So the link 404s. The actual section index lives at `/api-reference/server/rtvi/introduction`.

## Fix

Point the link at the real page:

```diff
-[Real-Time Voice Interface (RTVI)](/api-reference/server/rtvi)
+[Real-Time Voice Interface (RTVI)](/api-reference/server/rtvi/introduction)
```

## How I found it

Scanned all `.mdx` internal links against existing pages **and** the 437 `redirects` in `docs.json`. This was the only internal link with neither a target page nor a redirect — the other near-misses (`/server/events/service-events`, `/guides/fundamentals/service-settings`, etc.) are all covered by existing redirects, so they're left untouched.

Single-line change, no content/behavior impact.