### PR TITLE
docs: close gaps surfaced by Kapa source analytics (batch 2)

### DIFF
--- a/api-reference/server/frames/overview.mdx
+++ b/api-reference/server/frames/overview.mdx
@@ -175,6 +175,35 @@ Carries raw image fields shared by both input and output image frames.
   Image format (e.g., `"RGB"`, `"RGBA"`).
 </ParamField>
 
+## Creating a Custom Frame
+
+Frames are plain Python dataclasses, so you can define your own by subclassing one of the three base categories and decorating it with `@dataclass`. Pick the base class by how the frame should be handled:
+
+- `DataFrame` for ordered data such as text, audio, or your own payload. Cancelled by user interruptions.
+- `ControlFrame` for ordered control signals that flush in line with the data.
+- `SystemFrame` for high-priority signals that skip the queue and are not affected by interruptions.
+
+```python
+from dataclasses import dataclass
+
+from pipecat.frames.frames import DataFrame
+
+
+@dataclass
+class AsteriskCommandFrame(DataFrame):
+    """A custom command sent downstream to a telephony transport."""
+
+    command: str
+```
+
+Your frame travels the pipeline like any built-in frame, in the direction you push it (see [Frame Direction](#frame-direction)). If the frame must survive a user interruption, add the [`UninterruptibleFrame`](#uninterruptibleframe) mixin:
+
+```python
+@dataclass
+class AsteriskCommandFrame(DataFrame, UninterruptibleFrame):
+    command: str
+```
+
 ## Common Patterns
 
 Pipecat prefers pushing frames over calling methods directly between processors. Routing data through the pipeline as frames ensures correct processing order, which is critical for real-time use cases.
@@ -224,6 +253,12 @@ await aggregator.push_frame(
 )
 await aggregator.push_frame(EndWorkerFrame(), FrameDirection.UPSTREAM)
 ```
+
+<Tip>
+  See [Pipeline Termination](/pipecat/learn/pipeline-termination) for the
+  difference between `EndFrame` and `EndWorkerFrame`, why the direction matters,
+  and how to end a conversation from inside a tool call.
+</Tip>
 
 ### Changing Service Settings at Runtime
 

--- a/api-reference/server/frames/overview.mdx
+++ b/api-reference/server/frames/overview.mdx
@@ -186,7 +186,7 @@ Frames are plain Python dataclasses, so you can define your own by subclassing o
 ```python
 from dataclasses import dataclass
 
-from pipecat.frames.frames import DataFrame
+from pipecat.frames.frames import DataFrame, UninterruptibleFrame
 
 
 @dataclass

--- a/api-reference/server/services/transport/small-webrtc.mdx
+++ b/api-reference/server/services/transport/small-webrtc.mdx
@@ -195,13 +195,13 @@ ICE servers are **optional for local network development** but become important 
 
 ### When do you need ICE servers?
 
-| Scenario | STUN needed | TURN needed |
-| --- | --- | --- |
-| Both peers on the same local network | No | No |
-| Peers on different networks (Linux) | Yes | Usually not |
-| Peers on different networks (macOS / strict NAT) | Yes | Yes |
-| Docker on macOS (no `--network=host`) | Yes | Yes |
-| Production deployment | Yes | Recommended |
+| Scenario                                         | STUN needed | TURN needed |
+| ------------------------------------------------ | ----------- | ----------- |
+| Both peers on the same local network             | No          | No          |
+| Peers on different networks (Linux)              | Yes         | Usually not |
+| Peers on different networks (macOS / strict NAT) | Yes         | Yes         |
+| Docker on macOS (no `--network=host`)            | Yes         | Yes         |
+| Production deployment                            | Yes         | Recommended |
 
 ### Server-side configuration
 
@@ -222,6 +222,12 @@ webrtc_connection = SmallWebRTCConnection(
 )
 ```
 
+### Using ICE servers with the development runner
+
+If you start your bot with the [development runner](/api-reference/server/utilities/runner/guide) (`from pipecat.runner.run import main`), the runner builds the `SmallWebRTCConnection` for you, so you cannot pass `ice_servers` from your `bot()` function. The only ICE option the runner exposes is the `enableDefaultIceServers` flag in the client's `/start` request, which adds Google's public STUN server (`stun:stun.l.google.com:19302`) and nothing else. There is no built-in way to inject a custom STUN or TURN server through the default runner.
+
+To use a custom TURN server, run your own signaling server that creates the `SmallWebRTCConnection` directly with `ice_servers=[...]`, as shown in [Server-side configuration](#server-side-configuration) above.
+
 <Note>
   In production, WebRTC applications must run over HTTPS. Browsers block WebRTC
   access to microphone and camera on insecure origins.
@@ -238,8 +244,8 @@ PIPECAT_SCTP_MAX_CHUNK_SIZE=1100
 ```
 
 <Note>
-  This is a process-global setting due to an aiortc limitation — all
-  SmallWebRTC connections in the same process share the same value.
+  This is a process-global setting due to an aiortc limitation — all SmallWebRTC
+  connections in the same process share the same value.
 </Note>
 
 **When to lower it**

--- a/api-reference/server/utilities/runner/guide.mdx
+++ b/api-reference/server/utilities/runner/guide.mdx
@@ -90,6 +90,16 @@ The `run_bot()` function contains your actual bot logic and is transport-agnosti
 
 When you run this with `python bot.py`, the development runner starts a web server and opens a browser interface at `http://localhost:7860/client`. Each time someone connects, the runner calls your `bot()` function with WebRTC runner arguments.
 
+<Warning>
+  `webrtc_connection` only exists on `SmallWebRTCRunnerArguments`, not on the
+  base `RunnerArguments` class. The example above works because it runs with the
+  WebRTC transport. If you run with any other transport, accessing
+  `runner_args.webrtc_connection` raises `AttributeError: 'RunnerArguments'
+  object has no attribute 'webrtc_connection'`. To support more than one
+  transport, branch on the argument type with the `isinstance` pattern shown in
+  [Supporting Multiple Transports](#supporting-multiple-transports) below.
+</Warning>
+
 ## Supporting Multiple Transports
 
 To make your bot work across different platforms, you can detect the transport type from the runner arguments and create the appropriate transport. Here's how to support both Daily and WebRTC:
@@ -474,6 +484,16 @@ If you started the runner with `-t <transport>`, a `/start` request for any othe
 ```
 
 Returns a `sessionId` (and an `iceConfig` when `enableDefaultIceServers` is set). The bot starts when the WebRTC offer arrives.
+
+<Note>
+  `enableDefaultIceServers` is the only ICE option the runner exposes, and it
+  adds Google's public STUN server (`stun:stun.l.google.com:19302`) and nothing
+  else. The runner builds the `SmallWebRTCConnection` for you, so you cannot
+  pass a custom STUN or TURN server from your `bot()` function. To use a custom
+  TURN server, run your own signaling server that creates the
+  `SmallWebRTCConnection` directly: see [Using ICE servers with the development
+  runner](/api-reference/server/services/transport/small-webrtc#using-ice-servers-with-the-development-runner).
+</Note>
 
 **Request Format (`"transport": "daily"`):**
 

--- a/pipecat-cloud/fundamentals/active-sessions.mdx
+++ b/pipecat-cloud/fundamentals/active-sessions.mdx
@@ -237,7 +237,8 @@ Requests exceeding the per-transport limit are rejected with `413 Payload Too La
 <Note>
   For `transport: "websocket"`, the smaller 4 KB cap reflects the URL length constraint on the WebSocket upgrade — the body travels as a base64-encoded `?body=` query parameter that your client appends to the returned `wsUrl`. See [Passing parameters to the bot](/pipecat-cloud/guides/generic-websocket#passing-parameters-to-the-bot) for the client-side construction.
 
-  Sending a `body` also requires the service to be deployed with `websocket_auth = "token"` (see [WebSocket Authentication](/pipecat-cloud/guides/websocket-authentication)). A `/start` call with a `body` and `websocket_auth = "none"` is rejected with `400 Bad Request`.
+Sending a `body` also requires the service to be deployed with `websocket_auth = "token"` (see [WebSocket Authentication](/pipecat-cloud/guides/websocket-authentication)). A `/start` call with a `body` and `websocket_auth = "none"` is rejected with `400 Bad Request`.
+
 </Note>
 
 ## Agent capacity
@@ -245,7 +246,9 @@ Requests exceeding the per-transport limit are rejected with `413 Payload Too La
 Deployments have an upper limit for the number of sessions that can be started concurrently.
 This helps developers implement cost control and workload management and can be adjusted per deployment.
 
-See [Scaling](./scaling) for more information.
+Each agent instance runs a single session at a time (one bot per instance, regardless of the [compute profile](./scaling#instances) you choose). This means your total concurrency equals your instance-pool capacity: to run more sessions at once, you raise the pool size, not the per-instance load.
+
+See [Scaling](./scaling) for more on how the pool grows, and [Capacity Planning](../guides/capacity-planning) for sizing warm and reserved capacity.
 
 <Warning>
   The default instance pool capacity is **50 active sessions per deployment**.

--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -11,6 +11,14 @@ Agentic applications demand near-instant agent availability to maintain user eng
 
 An instance represents a single unit of compute that runs your agent.
 
+<Note>
+  Each instance runs **one active session at a time** (one bot per instance).
+  Your total concurrency equals the number of running instances, which you
+  control with [`max-agents`](#maximum-agents). Choosing a larger compute
+  profile (for example `agent-2x` or `agent-3x`) gives a single session more CPU
+  and memory; it does not let one instance handle more than one session.
+</Note>
+
 Instance costs are determined by:
 
 - [Active session](./active-sessions) runtime duration

--- a/pipecat/fundamentals/stt-latency-tuning.mdx
+++ b/pipecat/fundamentals/stt-latency-tuning.mdx
@@ -23,15 +23,66 @@ TTFS feeds directly into [turn stop strategies](/api-reference/server/utilities/
 
 Getting TTFS right is one of the most impactful tuning knobs for perceived conversation responsiveness.
 
+<Note>
+  TTFS is a configuration value the turn stop strategy uses, not a metric that
+  is logged at runtime. To observe live latency in your running bot (time to
+  first byte, user-to-bot latency), see the [Metrics
+  guide](/pipecat/fundamentals/metrics).
+</Note>
+
 ## Default P99 latency values
 
 Pipecat includes measured P99 TTFS values for every supported STT service. These are used automatically when you create a service — no configuration required.
 
-You can see default values in the [source code](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/services/stt_latency.py).
+| STT service          | Default P99 TTFS (seconds) |
+| -------------------- | -------------------------- |
+| Deepgram             | 0.35                       |
+| Deepgram (SageMaker) | 0.35                       |
+| Soniox               | 0.35                       |
+| ElevenLabs Realtime  | 0.41                       |
+| AssemblyAI           | 0.42                       |
+| Gradium              | 0.62                       |
+| Speechmatics         | 0.74                       |
+| Cartesia             | 0.81                       |
+| Together             | 1.00                       |
+| Sarvam               | 1.17                       |
+| Gladia               | 1.49                       |
+| Groq                 | 1.54                       |
+| Google               | 1.57                       |
+| Smallest             | 1.59                       |
+| OpenAI Realtime      | 1.66                       |
+| Azure                | 1.80                       |
+| Mistral              | 1.89                       |
+| AWS Transcribe       | 1.90                       |
+| OpenAI               | 2.01                       |
+| ElevenLabs           | 2.01                       |
+| Fal                  | 2.07                       |
+| xAI                  | 2.14                       |
+| NVIDIA (local)       | 1.00                       |
+| Whisper (local)      | 1.00                       |
+
+The source of truth for these values is [`stt_latency.py`](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/services/stt_latency.py), which may add services or refine numbers over time. Check there if a service is missing from the table above.
+
+<Note>
+  These built-in values were all measured with `VADParams.stop_secs=0.2`, the
+  recommended default. If you change `stop_secs`, the built-in value no longer
+  matches your setup and Pipecat logs a warning. Re-run the benchmark with your
+  VAD settings and pass the measured value to your STT service constructor. See
+  the [Stop Strategies
+  section](/api-reference/server/utilities/turn-management/user-turn-strategies)
+  for the full explanation of how this interacts with turn detection.
+</Note>
 
 <Note>
   Local services (NVIDIA, Whisper) default to 1.0s since actual latency depends
   entirely on your hardware. Always measure and override for local deployments.
+</Note>
+
+<Note>
+  Turn-based STT services (for example `CartesiaTurnsSTTService` and
+  `DeepgramFluxSTTService`) have no meaningful TTFS value. The server defines
+  the turn boundary directly, so there is no separate "speech end to final
+  transcript" interval to measure.
 </Note>
 
 ## Measuring latency for your deployment
@@ -44,6 +95,34 @@ The default values are measured under standard conditions, but your actual laten
 - **Audio quality** and encoding settings
 
 Use the [stt-benchmark](https://github.com/pipecat-ai/stt-benchmark) tool to measure TTFS for your specific setup. The tool sends standardized audio samples to your STT service and reports P50, P90, and P99 latency values.
+
+To run it, clone the repo and install with [`uv`](https://docs.astral.sh/uv/):
+
+```bash
+git clone https://github.com/pipecat-ai/stt-benchmark
+cd stt-benchmark
+uv sync
+
+# Add your provider API keys
+cp env.example .env
+
+# Download standardized audio samples
+uv run stt-benchmark download --num-samples 100
+
+# Run the benchmark for one or more services
+uv run stt-benchmark run --services deepgram,openai
+
+# View the P50/P90/P99 report
+uv run stt-benchmark report --service deepgram
+```
+
+If you run your bot with a non-default VAD setting, match the benchmark to it with `--vad-stop-secs` so the measured value reflects your configuration:
+
+```bash
+uv run stt-benchmark run --services deepgram --vad-stop-secs 0.3
+```
+
+See the [stt-benchmark README](https://github.com/pipecat-ai/stt-benchmark) for the full command reference.
 
 ## Overriding the default value
 

--- a/pipecat/fundamentals/stt-latency-tuning.mdx
+++ b/pipecat/fundamentals/stt-latency-tuning.mdx
@@ -34,34 +34,7 @@ Getting TTFS right is one of the most impactful tuning knobs for perceived conve
 
 Pipecat includes measured P99 TTFS values for every supported STT service. These are used automatically when you create a service — no configuration required.
 
-| STT service          | Default P99 TTFS (seconds) |
-| -------------------- | -------------------------- |
-| Deepgram             | 0.35                       |
-| Deepgram (SageMaker) | 0.35                       |
-| Soniox               | 0.35                       |
-| ElevenLabs Realtime  | 0.41                       |
-| AssemblyAI           | 0.42                       |
-| Gradium              | 0.62                       |
-| Speechmatics         | 0.74                       |
-| Cartesia             | 0.81                       |
-| Together             | 1.00                       |
-| Sarvam               | 1.17                       |
-| Gladia               | 1.49                       |
-| Groq                 | 1.54                       |
-| Google               | 1.57                       |
-| Smallest             | 1.59                       |
-| OpenAI Realtime      | 1.66                       |
-| Azure                | 1.80                       |
-| Mistral              | 1.89                       |
-| AWS Transcribe       | 1.90                       |
-| OpenAI               | 2.01                       |
-| ElevenLabs           | 2.01                       |
-| Fal                  | 2.07                       |
-| xAI                  | 2.14                       |
-| NVIDIA (local)       | 1.00                       |
-| Whisper (local)      | 1.00                       |
-
-The source of truth for these values is [`stt_latency.py`](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/services/stt_latency.py), which may add services or refine numbers over time. Check there if a service is missing from the table above.
+For the current P99 TTFS value for each service, see [`stt_latency.py`](https://github.com/pipecat-ai/pipecat/blob/main/src/pipecat/services/stt_latency.py). These values are refined and added to often, so the source file is the source of truth.
 
 <Note>
   These built-in values were all measured with `VADParams.stop_secs=0.2`, the


### PR DESCRIPTION
## What

Documentation edits across 6 pages, each backed by recurring real user questions in the Kapa source analytics export (citation logs). Every change addresses a cluster of 3+ questions where Kapa had to guess, read raw source, or hedged with "the knowledge sources do not contain...".

### Changes by cluster

**One session per instance** (asked 8x on scaling, 4x on active-sessions)
- `pipecat-cloud/fundamentals/scaling.mdx`: Note in Instances stating each instance runs one active session, concurrency equals instance count, and a larger compute profile (agent-2x/3x) gives one session more resources, not more sessions.
- `pipecat-cloud/fundamentals/active-sessions.mdx`: same point in Agent capacity, plus a cross-link to Capacity Planning.

**Custom ICE/TURN with the default runner** (asked 9x on small-webrtc, 4x on runner guide)
- `api-reference/server/services/transport/small-webrtc.mdx`: new "Using ICE servers with the development runner" subsection. The runner only supports `enableDefaultIceServers` (Google STUN); custom TURN needs your own signaling server.
- `api-reference/server/utilities/runner/guide.mdx`: matching Note near `enableDefaultIceServers`, plus a Warning that `webrtc_connection` only exists on `SmallWebRTCRunnerArguments` (the most-repeated runner error, 6x).
- Verified against `pipecat/src/pipecat/runner/run.py`.

**STT latency tuning** (4 clusters on `pipecat/fundamentals/stt-latency-tuning.mdx`)
- Default P99 TTFS table (values from `stt_latency.py`), with that file named as the source of truth.
- Note that built-in values assume `VADParams.stop_secs=0.2` and that changing it logs a warning.
- Runnable `stt-benchmark` commands (verified against the tool's README).
- Cross-link to the Metrics guide for observing live latency.

**Frames overview** (`api-reference/server/frames/overview.mdx`)
- New "Creating a Custom Frame" section (asked 4x; previously had no docs home).
- Cross-link to Pipeline Termination from "Ending a Conversation" (asked 6x).

## Notes
- All internal anchors verified to resolve.
- Prettier-formatted. No emdashes in added prose.
- Skipped: turn-events (per reviewer); CHANGELOG/pricing/root (external pages, not editable here). The pricing-page gaps were handled separately in daily-co/daily.co#210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)