### PR TITLE
docs: document custom sources in Context Hub reference

### DIFF
--- a/api-reference/context-hub.mdx
+++ b/api-reference/context-hub.mdx
@@ -36,6 +36,39 @@ If your project targets an older Pipecat version, pin the hub to it so results m
 uvx pipecat-ai-context-hub refresh --framework-version v0.0.96
 ```
 
+## Custom sources
+
+Point the hub at your own repositories with `PIPECAT_HUB_EXTRA_REPOS`, a comma-separated list of GitHub `org/repo` slugs. These are indexed alongside the default Pipecat repos, so your private code is searchable next to the framework. Set the variable, then run `refresh`:
+
+```bash
+PIPECAT_HUB_EXTRA_REPOS="your-org/your-repo,your-org/another-repo" \
+  uvx pipecat-ai-context-hub refresh
+```
+
+The hub also reads a `.env` file from the directory you run the command in, so you can keep the list there instead of exporting it each time:
+
+```bash
+# .env
+PIPECAT_HUB_EXTRA_REPOS="your-org/your-repo,your-org/another-repo"
+```
+
+Slugs that duplicate a default repo are deduped automatically, so it's harmless to leave them in. Your custom repos then surface through the same `search_*` and `get_*` tools as the framework.
+
+<Note>
+  Only Python (`.py`/`.pyi`), TypeScript (`.ts`/`.tsx`), and RST (`docs/**.rst`)
+  files are parsed into the searchable index. Other languages (for example
+  Swift, Kotlin, or C++ SDKs) are cloned but won't surface in `search_api` or
+  `get_code_snippet`.
+</Note>
+
+<Tip>
+  The hub clones with standard git, so private repos index fine as long as your
+  local git is already authenticated to GitHub — via an SSH key or a git
+  credential helper. The hub itself adds no token configuration. See the repo's
+  [`.env.example`](https://github.com/pipecat-ai/pipecat-context-hub/blob/main/.env.example)
+  for ready-made repo bundles.
+</Tip>
+
 ## Tools
 
 | Tool                | Use it to                                                                                            |


### PR DESCRIPTION
Add a Custom sources section explaining how to index your own repositories via PIPECAT_HUB_EXTRA_REPOS, the .env alternative, supported languages, and private-repo auth.