### PR TITLE
docs: update AssemblyAI STT for Universal 3.5 Pro Realtime

### DIFF
--- a/api-reference/server/services/stt/assemblyai.mdx
+++ b/api-reference/server/services/stt/assemblyai.mdx
@@ -23,18 +23,18 @@ description: "Speech-to-text service implementation using AssemblyAI's real-time
     Example with AssemblyAI built-in turn detection
   </Card>
   <Card
-    title="Universal-3 Pro Streaming"
+    title="Universal 3.5 Pro Realtime"
     icon="bolt"
     href="https://www.assemblyai.com/docs/streaming/universal-3-pro"
   >
-    U3 Pro streaming documentation and features
+    Universal 3.5 Pro Realtime documentation and features
   </Card>
   <Card
-    title="U3 Pro API Reference"
+    title="Universal 3.5 Pro Realtime API Reference"
     icon="book"
     href="https://www.assemblyai.com/docs/api-reference/streaming-api/universal-3-pro/universal-3-pro"
   >
-    Complete U3 Pro streaming API reference
+    Complete Universal 3.5 Pro Realtime API reference
   </Card>
   <Card
     title="AssemblyAI Console"
@@ -114,9 +114,10 @@ Before using AssemblyAI STT services, you need:
   AssemblyAI to return finals ASAP so Pipecat's turn detection (e.g., Smart
   Turn) decides when the user is done. VAD stop sends ForceEndpoint as ceiling.
   No UserStarted/StoppedSpeakingFrame emitted from STT. When `False` (AssemblyAI
-  turn detection mode, u3-rt-pro only): AssemblyAI's model controls turn endings
-  using built-in turn detection. Uses AssemblyAI API defaults for all parameters
-  unless explicitly set. Emits UserStarted/StoppedSpeakingFrame from STT.
+  turn detection mode, `universal-3-5-pro` only): AssemblyAI's model controls
+  turn endings using built-in turn detection. Uses AssemblyAI API defaults for
+  all parameters unless explicitly set. Emits UserStarted/StoppedSpeakingFrame
+  from STT.
 </ParamField>
 
 <ParamField path="should_interrupt" type="bool" default="True">
@@ -153,49 +154,49 @@ Before using AssemblyAI STT services, you need:
 
 Connection-level parameters previously passed via the `connection_params` constructor argument.
 
-| Parameter                                | Type        | Default       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| ---------------------------------------- | ----------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sample_rate`                            | `int`       | `16000`       | Audio sample rate in Hz.                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| `encoding`                               | `Literal`   | `"pcm_s16le"` | Audio encoding format. Options: `"pcm_s16le"`, `"pcm_mulaw"`.                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `end_of_turn_confidence_threshold`       | `float`     | `None`        | Confidence threshold for end-of-turn detection.                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `min_turn_silence`                       | `int`       | `None`        | Minimum silence duration (ms) when confident about end-of-turn.                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| `min_end_of_turn_silence_when_confident` | `int`       | `None`        | **DEPRECATED**. Use `min_turn_silence` instead. Will be removed in a future version.                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `max_turn_silence`                       | `int`       | `None`        | Maximum silence duration (ms) before forcing end-of-turn.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `keyterms_prompt`                        | `List[str]` | `None`        | List of key terms to guide transcription. Will be JSON serialized before sending.                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `prompt`                                 | `str`       | `None`        | **BETA**: Optional text prompt to guide transcription. Only used with U3 Pro models. Cannot be used with `keyterms_prompt`. We suggest starting with no prompt. See [AssemblyAI prompting best practices](https://www.assemblyai.com/docs/streaming/universal-3-pro/prompting) for guidance.                                                                                                                                                                                               |
-| `speech_model`                           | `Literal`   | `"universal-3-5-pro"` | **Required**. Speech model to use. Options: `"universal-streaming-english"`, `"universal-streaming-multilingual"`, `"u3-rt-pro"`, `"u3-rt-pro-beta-1"`, `"universal-3-5-pro"`. Defaults to `"universal-3-5-pro"` if not specified. The U3 Pro family (`u3-rt-pro`, `u3-rt-pro-beta-1`, `universal-3-5-pro`) supports built-in turn detection, prompting, continuous partials, context carryover, and voice focus.                                                                                 |
-| `language_detection`                     | `bool`      | `None`        | Enable automatic language detection. Only applicable to `universal-streaming-multilingual`. Turn messages include language information.                                                                                                                                                                                                                                                                                                                                                   |
-| `format_turns`                           | `bool`      | `True`        | Whether to format transcript turns. Only applicable to `universal-streaming-english` and `universal-streaming-multilingual` models. For `u3-rt-pro`, formatting is automatic and built-in.                                                                                                                                                                                                                                                                                                |
-| `speaker_labels`                         | `bool`      | `None`        | Enable speaker diarization. Final transcripts include a speaker field (e.g., "Speaker A", "Speaker B").                                                                                                                                                                                                                                                                                                                                                                                   |
-| `vad_threshold`                          | `float`     | `None`        | Voice activity detection confidence threshold. Only applicable to U3 Pro models. The confidence threshold (0.0 to 1.0) for classifying audio frames as silence. Frames with VAD confidence below this value are considered silent. Increase for noisy environments to reduce false speech detection. Defaults to 0.3 (API default). For best performance when using with external VAD (e.g., Silero), align this value with your VAD's activation threshold. Defaults to `None` (not sent). |
+| Parameter                                | Type        | Default               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| ---------------------------------------- | ----------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sample_rate`                            | `int`       | `16000`               | Audio sample rate in Hz.                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `encoding`                               | `Literal`   | `"pcm_s16le"`         | Audio encoding format. Options: `"pcm_s16le"`, `"pcm_mulaw"`.                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `end_of_turn_confidence_threshold`       | `float`     | `None`                | Confidence threshold for end-of-turn detection.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `min_turn_silence`                       | `int`       | `None`                | Minimum silence duration (ms) when confident about end-of-turn.                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `min_end_of_turn_silence_when_confident` | `int`       | `None`                | **DEPRECATED**. Use `min_turn_silence` instead. Will be removed in a future version.                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `max_turn_silence`                       | `int`       | `None`                | Maximum silence duration (ms) before forcing end-of-turn.                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `keyterms_prompt`                        | `List[str]` | `None`                | List of key terms to guide transcription. Will be JSON serialized before sending.                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `prompt`                                 | `str`       | `None`                | Optional text prompt to guide transcription. Only used with `universal-3-5-pro`. Cannot be used with `keyterms_prompt`. We suggest starting with no prompt. See [AssemblyAI prompting best practices](https://www.assemblyai.com/docs/streaming/universal-3-pro/prompting) for guidance.                                                                                                                                                                                                          |
+| `speech_model`                           | `Literal`   | `"universal-3-5-pro"` | **Required**. Speech model to use. Options: `"universal-streaming-english"`, `"universal-streaming-multilingual"`, `"universal-3-5-pro"`. Defaults to `"universal-3-5-pro"` if not specified. `universal-3-5-pro` supports built-in turn detection, prompting, continuous partials, context carryover, and voice focus.                                                                                                                                                                           |
+| `language_detection`                     | `bool`      | `None`                | Enable automatic language detection. Only applicable to `universal-streaming-multilingual`. Turn messages include language information.                                                                                                                                                                                                                                                                                                                                                           |
+| `format_turns`                           | `bool`      | `True`                | Whether to format transcript turns. Only applicable to `universal-streaming-english` and `universal-streaming-multilingual` models. For `universal-3-5-pro`, formatting is automatic and built-in.                                                                                                                                                                                                                                                                                                |
+| `speaker_labels`                         | `bool`      | `None`                | Enable speaker diarization. Final transcripts include a speaker field (e.g., "Speaker A", "Speaker B").                                                                                                                                                                                                                                                                                                                                                                                           |
+| `vad_threshold`                          | `float`     | `None`                | Voice activity detection confidence threshold. Only applicable to `universal-3-5-pro`. The confidence threshold (0.0 to 1.0) for classifying audio frames as silence. Frames with VAD confidence below this value are considered silent. Increase for noisy environments to reduce false speech detection. Defaults to 0.3 (API default). For best performance when using with external VAD (e.g., Silero), align this value with your VAD's activation threshold. Defaults to `None` (not sent). |
 
 ### Settings
 
 Runtime-configurable settings passed via the `settings` constructor argument using `AssemblyAISTTService.Settings(...)`. These can be updated mid-conversation with `STTUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter                          | Type                                   | Default       | Description                                                                                                                                                                              |
-| ---------------------------------- | -------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `model`                            | `str`                                  | `None`        | STT model identifier. _(Inherited from base STT settings.)_                                                                                                                              |
-| `language`                         | `Language \| str`                      | `Language.EN` | Language for speech recognition. _(Inherited from base STT settings.)_                                                                                                                   |
-| `formatted_finals`                 | `bool`                                 | `True`        | Whether to enable transcript formatting.                                                                                                                                                 |
-| `word_finalization_max_wait_time`  | `int`                                  | `None`        | Maximum time to wait for word finalization in milliseconds.                                                                                                                              |
-| `end_of_turn_confidence_threshold` | `float`                                | `None`        | Confidence threshold for end-of-turn detection.                                                                                                                                          |
-| `min_turn_silence`                 | `int`                                  | `None`        | Minimum silence duration (ms) when confident about end-of-turn.                                                                                                                          |
-| `max_turn_silence`                 | `int`                                  | `None`        | Maximum silence duration (ms) before forcing end-of-turn.                                                                                                                                |
-| `keyterms_prompt`                  | `List[str]`                            | `None`        | List of key terms to guide transcription.                                                                                                                                                |
-| `prompt`                           | `str`                                  | `None`        | Optional text prompt to guide transcription (U3 Pro only).                                                                                                                               |
-| `language_detection`               | `bool`                                 | `None`        | Enable automatic language detection.                                                                                                                                                     |
-| `format_turns`                     | `bool`                                 | `True`        | Whether to format transcript turns.                                                                                                                                                      |
-| `speaker_labels`                   | `bool`                                 | `None`        | Enable speaker diarization.                                                                                                                                                              |
-| `vad_threshold`                    | `float`                                | `None`        | VAD confidence threshold (0.0–1.0) for classifying audio frames as silence (U3 Pro only).                                                                                                |
-| `domain`                           | `str`                                  | `None`        | Optional domain for specialized recognition modes (e.g., `"medical-v1"` for Medical Mode).                                                                                               |
-| `continuous_partials`              | `bool`                                 | `True`        | Emit partial transcripts continuously during long turns (U3 Pro only).                                                                                                                   |
-| `interruption_delay`               | `int`                                  | `None`        | Override for how soon the first partial is emitted, in milliseconds (0–1000). U3 Pro only.                                                                                              |
-| `agent_context`                    | `str`                                  | `None`        | Context carryover seed — the agent's most recent spoken reply. Improves transcription of the user's next turn (U3 Pro only). Clipped to ~1500 characters.                               |
-| `previous_context_n_turns`         | `int`                                  | `None`        | Maximum prior conversation entries (0–100) carried forward as context. Set to 0 to disable context carryover (U3 Pro only). Defaults to server default (3).                             |
-| `voice_focus`                      | `Literal["near-field", "far-field"]`   | `None`        | Isolate primary voice and suppress background noise. Set to `"near-field"` for close mics or `"far-field"` for distant capture (U3 Pro only).                                           |
-| `voice_focus_threshold`            | `float`                                | `None`        | How aggressively background audio is suppressed (0.0–1.0). Only takes effect when `voice_focus` is set (U3 Pro only).                                                                   |
-| `mode`                             | `Literal["min_latency", "balanced", "max_accuracy"]` | `None`        | Latency/accuracy preset, trading transcription accuracy against turn-finalization latency (U3 Pro only). Server defaults to `"balanced"`.                               |
+| Parameter                          | Type                                                 | Default               | Description                                                                                                                                                              |
+| ---------------------------------- | ---------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `model`                            | `str`                                                | `"universal-3-5-pro"` | STT model identifier. _(Inherited from base STT settings.)_                                                                                                              |
+| `language`                         | `Language \| str`                                    | `Language.EN`         | Language for speech recognition. _(Inherited from base STT settings.)_                                                                                                   |
+| `formatted_finals`                 | `bool`                                               | `True`                | Whether to enable transcript formatting.                                                                                                                                 |
+| `word_finalization_max_wait_time`  | `int`                                                | `None`                | Maximum time to wait for word finalization in milliseconds.                                                                                                              |
+| `end_of_turn_confidence_threshold` | `float`                                              | `None`                | Confidence threshold for end-of-turn detection.                                                                                                                          |
+| `min_turn_silence`                 | `int`                                                | `None`                | Minimum silence duration (ms) when confident about end-of-turn.                                                                                                          |
+| `max_turn_silence`                 | `int`                                                | `None`                | Maximum silence duration (ms) before forcing end-of-turn.                                                                                                                |
+| `keyterms_prompt`                  | `List[str]`                                          | `None`                | List of key terms to guide transcription.                                                                                                                                |
+| `prompt`                           | `str`                                                | `None`                | Optional text prompt to guide transcription (`universal-3-5-pro` only).                                                                                                  |
+| `language_detection`               | `bool`                                               | `None`                | Enable automatic language detection.                                                                                                                                     |
+| `format_turns`                     | `bool`                                               | `True`                | Whether to format transcript turns.                                                                                                                                      |
+| `speaker_labels`                   | `bool`                                               | `None`                | Enable speaker diarization.                                                                                                                                              |
+| `vad_threshold`                    | `float`                                              | `None`                | VAD confidence threshold (0.0–1.0) for classifying audio frames as silence (`universal-3-5-pro` only).                                                                   |
+| `domain`                           | `str`                                                | `None`                | Optional domain for specialized recognition modes (e.g., `"medical-v1"` for Medical Mode).                                                                               |
+| `continuous_partials`              | `bool`                                               | `True`                | Emit partial transcripts continuously during long turns (`universal-3-5-pro` only).                                                                                      |
+| `interruption_delay`               | `int`                                                | `None`                | Override for how soon the first partial is emitted, in milliseconds (0–1000). `universal-3-5-pro` only.                                                                  |
+| `agent_context`                    | `str`                                                | `None`                | Context carryover seed — the agent's most recent spoken reply. Improves transcription of the user's next turn (`universal-3-5-pro` only). Clipped to ~1500 characters.   |
+| `previous_context_n_turns`         | `int`                                                | `None`                | Maximum prior conversation entries (0–100) carried forward as context. Set to 0 to disable context carryover (`universal-3-5-pro` only). Defaults to server default (3). |
+| `voice_focus`                      | `Literal["near-field", "far-field"]`                 | `None`                | Isolate primary voice and suppress background noise. Set to `"near-field"` for close mics or `"far-field"` for distant capture (`universal-3-5-pro` only).               |
+| `voice_focus_threshold`            | `float`                                              | `None`                | How aggressively background audio is suppressed (0.0–1.0). Only takes effect when `voice_focus` is set (`universal-3-5-pro` only).                                       |
+| `mode`                             | `Literal["min_latency", "balanced", "max_accuracy"]` | `None`                | Latency/accuracy preset, trading transcription accuracy against turn-finalization latency (`universal-3-5-pro` only). Server defaults to `"balanced"`.                   |
 
 ## Usage
 
@@ -225,7 +226,7 @@ stt = AssemblyAISTTService(
 
 ### With AssemblyAI Built-in Turn Detection
 
-AssemblyAI's u3-rt-pro model supports built-in turn detection for more natural conversation flow:
+AssemblyAI's `universal-3-5-pro` model supports built-in turn detection for more natural conversation flow:
 
 ```python
 from pipecat.services.assemblyai.stt import AssemblyAISTTService
@@ -259,7 +260,7 @@ stt = AssemblyAISTTService(
 
 ### With Context Carryover
 
-Context carryover (U3 Pro only) improves transcription by giving the model memory of recent conversation turns:
+Context carryover (`universal-3-5-pro` only) improves transcription by giving the model memory of recent conversation turns:
 
 ```python
 from pipecat.services.assemblyai.stt import AssemblyAISTTService
@@ -275,9 +276,51 @@ stt = AssemblyAISTTService(
 
 Context carryover helps with short answers, spelled-out entities (emails, IDs), and similar-sounding words. Set `previous_context_n_turns=0` to disable automatic carryover.
 
+#### How it works in Pipecat
+
+Carryover is driven by Pipecat's standard turn aggregation — you don't register an observer or call anything yourself:
+
+1. As the bot's reply streams, the **assistant context aggregator** (the second processor returned by `LLMContextAggregatorPair`) accumulates the spoken text for the turn.
+2. When the assistant turn ends, that aggregator broadcasts an `LLMContextAssistantTurnFrame` carrying the aggregated reply text, both upstream and downstream through the pipeline.
+3. The base `STTService` handles that frame and calls its `_process_assistant_turn()` hook. `AssemblyAISTTService` overrides the hook to forward the text to `update_agent_context()`, which sends an `UpdateConfiguration` message over the live AssemblyAI WebSocket — no reconnect.
+4. AssemblyAI folds that reply, alongside recent user transcripts, into its rolling carryover budget (~1500 characters) and uses it to transcribe the user's next turn.
+
+The hook is a no-op unless the model is `universal-3-5-pro` and `previous_context_n_turns` is non-zero.
+
+#### What your agent needs
+
+Nothing carryover-specific — as long as your pipeline already includes the standard context aggregators (nearly every Pipecat voice agent does). The `assistant_aggregator` placed at the end of the pipeline is what emits the turn frame that drives carryover:
+
+```python
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair
+
+context = LLMContext()
+user_aggregator, assistant_aggregator = LLMContextAggregatorPair(context)
+
+pipeline = Pipeline(
+    [
+        transport.input(),
+        stt,  # AssemblyAISTTService(settings=...Settings(model="universal-3-5-pro"))
+        user_aggregator,
+        llm,
+        tts,
+        transport.output(),
+        assistant_aggregator,  # emits LLMContextAssistantTurnFrame → drives carryover
+    ]
+)
+```
+
+For finer control:
+
+- **Seed the opening line** with `agent_context=` so the first user turn benefits before any bot reply has streamed (e.g. a fixed greeting).
+- **Update manually** with `await stt.update_agent_context(text)` when what the bot actually said differs from the LLM context text (dynamic TTS, an interrupted reply).
+- **Tune the window** with `previous_context_n_turns` (`0` disables carryover; the server default is 3).
+
 ### With Voice Focus
 
-Voice focus (U3 Pro only) isolates the primary speaker and suppresses background noise:
+Voice focus (`universal-3-5-pro` only) isolates the primary speaker and suppresses background noise:
 
 ```python
 from pipecat.services.assemblyai.stt import AssemblyAISTTService
@@ -301,7 +344,7 @@ Use `"near-field"` for close-talking mics (headsets, handsets) or `"far-field"` 
 async def update_agent_context(text: str)
 ```
 
-Send the agent's latest spoken reply to AssemblyAI as carryover context (U3 Pro only). Improves transcription of the user's next turn — short answers, spelled-out entities, disambiguation. No-op for non-U3 Pro models.
+Send the agent's latest spoken reply to AssemblyAI as carryover context (`universal-3-5-pro` only). Improves transcription of the user's next turn — short answers, spelled-out entities, disambiguation. No-op for other models.
 
 **Parameters:**
 
@@ -318,15 +361,15 @@ await stt.update_agent_context("Your order total is $42.50.")
 
 ## Notes
 
-- **U3 Pro models**: The default model is `universal-3-5-pro`. The U3 Pro family includes `u3-rt-pro`, `u3-rt-pro-beta-1`, and `universal-3-5-pro`, all supporting built-in turn detection, prompting, continuous partials, context carryover, and voice focus.
+- **Model**: The default model is `universal-3-5-pro`, AssemblyAI's flagship streaming model. It supports built-in turn detection, prompting, continuous partials, context carryover, and voice focus. The `universal-streaming-english` and `universal-streaming-multilingual` models are also available for English-only and multilingual (with language detection) use cases.
 - **Turn detection modes**:
   - **Pipecat mode** (`vad_force_turn_endpoint=True`, default): Forces AssemblyAI to return finals ASAP so Pipecat's turn detection (e.g., Smart Turn) decides when the user is done. The service sends a `ForceEndpoint` message when VAD detects the user has stopped speaking.
-  - **AssemblyAI mode** (`vad_force_turn_endpoint=False`, U3 Pro only): AssemblyAI's model controls turn endings using built-in turn detection. The service emits `UserStartedSpeakingFrame` and `UserStoppedSpeakingFrame` based on AssemblyAI's detection.
-- **Context carryover** (U3 Pro only): Seed the agent's most recent reply, improving transcription of the user's next turn — short answers, spelled-out entities, disambiguation. `update_agent_context()` is automatically invoked each time an assistant turn is completed. Control the window size with `previous_context_n_turns` (0–100, default 3); set to 0 to disable carryover entirely.
-- **Voice focus** (U3 Pro only): Set `voice_focus` to `"near-field"` or `"far-field"` to isolate the primary voice and suppress background noise. Tune suppression strength with `voice_focus_threshold` (0.0–1.0, higher values suppress more).
+  - **AssemblyAI mode** (`vad_force_turn_endpoint=False`, `universal-3-5-pro` only): AssemblyAI's model controls turn endings using built-in turn detection. The service emits `UserStartedSpeakingFrame` and `UserStoppedSpeakingFrame` based on AssemblyAI's detection.
+- **Context carryover** (`universal-3-5-pro` only): Seed the agent's most recent reply, improving transcription of the user's next turn — short answers, spelled-out entities, disambiguation. `update_agent_context()` is automatically invoked each time an assistant turn is completed. Control the window size with `previous_context_n_turns` (0–100, default 3); set to 0 to disable carryover entirely.
+- **Voice focus** (`universal-3-5-pro` only): Set `voice_focus` to `"near-field"` or `"far-field"` to isolate the primary voice and suppress background noise. Tune suppression strength with `voice_focus_threshold` (0.0–1.0, higher values suppress more).
 - **Speaker diarization**: Enable `speaker_labels=True` in Settings to automatically identify different speakers. Final transcripts will include a speaker field (e.g., "Speaker A", "Speaker B"). Use the `speaker_format` parameter to format transcripts with speaker labels.
 - **Language detection**: When using `universal-streaming-multilingual` with `language_detection=True`, Turn messages include `language_code` and `language_confidence` fields for automatic language detection.
-- **Prompting**: The `prompt` parameter (U3 Pro only) allows you to guide transcription for specific names, terms, or domain vocabulary. This is a beta feature - AssemblyAI recommends testing without a prompt first. Cannot be used with `keyterms_prompt`.
+- **Prompting**: The `prompt` parameter (`universal-3-5-pro` only) allows you to guide transcription for specific names, terms, or domain vocabulary. AssemblyAI recommends testing without a prompt first. Cannot be used with `keyterms_prompt`.
 - **Dynamic settings updates**: Most settings can be updated at runtime using `STTUpdateSettingsFrame`. `agent_context` is hot-updatable without reconnecting; other settings require a reconnect.
 
 <Tip>

--- a/api-reference/server/services/stt/assemblyai.mdx
+++ b/api-reference/server/services/stt/assemblyai.mdx
@@ -276,48 +276,6 @@ stt = AssemblyAISTTService(
 
 Context carryover helps with short answers, spelled-out entities (emails, IDs), and similar-sounding words. Set `previous_context_n_turns=0` to disable automatic carryover.
 
-#### How it works in Pipecat
-
-Carryover is driven by Pipecat's standard turn aggregation — you don't register an observer or call anything yourself:
-
-1. As the bot's reply streams, the **assistant context aggregator** (the second processor returned by `LLMContextAggregatorPair`) accumulates the spoken text for the turn.
-2. When the assistant turn ends, that aggregator broadcasts an `LLMContextAssistantTurnFrame` carrying the aggregated reply text, both upstream and downstream through the pipeline.
-3. The base `STTService` handles that frame and calls its `_process_assistant_turn()` hook. `AssemblyAISTTService` overrides the hook to forward the text to `update_agent_context()`, which sends an `UpdateConfiguration` message over the live AssemblyAI WebSocket — no reconnect.
-4. AssemblyAI folds that reply, alongside recent user transcripts, into its rolling carryover budget (~1500 characters) and uses it to transcribe the user's next turn.
-
-The hook is a no-op unless the model is `universal-3-5-pro` and `previous_context_n_turns` is non-zero.
-
-#### What your agent needs
-
-Nothing carryover-specific — as long as your pipeline already includes the standard context aggregators (nearly every Pipecat voice agent does). The `assistant_aggregator` placed at the end of the pipeline is what emits the turn frame that drives carryover:
-
-```python
-from pipecat.pipeline.pipeline import Pipeline
-from pipecat.processors.aggregators.llm_context import LLMContext
-from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair
-
-context = LLMContext()
-user_aggregator, assistant_aggregator = LLMContextAggregatorPair(context)
-
-pipeline = Pipeline(
-    [
-        transport.input(),
-        stt,  # AssemblyAISTTService(settings=...Settings(model="universal-3-5-pro"))
-        user_aggregator,
-        llm,
-        tts,
-        transport.output(),
-        assistant_aggregator,  # emits LLMContextAssistantTurnFrame → drives carryover
-    ]
-)
-```
-
-For finer control:
-
-- **Seed the opening line** with `agent_context=` so the first user turn benefits before any bot reply has streamed (e.g. a fixed greeting).
-- **Update manually** with `await stt.update_agent_context(text)` when what the bot actually said differs from the LLM context text (dynamic TTS, an interrupted reply).
-- **Tune the window** with `previous_context_n_turns` (`0` disables carryover; the server default is 3).
-
 ### With Voice Focus
 
 Voice focus (`universal-3-5-pro` only) isolates the primary speaker and suppresses background noise:


### PR DESCRIPTION
Aligns the AssemblyAI STT reference page with the Universal 3.5 Pro Realtime branding and feature set.

## Changes

- **Rebrand cards** — "Universal-3 Pro Streaming" / "U3 Pro API Reference" → "Universal 3.5 Pro Realtime" / "Universal 3.5 Pro Realtime API Reference" (descriptions updated to match).
- **Terminology** — replaced all `u3-rt-pro` / "U3 Pro" references with `universal-3-5-pro` throughout (param fields, both tables, usage examples, methods, and Notes).
- **`speech_model`** — trimmed options to `universal-3-5-pro` and removed the **BETA** tag on `prompt`.
- **Settings** — `model` default `None` → `"universal-3-5-pro"`.
- **Context carryover** — expanded with "How it works in Pipecat" and "What your agent needs" subsections.
- Kept the `mode` Settings row (verified as a current parameter in `pipecat/src/pipecat/services/assemblyai/stt.py`), with its annotation rebranded.

## Verification

- `mint broken-links` — clean.
- `npx prettier --write` — applied (tables re-aligned).
- Previewed locally via `mint dev`.