### PR TITLE
GoogleVertexLLMService import fix

### DIFF
--- a/api-reference/server/services/llm/google-vertex.mdx
+++ b/api-reference/server/services/llm/google-vertex.mdx
@@ -129,7 +129,7 @@ Before using Google Vertex AI LLM services, you need:
 
 ```python
 import os
-from pipecat.services.google import GoogleVertexLLMService
+from pipecat.services.google.vertex.llm import GoogleVertexLLMService
 
 llm = GoogleVertexLLMService(
     credentials_path=os.getenv("GOOGLE_APPLICATION_CREDENTIALS"),
@@ -142,7 +142,7 @@ llm = GoogleVertexLLMService(
 ### With Credentials JSON String
 
 ```python
-from pipecat.services.google import GoogleVertexLLMService
+from pipecat.services.google.vertex.llm import GoogleVertexLLMService
 
 llm = GoogleVertexLLMService(
     credentials=os.getenv("GOOGLE_CREDENTIALS_JSON"),
@@ -159,7 +159,7 @@ llm = GoogleVertexLLMService(
 ### With Application Default Credentials
 
 ```python
-from pipecat.services.google import GoogleVertexLLMService
+from pipecat.services.google.vertex.llm import GoogleVertexLLMService
 
 # Uses ADC when neither credentials nor credentials_path is provided
 llm = GoogleVertexLLMService(


### PR DESCRIPTION
Updated the import path for GoogleVertexLLMService class. 
Earlier import: from pipecat.services.google import GoogleVertexLLMService
Current import: from pipecat.services.google.vertex.llm import GoogleVertexLLMService