### PR TITLE
docs: add Protoface community video service

### DIFF
--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -261,12 +261,13 @@ VAD services analyze audio input to detect when a user starts and stops speaking
 
 Video services enable you to build an avatar where audio and video are synchronized.
 
-| Service                                               | Setup                         | Maintainer |
-| ----------------------------------------------------- | ----------------------------- | ---------- |
-| [Anam](/api-reference/server/services/video/anam)     | `uv add pipecat-anam`         | Community  |
-| [HeyGen](/api-reference/server/services/video/heygen) | `uv add "pipecat-ai[heygen]"` | Pipecat    |
-| [Simli](/api-reference/server/services/video/simli)   | `uv add "pipecat-ai[simli]"`  | Pipecat    |
-| [Tavus](/api-reference/server/services/video/tavus)   | `uv add "pipecat-ai[tavus]"`  | Pipecat    |
+| Service                                                     | Setup                         | Maintainer |
+| ----------------------------------------------------------- | ----------------------------- | ---------- |
+| [Anam](/api-reference/server/services/video/anam)           | `uv add pipecat-anam`         | Community  |
+| [HeyGen](/api-reference/server/services/video/heygen)       | `uv add "pipecat-ai[heygen]"` | Pipecat    |
+| [Protoface](/api-reference/server/services/video/protoface) | `uv add pipecat-protoface`    | Community  |
+| [Simli](/api-reference/server/services/video/simli)         | `uv add "pipecat-ai[simli]"`  | Pipecat    |
+| [Tavus](/api-reference/server/services/video/tavus)         | `uv add "pipecat-ai[tavus]"`  | Pipecat    |
 
 ## Vision
 

--- a/api-reference/server/services/video/protoface.mdx
+++ b/api-reference/server/services/video/protoface.mdx
@@ -1,0 +1,162 @@
+---
+title: "Protoface"
+description: "Real-time video avatars for conversational AI"
+---
+
+import { CommunityMaintained } from "/snippets/community-maintained.mdx";
+
+<CommunityMaintained
+  maintainer="protoface-ai"
+  maintainerUrl="https://github.com/protoface-ai"
+  repo="https://github.com/protoface-ai/protoface-plugin-pipecat"
+/>
+
+## Overview
+
+`ProtofaceVideoService` renders Pipecat TTS output through a real-time Protoface
+video avatar. It consumes TTS audio and emits synchronized avatar video
+(`OutputImageRawFrame`) and audio (`SpeechOutputAudioRawFrame`) downstream.
+
+Use it with any Pipecat transport that supports audio and video output.
+
+<CardGroup cols={2}>
+  <Card
+    title="Source Repository"
+    icon="github"
+    href="https://github.com/protoface-ai/protoface-plugin-pipecat"
+  >
+    Source code, examples, and issues for the Protoface integration
+  </Card>
+  <Card
+    title="PyPI Package"
+    icon="cube"
+    href="https://pypi.org/project/pipecat-protoface/"
+  >
+    The `pipecat-protoface` package on PyPI
+  </Card>
+  <Card
+    title="Protoface Documentation"
+    icon="book"
+    href="https://docs.protoface.com"
+  >
+    Official Protoface documentation and guides
+  </Card>
+  <Card title="Protoface Platform" icon="key" href="https://protoface.com">
+    Create avatars and manage API access
+  </Card>
+</CardGroup>
+
+## Installation
+
+This is a community-maintained package distributed separately from `pipecat-ai`:
+
+```bash
+uv add pipecat-protoface
+```
+
+Install any Pipecat extras required by your chosen transport and AI services
+separately.
+
+## Prerequisites
+
+### Protoface Account Setup
+
+Before using the Protoface video service, you need:
+
+1. **Protoface API key**: Get access through the [Protoface Platform](https://protoface.com)
+2. **Protoface avatar ID**: Create or select an avatar in the Protoface Platform
+   and copy its ID
+
+You'll also need API keys for the Pipecat services used in your pipeline.
+
+### Required Environment Variables
+
+- `PROTOFACE_API_KEY`: Your Protoface API key
+- `PROTOFACE_AVATAR_ID`: Your Protoface avatar ID
+
+## Configuration
+
+Constructor parameters for `ProtofaceVideoService`:
+
+<ParamField path="api_key" type="str" required>
+  Protoface API key for authentication.
+</ParamField>
+
+<ParamField path="avatar_id" type="str" required>
+  Protoface avatar ID for the hosted avatar session.
+</ParamField>
+
+<ParamField path="api_url" type="str" default="https://api.protoface.com">
+  Protoface API URL. Most users can omit this.
+</ParamField>
+
+<ParamField path="max_duration_seconds" type="int" default="None">
+  Maximum session duration in seconds.
+</ParamField>
+
+<ParamField path="metadata" type="Mapping" default="None">
+  Metadata to attach when creating the Protoface session.
+</ParamField>
+
+<ParamField path="settings" type="ProtofaceVideoSettings" default="None">
+  Advanced settings for buffering and client readiness. Most users can omit
+  this.
+</ParamField>
+
+<Note>
+  For the latest examples and configuration options, see the [source
+  repository](https://github.com/protoface-ai/protoface-plugin-pipecat).
+</Note>
+
+## Usage
+
+### Basic Setup
+
+```python
+import os
+
+from pipecat_protoface import ProtofaceVideoService
+from pipecat.pipeline.pipeline import Pipeline
+
+protoface = ProtofaceVideoService(
+    api_key=os.environ["PROTOFACE_API_KEY"],
+    avatar_id=os.environ["PROTOFACE_AVATAR_ID"],
+)
+
+pipeline = Pipeline([
+    transport.input(),
+    stt,
+    context_aggregator.user(),
+    llm,
+    tts,
+    protoface,  # Video avatar (emits synchronized audio/video)
+    transport.output(),
+    context_aggregator.assistant(),
+])
+```
+
+### Realtime Speech-to-Speech
+
+For realtime speech-to-speech services, place `ProtofaceVideoService` after your
+realtime LLM service and before the output transport:
+
+```python
+pipeline = Pipeline([
+    transport.input(),
+    context_aggregator.user(),
+    gemini_live,
+    context_aggregator.assistant(),
+    protoface,
+    transport.output(),
+])
+```
+
+See the
+[example](https://github.com/protoface-ai/protoface-plugin-pipecat/blob/master/examples/video_service.py)
+in the source repository for a complete WebRTC pipeline using Gemini Live.
+
+## Compatibility
+
+Tested with Pipecat v1.4.0+ (Python 3.11+). Check the [source
+repository](https://github.com/protoface-ai/protoface-plugin-pipecat) for the
+latest compatibility notes and examples.

--- a/docs.json
+++ b/docs.json
@@ -486,6 +486,7 @@
                     "pages": [
                       "api-reference/server/services/video/anam",
                       "api-reference/server/services/video/heygen",
+                      "api-reference/server/services/video/protoface",
                       "api-reference/server/services/video/simli",
                       "api-reference/server/services/video/tavus"
                     ]


### PR DESCRIPTION
## Details

- Service: Protoface
- Repository: https://github.com/protoface-ai/protoface-plugin-pipecat
- PyPI: https://pypi.org/project/pipecat-protoface
- Docs: https://docs.protoface.com/
- Platform: https://protoface.com/
- Maintainer: @protoface-ai
- Pipecat Compatibility: Tested with Pipecat v1.4.0+

## About

This adds the official Protoface video avatar integration for Pipecat, built and maintained by the Protoface team.

`ProtofaceVideoService` consumes Pipecat TTS audio and emits synchronized avatar video (`OutputImageRawFrame`) and audio (`SpeechOutputAudioRawFrame`) downstream.

Changes include:
- Provider page for `ProtofaceVideoService`
- Video services table entry
- Navigation entry in `docs.json`

## Validation
- Previewed locally with Mintlify