### PR TITLE
docs: fill gaps surfaced by top-questions analysis

### DIFF
--- a/api-reference/server/services/transport/daily.mdx
+++ b/api-reference/server/services/transport/daily.mdx
@@ -301,7 +301,7 @@ transport = DailyTransport(
 )
 ```
 
-With this enabled, Daily runs transcription server-side and the transport pushes `TranscriptionFrame`s into the pipeline. **You do not add a separate STT service** (no `DeepgramSTTService`, etc.) — the transport fills that role. Your bot receives the same transcriptions in-call participants see, and you can also handle them directly via the [`on_transcription_message`](#on-transcription-message) event.
+With this enabled, Daily runs transcription server-side and the transport pushes `TranscriptionFrame`s into the pipeline. **You do not add a separate STT service** (no `DeepgramSTTService`, etc.) — the transport fills that role. Your bot receives the same transcriptions in-call participants see, and you can also handle them directly via the [`on_transcription_message`](#on_transcription_message) event.
 
 When to use this versus a dedicated STT service:
 

--- a/api-reference/server/services/transport/daily.mdx
+++ b/api-reference/server/services/transport/daily.mdx
@@ -283,7 +283,11 @@ See the [complete example](https://github.com/pipecat-ai/pipecat/blob/main/examp
 Daily can transcribe the call for you (powered by Deepgram) instead of you adding a dedicated STT service to the pipeline. Set `transcription_enabled=True` on `DailyParams`:
 
 ```python
-from pipecat.transports.daily import DailyTransport, DailyParams, DailyTranscriptionSettings
+from pipecat.transports.daily.transport import (
+    DailyTransport,
+    DailyParams,
+    DailyTranscriptionSettings,
+)
 
 transport = DailyTransport(
     room_url,
@@ -295,7 +299,7 @@ transport = DailyTransport(
         transcription_enabled=True,
         transcription_settings=DailyTranscriptionSettings(
             language="en",
-            model="nova-2-general",
+            model="nova-3-general",
         ),
     ),
 )
@@ -309,8 +313,8 @@ When to use this versus a dedicated STT service:
 - **Dedicated STT service in the pipeline**: full control over provider, model, and settings, billed on your own provider account. This is what most Pipecat examples use. See [Speech to Text](/pipecat/learn/speech-to-text).
 
 <Warning>
-  Don't do both for the same audio. Enabling `transcription_enabled` **and**
-  adding an STT processor transcribes the same audio twice and bills it twice.
+  Only enable one STT service. Enabling `transcription_enabled` **and** adding
+  an STT processor will transcribe the same audio twice and bill you twice.
 </Warning>
 
 ### Screen Audio Destination

--- a/api-reference/server/services/transport/daily.mdx
+++ b/api-reference/server/services/transport/daily.mdx
@@ -278,6 +278,41 @@ See the [complete example](https://github.com/pipecat-ai/pipecat/blob/main/examp
 
 ## Notes
 
+### Using built-in transcription
+
+Daily can transcribe the call for you (powered by Deepgram) instead of you adding a dedicated STT service to the pipeline. Set `transcription_enabled=True` on `DailyParams`:
+
+```python
+from pipecat.transports.daily import DailyTransport, DailyParams, DailyTranscriptionSettings
+
+transport = DailyTransport(
+    room_url,
+    token,
+    "Voice Bot",
+    DailyParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        transcription_enabled=True,
+        transcription_settings=DailyTranscriptionSettings(
+            language="en",
+            model="nova-2-general",
+        ),
+    ),
+)
+```
+
+With this enabled, Daily runs transcription server-side and the transport pushes `TranscriptionFrame`s into the pipeline. **You do not add a separate STT service** (no `DeepgramSTTService`, etc.) — the transport fills that role. Your bot receives the same transcriptions in-call participants see, and you can also handle them directly via the [`on_transcription_message`](#on-transcription-message) event.
+
+When to use this versus a dedicated STT service:
+
+- **Built-in (`transcription_enabled=True`)**: one less service to wire up. Billed by Daily per participant-minute, separate from your own Deepgram key. Less control over provider and tuning.
+- **Dedicated STT service in the pipeline**: full control over provider, model, and settings, billed on your own provider account. This is what most Pipecat examples use. See [Speech to Text](/pipecat/learn/speech-to-text).
+
+<Warning>
+  Don't do both for the same audio. Enabling `transcription_enabled` **and**
+  adding an STT processor transcribes the same audio twice and bills it twice.
+</Warning>
+
 ### Screen Audio Destination
 
 DailyTransport includes built-in support for Daily's `screenAudio` destination. When `"screenAudio"` is included in the `audio_out_destinations` parameter, a dedicated screen audio track is automatically created at join time:

--- a/pipecat-cloud/fundamentals/active-sessions.mdx
+++ b/pipecat-cloud/fundamentals/active-sessions.mdx
@@ -65,6 +65,13 @@ async with aiohttp.ClientSession() as session:
 
 </CodeGroup>
 
+<Tip>
+  `createDailyRoom: true` makes Pipecat Cloud create a Daily room and hand it to
+  the bot. To start a bot in a Daily room you **already created**, pass the room
+  URL and token in `body` instead — see [Joining an existing Daily
+  room](/pipecat-cloud/guides/daily-webrtc#joining-an-existing-daily-room).
+</Tip>
+
 ### Using Python
 
 The Pipecat Cloud Python library (`uv add pipecatcloud`) provides helper methods to start a session with your agent:

--- a/pipecat-cloud/guides/daily-webrtc.mdx
+++ b/pipecat-cloud/guides/daily-webrtc.mdx
@@ -91,6 +91,77 @@ The response includes `dailyRoom` (URL) and `dailyToken` fields that can be used
   </Tab>
 </Tabs>
 
+### Joining an existing Daily room
+
+`createDailyRoom: true` tells Pipecat Cloud to create a room for you and hand the bot the room URL and token automatically. If you already created a room yourself (for example, with the [Daily REST API](https://docs.daily.co/reference/rest-api/rooms) using your own Daily API key), you join it instead by **passing the room URL and token in the `body`** of the start request.
+
+The `/start` endpoint has no top-level parameter for an existing room. `createDailyRoom`, `dailyRoomProperties`, and `dailyMeetingTokenProperties` only apply when the platform creates the room. So for an existing room, leave `createDailyRoom` out (it defaults to `false`) and put the room details in `body`:
+
+<Tabs>
+  <Tab title="REST API">
+
+```bash
+curl --location --request POST 'https://api.pipecat.daily.co/v1/public/my-agent-name/start' \
+  --header 'Authorization: Bearer YOUR_API_KEY' \
+  --header 'Content-Type: application/json' \
+  --data-raw '{
+    "body": {
+      "room_url": "https://your-domain.daily.co/your-room",
+      "token": "your-meeting-token"
+    }
+  }'
+```
+
+  </Tab>
+
+  <Tab title="Python SDK">
+
+```python
+from pipecatcloud import Session, SessionParams
+
+session = Session(
+    agent_name="my-agent",
+    api_key="pk_...",
+    params=SessionParams(
+        # Don't set use_daily — you're supplying the room yourself
+        data={
+            "room_url": "https://your-domain.daily.co/your-room",
+            "token": "your-meeting-token",
+        },
+    ),
+)
+response = await session.start()
+```
+
+  </Tab>
+</Tabs>
+
+In your `bot.py`, read the room details from `args.body` and build the transport yourself:
+
+```python
+from pipecat.runner.types import PipecatRunnerArguments
+from pipecat.transports.daily import DailyParams, DailyTransport
+
+async def bot(args: PipecatRunnerArguments):
+    room_url = args.body["room_url"]
+    token = args.body["token"]
+
+    transport = DailyTransport(
+        room_url,
+        token,
+        "Voice Bot",
+        DailyParams(audio_in_enabled=True, audio_out_enabled=True),
+    )
+    # ... build and run your pipeline
+```
+
+<Warning>
+  `args.room_url` and `args.token` (on `DailyRunnerArguments`) are populated
+  **only when Pipecat Cloud creates the room** via `createDailyRoom: true`. When
+  you bring your own room, those fields are empty — read the values from
+  `args.body` instead, as shown above.
+</Warning>
+
 ### Using Your Own Daily API Key
 
 While Pipecat Cloud provides a Daily API key with included 1:1 voice minutes, you can optionally use your own Daily API key if you have specific requirements. When using your own key, all usage will be billed according to your Daily account's pricing plan rather than being included with your Pipecat Cloud subscription.

--- a/pipecat-cloud/guides/daily-webrtc.mdx
+++ b/pipecat-cloud/guides/daily-webrtc.mdx
@@ -139,10 +139,10 @@ response = await session.start()
 In your `bot.py`, read the room details from `args.body` and build the transport yourself:
 
 ```python
-from pipecat.runner.types import PipecatRunnerArguments
-from pipecat.transports.daily import DailyParams, DailyTransport
+from pipecat.runner.types import RunnerArguments
+from pipecat.transports.daily.transport import DailyParams, DailyTransport
 
-async def bot(args: PipecatRunnerArguments):
+async def bot(args: RunnerArguments):
     room_url = args.body["room_url"]
     token = args.body["token"]
 

--- a/pipecat-cloud/guides/telephony/daily-dial-out.mdx
+++ b/pipecat-cloud/guides/telephony/daily-dial-out.mdx
@@ -102,17 +102,16 @@ Here are various configurations you can use in the `dialout_settings` array:
 
 Most dial-out failures come from the room or the Daily account not being set up for outbound calls. The error text tells you which:
 
-| Error | Cause | Fix |
-| --- | --- | --- |
-| `dial-out not enabled for room. add enable_dialout property to room` | The room was created without `enable_dialout`. | Set `"enable_dialout": true` in `dailyRoomProperties` when you start the session (see above). It must be set at room creation. |
-| `property 'enable_dialout' cannot be set to that value with your current plan` | The Daily account behind your `DAILY_API_KEY` doesn't have dial-out enabled. | Dial-out is a paid feature. Confirm you're using the key for a pay-as-you-go Daily account with telephony enabled, then [contact sales](https://www.daily.co/contact/sales) to enable it. Pipecat Cloud billing is separate from Daily telephony capability. |
-| `International dialout not supported. Contact sales to enable it for your domain` | The destination is a different country from your account's allowed region, and international dial-out is gated. | [Contact sales](https://www.daily.co/contact/sales) to enable international dial-out for your domain. |
+| Error                                                                             | Cause                                                            | Fix                                                                                                                       |
+| --------------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `dial-out not enabled for room. add enable_dialout property to room`              | The room was created without `enable_dialout`.                  | Set `"enable_dialout": true` in `dailyRoomProperties` at room creation (see above).                                       |
+| `property 'enable_dialout' cannot be set to that value with your current plan`    | The Daily account behind your key doesn't have dial-out.        | Dial-out is a paid Daily feature. Use a pay-as-you-go Daily key and [contact sales](https://www.daily.co/contact/sales).  |
+| `International dialout not supported. Contact sales to enable it for your domain` | International dial-out is gated for your account's domain.       | [Contact sales](https://www.daily.co/contact/sales) to enable international dial-out for your domain.                     |
 
 <Note>
-  If you use the Pipecat Cloud-provisioned Daily key, dial-out enablement and
-  plan limits apply to that integrated Daily account. If you bring your own
-  Daily key, they apply to the account that key belongs to — make sure it's the
-  account you actually enabled telephony on.
+  Dial-out enablement and plan limits apply to whichever Daily account owns the
+  key in use — the Pipecat Cloud-provisioned one, or your own if you bring a key.
+  Make sure telephony is enabled on that account.
 </Note>
 
 ## Next Steps

--- a/pipecat-cloud/guides/telephony/daily-dial-out.mdx
+++ b/pipecat-cloud/guides/telephony/daily-dial-out.mdx
@@ -98,6 +98,23 @@ Here are various configurations you can use in the `dialout_settings` array:
 
 </CodeGroup>
 
+## Troubleshooting
+
+Most dial-out failures come from the room or the Daily account not being set up for outbound calls. The error text tells you which:
+
+| Error | Cause | Fix |
+| --- | --- | --- |
+| `dial-out not enabled for room. add enable_dialout property to room` | The room was created without `enable_dialout`. | Set `"enable_dialout": true` in `dailyRoomProperties` when you start the session (see above). It must be set at room creation. |
+| `property 'enable_dialout' cannot be set to that value with your current plan` | The Daily account behind your `DAILY_API_KEY` doesn't have dial-out enabled. | Dial-out is a paid feature. Confirm you're using the key for a pay-as-you-go Daily account with telephony enabled, then [contact sales](https://www.daily.co/contact/sales) to enable it. Pipecat Cloud billing is separate from Daily telephony capability. |
+| `International dialout not supported. Contact sales to enable it for your domain` | The destination is a different country from your account's allowed region, and international dial-out is gated. | [Contact sales](https://www.daily.co/contact/sales) to enable international dial-out for your domain. |
+
+<Note>
+  If you use the Pipecat Cloud-provisioned Daily key, dial-out enablement and
+  plan limits apply to that integrated Daily account. If you bring your own
+  Daily key, they apply to the account that key belongs to — make sure it's the
+  account you actually enabled telephony on.
+</Note>
+
 ## Next Steps
 
 After configuring your dial-out functionality, you can implement a Pipecat bot to handle the call interactions:

--- a/pipecat-flows/introduction.mdx
+++ b/pipecat-flows/introduction.mdx
@@ -21,6 +21,24 @@ Pipecat Flows is best suited for use cases where:
 
 **Pipecat Flows** complements Pipecat by providing structure to a conversation, managing context and tools as the conversation progresses from one state to another. This is separate from the core pipeline, allowing you to separate conversation logic from pipeline mechanics.
 
+<Warning>
+  **Pipecat Flows needs a text LLM that supports function calling** — use it
+  with a cascaded **STT → LLM → TTS** pipeline (OpenAI, Anthropic, Google
+  Gemini, AWS Bedrock, or any OpenAI-compatible service).
+
+  **Speech-to-speech (realtime) models are not supported**: Gemini Live, OpenAI
+  Realtime, Ultravox, and AWS Nova Sonic don't work with Flows. To move between
+  nodes, Flows rewrites the LLM's context and tools mid-session, and these
+  realtime APIs don't yet expose the controls needed to do that. This is a known
+  limitation tracked upstream — it will be enabled once the realtime APIs
+  support it.
+
+  If you want a graph-of-nodes structure with a realtime model today, you'll
+  need to build that logic yourself with function calling rather than using
+  Pipecat Flows. See the [supported providers
+  table](/api-reference/pipecat-flows/overview#llm-provider-support).
+</Warning>
+
 ## Installation
 
 ```bash

--- a/pipecat-flows/introduction.mdx
+++ b/pipecat-flows/introduction.mdx
@@ -22,20 +22,16 @@ Pipecat Flows is best suited for use cases where:
 **Pipecat Flows** complements Pipecat by providing structure to a conversation, managing context and tools as the conversation progresses from one state to another. This is separate from the core pipeline, allowing you to separate conversation logic from pipeline mechanics.
 
 <Warning>
-  **Pipecat Flows needs a text LLM that supports function calling** — use it
-  with a cascaded **STT → LLM → TTS** pipeline (OpenAI, Anthropic, Google
-  Gemini, AWS Bedrock, or any OpenAI-compatible service).
+  **Pipecat Flows needs a text LLM that supports function calling** — use a
+  cascaded **STT → LLM → TTS** pipeline (OpenAI, Anthropic, Google Gemini, AWS
+  Bedrock, or any OpenAI-compatible service).
 
-  **Speech-to-speech (realtime) models are not supported**: Gemini Live, OpenAI
-  Realtime, Ultravox, and AWS Nova Sonic don't work with Flows. To move between
-  nodes, Flows rewrites the LLM's context and tools mid-session, and these
-  realtime APIs don't yet expose the controls needed to do that. This is a known
-  limitation tracked upstream — it will be enabled once the realtime APIs
-  support it.
-
-  If you want a graph-of-nodes structure with a realtime model today, you'll
-  need to build that logic yourself with function calling rather than using
-  Pipecat Flows. See the [supported providers
+  **Speech-to-speech (realtime) models aren't supported** — Gemini Live, OpenAI
+  Realtime, Ultravox, and AWS Nova Sonic. Flows moves between nodes by rewriting
+  the LLM's context and tools mid-session, and these realtime APIs don't yet
+  expose the controls to do that (a known limitation, tracked upstream). To get
+  a graph-of-nodes structure with a realtime model today, build it yourself with
+  function calling instead. See the [supported providers
   table](/api-reference/pipecat-flows/overview#llm-provider-support).
 </Warning>
 

--- a/pipecat/learn/speech-to-text.mdx
+++ b/pipecat/learn/speech-to-text.mdx
@@ -52,6 +52,22 @@ Pipecat provides two types of STT services based on how they process audio:
   needs.
 </Note>
 
+## Dedicated STT service vs. transport-provided transcription
+
+There are two ways to get transcriptions into your pipeline:
+
+1. **A dedicated STT service** (the approach on this page). You add an STT processor like `DeepgramSTTService` to the pipeline. It runs on the user's audio frames and emits `TranscriptionFrame`s. You bring your own provider API key, pick the model, and control every setting.
+
+2. **Transport-provided transcription.** Some transports can transcribe for you and push transcription frames into the pipeline directly, so you don't add an STT processor at all. The clearest example is Daily: set [`transcription_enabled=True`](/api-reference/server/services/transport/daily#using-built-in-transcription) on `DailyParams` and Daily runs Deepgram server-side. Your bot receives the same transcriptions in-call participants see.
+
+**Which should you use?** A dedicated STT service is the default for most bots: it gives you full control over the provider, model, and tuning, and keeps STT cost on your own provider account. Use transport-provided transcription when you want one less service to wire up and are fine with the transport's provider and billing. With Daily, transcription is billed by Daily per participant-minute, separate from your own Deepgram key. Don't enable both at once for the same audio.
+
+<Note>
+  Don't add a dedicated STT service **and** set `transcription_enabled=True` on
+  the same transport. Pick one, or you'll process the same audio twice and pay
+  for it twice.
+</Note>
+
 ## Supported STT Services
 
 Pipecat supports a wide range of STT providers to fit different needs and budgets:

--- a/pipecat/learn/speech-to-text.mdx
+++ b/pipecat/learn/speech-to-text.mdx
@@ -52,22 +52,6 @@ Pipecat provides two types of STT services based on how they process audio:
   needs.
 </Note>
 
-## Dedicated STT service vs. transport-provided transcription
-
-There are two ways to get transcriptions into your pipeline:
-
-1. **A dedicated STT service** (the approach on this page). You add an STT processor like `DeepgramSTTService` to the pipeline. It runs on the user's audio frames and emits `TranscriptionFrame`s. You bring your own provider API key, pick the model, and control every setting.
-
-2. **Transport-provided transcription.** Some transports can transcribe for you and push transcription frames into the pipeline directly, so you don't add an STT processor at all. The clearest example is Daily: set [`transcription_enabled=True`](/api-reference/server/services/transport/daily#using-built-in-transcription) on `DailyParams` and Daily runs Deepgram server-side. Your bot receives the same transcriptions in-call participants see.
-
-**Which should you use?** A dedicated STT service is the default for most bots: it gives you full control over the provider, model, and tuning, and keeps STT cost on your own provider account. Use transport-provided transcription when you want one less service to wire up and are fine with the transport's provider and billing. With Daily, transcription is billed by Daily per participant-minute, separate from your own Deepgram key. Don't enable both at once for the same audio.
-
-<Note>
-  Don't add a dedicated STT service **and** set `transcription_enabled=True` on
-  the same transport. Pick one, or you'll process the same audio twice and pay
-  for it twice.
-</Note>
-
 ## Supported STT Services
 
 Pipecat supports a wide range of STT providers to fit different needs and budgets:

--- a/pipecat/telephony/daily-pstn.mdx
+++ b/pipecat/telephony/daily-pstn.mdx
@@ -402,8 +402,8 @@ A warm transfer connects the caller to a human specialist after the bot briefs t
 2. **Caller asks for a specialist.** The bot calls an `initiate_warm_transfer` LLM function with the target and a short summary of the caller's issue.
 3. **Bot puts the caller on hold** — it plays a hold message, enables hold music, and gates the caller's audio so they don't hear the briefing.
 4. **Bot dials the specialist** with `start_dialout`.
-5. **Specialist answers** (`on_dialout_answered`). The bot takes the caller off hold and briefs the specialist (the caller hears this too).
-6. **Everyone is connected.** The bot stays in the room, bridging the audio.
+5. **Specialist answers** (`on_dialout_answered`). The bot briefs the specialist while the caller remains on hold.
+6. **Everyone is connected.** The bot takes the caller off hold and stays in the room, bridging the audio.
 7. **Call ends** when the specialist hangs up after a successful connection, or when a participant leaves — the bot ends its own session with an `EndWorkerFrame`.
 
 ### Room configuration

--- a/pipecat/telephony/daily-pstn.mdx
+++ b/pipecat/telephony/daily-pstn.mdx
@@ -328,15 +328,12 @@ Daily supports two transfer patterns:
 - **Warm transfer** — the bot stays on the call, dials a specialist, briefs them while the caller is on hold, then bridges everyone together.
 
 <Note>
-  Choose the pattern by who needs to stay connected. In a warm transfer the
-  **bot stays in the room as the audio bridge for the whole call** — this is
-  deliberate. When the bot (the room owner) leaves, the Daily room terminates
-  and any remaining PSTN legs are dropped. There is no first-class "bot leaves,
-  the two callers keep talking in the room" mode: a room's
-  `max_idle_timeout_sec` only holds a bot-less room open for a fixed countdown,
-  not until the humans hang up. So for caller-to-human handoffs where both
-  parties stay on Daily, keep the bot in the room (warm transfer). To remove the
-  bot entirely, transfer the caller off Daily with a cold transfer (SIP REFER).
+  The bot is the room owner, so when it leaves, the Daily room terminates and any
+  remaining PSTN legs drop — there's no "bot leaves, the two callers keep talking"
+  mode (`max_idle_timeout_sec` only holds a bot-less room open for a fixed
+  countdown). To keep a caller and a human on Daily together, use a warm transfer
+  (the bot stays as the bridge); to drop the bot entirely, use a cold transfer
+  off Daily via SIP REFER.
 </Note>
 
 ## Cold transfer
@@ -394,7 +391,7 @@ async def on_dialout_answered(transport, data):
 
 ## Warm transfer
 
-A warm transfer connects the caller to a human specialist after the bot briefs that specialist on the call. Unlike a cold transfer, **the bot stays in the room for the entire call and acts as the audio bridge** between the caller and the specialist. Because the bot never leaves, the room stays alive naturally — you don't need any room-lifecycle configuration.
+A warm transfer connects the caller to a human specialist after the bot briefs that specialist on the call. Unlike a cold transfer, **the bot stays in the room for the entire call and acts as the audio bridge** between the caller and the specialist.
 
 ### How warm transfer works
 

--- a/pipecat/telephony/daily-pstn.mdx
+++ b/pipecat/telephony/daily-pstn.mdx
@@ -322,9 +322,28 @@ To test dial-out functionality:
 
 ## Call Transfers
 
-Daily supports cold transfers, allowing you to transfer an active call to another phone number. The bot can initiate a transfer and then leave the call, connecting the caller directly to the transfer destination.
+Daily supports two transfer patterns:
 
-### How Call Transfers Work
+- **Cold transfer** — the bot hands the caller off to another number and leaves. The caller is connected directly to the destination; the bot is no longer involved.
+- **Warm transfer** — the bot stays on the call, dials a specialist, briefs them while the caller is on hold, then bridges everyone together.
+
+<Note>
+  Choose the pattern by who needs to stay connected. In a warm transfer the
+  **bot stays in the room as the audio bridge for the whole call** — this is
+  deliberate. When the bot (the room owner) leaves, the Daily room terminates
+  and any remaining PSTN legs are dropped. There is no first-class "bot leaves,
+  the two callers keep talking in the room" mode: a room's
+  `max_idle_timeout_sec` only holds a bot-less room open for a fixed countdown,
+  not until the humans hang up. So for caller-to-human handoffs where both
+  parties stay on Daily, keep the bot in the room (warm transfer). To remove the
+  bot entirely, transfer the caller off Daily with a cold transfer (SIP REFER).
+</Note>
+
+## Cold transfer
+
+A cold transfer hands the caller off to another number and the bot exits.
+
+### How cold transfer works
 
 1. **Bot receives transfer request** (via function call or user input)
 2. **Bot informs the caller** about the transfer
@@ -333,7 +352,7 @@ Daily supports cold transfers, allowing you to transfer an active call to anothe
 5. **Bot leaves the call** (cold transfer)
 6. **Caller and destination** continue the conversation
 
-### Implementing Call Transfers
+### Implementing a cold transfer
 
 Call transfers are typically implemented as LLM function calls that your bot can invoke:
 
@@ -371,6 +390,50 @@ async def on_dialout_answered(transport, data):
 >
   See the full call transfer example with LLM function calls, event handling,
   and error management
+</Card>
+
+## Warm transfer
+
+A warm transfer connects the caller to a human specialist after the bot briefs that specialist on the call. Unlike a cold transfer, **the bot stays in the room for the entire call and acts as the audio bridge** between the caller and the specialist. Because the bot never leaves, the room stays alive naturally — you don't need any room-lifecycle configuration.
+
+### How warm transfer works
+
+1. **Caller dials in** and talks to the bot.
+2. **Caller asks for a specialist.** The bot calls an `initiate_warm_transfer` LLM function with the target and a short summary of the caller's issue.
+3. **Bot puts the caller on hold** — it plays a hold message, enables hold music, and gates the caller's audio so they don't hear the briefing.
+4. **Bot dials the specialist** with `start_dialout`.
+5. **Specialist answers** (`on_dialout_answered`). The bot takes the caller off hold and briefs the specialist (the caller hears this too).
+6. **Everyone is connected.** The bot stays in the room, bridging the audio.
+7. **Call ends** when the specialist hangs up after a successful connection, or when a participant leaves — the bot ends its own session with an `EndWorkerFrame`.
+
+### Room configuration
+
+The room only needs dial-out and SIP enabled. No `max_idle_timeout_sec` or other keep-alive setting is required, because the bot stays in the room:
+
+```python server_utils.py
+from pipecat.transports.daily.utils import DailyRoomProperties, DailyRoomSipParams
+
+room_properties = DailyRoomProperties(
+    enable_dialout=True,
+    sip=DailyRoomSipParams(display_name=call_data.from_phone),
+)
+```
+
+### Key components
+
+The example builds the flow from a few reusable pieces:
+
+- **A coordinator processor** (`TransferCoordinator`) — a `FrameProcessor` that drives the transfer as a small state machine: start transfer → hold caller and dial specialist → connect on answer → end on hang-up. Keeping the state in one processor avoids scattering call-flow logic across event handlers.
+- **Hold music** via `SoundfileMixer`, toggled with `MixerEnableFrame(True/False)` so the caller hears music while on hold and the specialist's ringing once dial-out connects.
+- **Audio gating** with a mute strategy and a `CustomerHoldFrame`, so the caller's audio is held during the briefing and released once everyone is connected.
+
+<Card
+  title="Complete Warm Transfer Implementation"
+  icon="code"
+  href="https://github.com/pipecat-ai/pipecat-examples/tree/main/phone-chatbot/daily-pstn-warm-transfer"
+>
+  See the full warm transfer example: the transfer coordinator, hold music,
+  audio gating, the LLM transfer function, and dial-out event handling.
 </Card>
 
 ## Deployment


### PR DESCRIPTION
## What

Fills four documentation gaps surfaced by the Kapa top-questions export (the most-asked Pipecat questions over the period).

## Changes

- **Flows + speech-to-speech** (`pipecat-flows/introduction.mdx`): state plainly that realtime/S2S models (Gemini Live, OpenAI Realtime, Ultravox, Nova Sonic) are **not** supported by Flows, and why (Flows rewrites context/tools mid-session to move between nodes; S2S APIs don't expose those controls). This was the single most-repeated question in the export, and the answer previously only lived in the API reference.
- **Transcription vs STT service** (`pipecat/learn/speech-to-text.mdx`, `api-reference/.../transport/daily.mdx`): explain the choice between a dedicated STT service in the pipeline and transport-provided transcription (`DailyParams(transcription_enabled=True)`), with the cost/control tradeoff and a "don't run both" warning. Adds a usage block to the DailyTransport reference.
- **Pipecat Cloud — existing Daily room** (`pipecat-cloud/guides/daily-webrtc.mdx`, `pipecat-cloud/fundamentals/active-sessions.mdx`): document starting a bot in a room you already created by passing `room_url`/`token` in `body` (no top-level start param exists), and correct the assumption that `args.room_url` is populated for an existing room.
- **Telephony** (`pipecat/telephony/daily-pstn.mdx`, `pipecat-cloud/guides/telephony/daily-dial-out.mdx`): add a **Warm transfer** section (bot stays in the room as the audio bridge), correcting the recurring "room dies when the bot leaves" misconception, grounded in the `daily-pstn-warm-transfer` example. Add a dial-out **Troubleshooting** table for the common `enable_dialout` errors.

## Source

Produced via the `/analyze-top-questions` review of the top-questions export (clusters 2–5). Each change is backed by either the actual example code, the OpenAPI start schema, or maintainer answers confirmed in the knowledge base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)