### PR TITLE
Add Latitude to OpenTelemetry exporter options

### DIFF
--- a/api-reference/server/utilities/opentelemetry.mdx
+++ b/api-reference/server/utilities/opentelemetry.mdx
@@ -151,6 +151,25 @@ exporter = OTLPSpanExporter(
 
 See our [Langfuse example](https://github.com/pipecat-ai/pipecat-examples/tree/main/open-telemetry/langfuse) for details on configuring this exporter.
 
+### Latitude
+
+[Latitude](https://latitude.so) is an open-source LLM observability and evaluation platform that ingests OTLP traces. Use the HTTP OTLP exporter and point it at Latitude's ingestion endpoint:
+
+```python
+import os
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+exporter = OTLPSpanExporter(
+    endpoint="https://ingest.latitude.so/v1/traces",
+    headers={
+        "Authorization": f"Bearer {os.environ['LATITUDE_API_KEY']}",
+        "X-Latitude-Project": os.environ["LATITUDE_PROJECT"],
+    },
+)
+```
+
+Sign up at [console.latitude.so](https://console.latitude.so/login), or self-host and point the endpoint at your own ingestion host.
+
 ### Console Exporter (for debugging)
 
 The console exporter can be enabled alongside any other exporter by setting `console_export=True`:


### PR DESCRIPTION
Adds a **Latitude** subsection to the Exporter Options on the OpenTelemetry page.

[Latitude](https://latitude.so) is an open-source LLM observability and evaluation platform that ingests OTLP traces. Like the existing Langfuse HTTP OTLP usage, it needs no Pipecat-specific package: configure the HTTP OTLP exporter with Latitude's ingestion endpoint and `Authorization` / `X-Latitude-Project` headers. Single-file docs change with a runnable snippet.
