### PR TITLE
docs: present Pipecat Flows as built into core Pipecat

### DIFF
--- a/api-reference/pipecat-flows/exceptions.mdx
+++ b/api-reference/pipecat-flows/exceptions.mdx
@@ -8,7 +8,7 @@ description: "Error handling hierarchy for Pipecat Flows"
 Pipecat Flows defines a hierarchy of exceptions for handling errors during flow execution. All exceptions inherit from `FlowError`, making it possible to catch all flow-related errors with a single handler.
 
 ```python
-from pipecat_flows import (
+from pipecat.flows import (
     FlowError,
     FlowInitializationError,
     FlowTransitionError,

--- a/api-reference/pipecat-flows/flow-manager.mdx
+++ b/api-reference/pipecat-flows/flow-manager.mdx
@@ -238,7 +238,7 @@ node_config = NodeConfig(
 ### Basic Setup
 
 ```python
-from pipecat_flows import FlowManager, FlowResult, NodeConfig
+from pipecat.flows import FlowManager, FlowResult, NodeConfig
 
 async def create_initial_node() -> NodeConfig:
     return NodeConfig(
@@ -260,7 +260,7 @@ await flow_manager.initialize(initial_node=await create_initial_node())
 ### Using Global Functions
 
 ```python
-from pipecat_flows import FlowManager, NodeConfig
+from pipecat.flows import FlowManager, NodeConfig
 
 async def transfer_to_human(flow_manager: FlowManager) -> tuple[None, NodeConfig]:
     """Transfer the conversation to a human agent."""

--- a/api-reference/pipecat-flows/overview.mdx
+++ b/api-reference/pipecat-flows/overview.mdx
@@ -10,27 +10,27 @@ description: "Reference docs for Pipecat's conversation flow system"
   [guides](/pipecat-flows/guides/quickstart) first.
 </Tip>
 
-Pipecat Flows is an add-on framework for Pipecat that allows you to build structured conversations in your AI applications. It enables you to define conversation paths while handling the complexities of state management and LLM interactions.
+Pipecat Flows is Pipecat's framework for building structured conversations. It builds on the pipeline to let you define conversation paths while handling the complexities of state management and LLM interactions.
 
 <CardGroup cols={3}>
   <Card
     title="API Reference"
     icon="code"
-    href="https://reference-flows.pipecat.ai"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.flows.html"
   >
     Complete API documentation and method details
   </Card>
   <Card
     title="GitHub Repository"
     icon="github"
-    href="https://github.com/pipecat-ai/pipecat-flows"
+    href="https://github.com/pipecat-ai/pipecat"
   >
     Source code, examples, and issue tracking
   </Card>
   <Card
     title="Hello World Example"
     icon="play"
-    href="https://github.com/pipecat-ai/pipecat-flows/blob/main/examples/quickstart/hello_world.py"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/flows/hello_world.py"
   >
     Working example with basic conversation flow
   </Card>
@@ -38,17 +38,7 @@ Pipecat Flows is an add-on framework for Pipecat that allows you to build struct
 
 ## Installation
 
-### Pipecat Flows
-
-To use Pipecat Flows, install the required dependency:
-
-```bash
-uv add pipecat-ai-flows
-```
-
-### Pipecat Dependencies
-
-For fresh installations, you'll need to install Pipecat with dependencies for your Transport, STT, LLM, and TTS providers.
+Pipecat Flows is included with Pipecat. For fresh installations, install Pipecat with dependencies for your Transport, STT, LLM, and TTS providers.
 
 For example, to use Daily, OpenAI, Deepgram, Cartesia, and Silero:
 

--- a/api-reference/pipecat-flows/types.mdx
+++ b/api-reference/pipecat-flows/types.mdx
@@ -150,7 +150,7 @@ Convert to a standard `FunctionSchema` for use with LLMs. Strips Flows-specific 
 ### Example
 
 ```python
-from pipecat_flows import FlowsFunctionSchema, FlowResult
+from pipecat.flows import FlowsFunctionSchema, FlowResult
 
 async def handle_weather(args, flow_manager):
     city = args["city"]
@@ -232,7 +232,7 @@ Enum defining strategies for managing conversation context during node transitio
 | `RESET_WITH_SUMMARY` | **Deprecated.** Reset context but include an LLM-generated summary. Use Pipecat's native [context summarization](/pipecat/fundamentals/context-summarization) instead. Requires `summary_prompt` in `ContextStrategyConfig`. |
 
 ```python
-from pipecat_flows import ContextStrategy
+from pipecat.flows import ContextStrategy
 
 strategy = ContextStrategy.APPEND
 strategy = ContextStrategy.RESET
@@ -259,7 +259,7 @@ Dataclass for configuring context management behavior.
 ### Example
 
 ```python
-from pipecat_flows import ContextStrategy, ContextStrategyConfig
+from pipecat.flows import ContextStrategy, ContextStrategyConfig
 
 # Append (default)
 config = ContextStrategyConfig(strategy=ContextStrategy.APPEND)
@@ -296,7 +296,7 @@ Decorator that overrides a function's default call options. It's optional — a 
 ### Example
 
 ```python
-from pipecat_flows import FlowManager, flows_tool_options, ConsolidatedFunctionResult
+from pipecat.flows import FlowManager, flows_tool_options, ConsolidatedFunctionResult
 
 @flows_tool_options(cancel_on_interruption=True)
 async def lookup_order(

--- a/overview/flows.mdx
+++ b/overview/flows.mdx
@@ -15,11 +15,11 @@ Pipecat Flows is best suited for use cases where:
 - **Your bot handles complex tasks** that can be broken down into smaller, manageable pieces
 - **You want to improve LLM accuracy** by focusing the model on one specific task at a time instead of managing multiple responsibilities simultaneously
 
-## How Pipecat and Pipecat Flows Work Together
+## How Pipecat Flows Builds on the Pipeline
 
-**Pipecat** defines the core capabilities of your bot — the pipeline and processors that enable receiving audio, transcribing input, running LLM completions, converting responses to audio, and sending audio back to the user.
+A Pipecat **pipeline** provides your bot's core mechanics — receiving audio, transcribing input, running LLM completions, converting responses to audio, and sending audio back to the user.
 
-**Pipecat Flows** complements Pipecat by providing structure to a conversation, managing context and tools as the conversation progresses from one state to another. This is separate from the core pipeline, allowing you to separate conversation logic from pipeline mechanics.
+**Pipecat Flows** builds on that pipeline to structure the conversation, managing context and tools as it moves from one state to the next. This keeps your conversation logic cleanly separated from the pipeline mechanics.
 
 ## Ready to Build?
 
@@ -44,7 +44,7 @@ Pipecat Flows is best suited for use cases where:
   <Card
     title="GitHub"
     icon="github"
-    href="https://github.com/pipecat-ai/pipecat-flows"
+    href="https://github.com/pipecat-ai/pipecat"
   >
     Source code, issues, and contributions
   </Card>

--- a/pipecat-flows/examples.mdx
+++ b/pipecat-flows/examples.mdx
@@ -9,7 +9,7 @@ Explore these examples to see Pipecat Flows in action. Each example demonstrates
   <Card
     title="Hello World"
     icon="rocket"
-    href="https://github.com/pipecat-ai/pipecat-flows/tree/main/examples/quickstart"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/flows/hello_world.py"
   >
     A great first Flow to show you the ropes. Two-node flow that asks for a
     favorite color.
@@ -17,48 +17,48 @@ Explore these examples to see Pipecat Flows in action. Each example demonstrates
   <Card
     title="Food Ordering"
     icon="burger"
-    href="https://github.com/pipecat-ai/pipecat-flows/blob/main/examples/food_ordering.py"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/flows/food_ordering.py"
   >
     Multi-step ordering flow with menu selection, customization, and checkout.
   </Card>
   <Card
     title="Restaurant Reservation"
     icon="utensils"
-    href="https://github.com/pipecat-ai/pipecat-flows/blob/main/examples/restaurant_reservation.py"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/flows/restaurant_reservation.py"
   >
     Collect party size, date, time, and contact details for a reservation.
   </Card>
   <Card
     title="Patient Intake"
     icon="hospital"
-    href="https://github.com/pipecat-ai/pipecat-flows/blob/main/examples/patient_intake.py"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/flows/patient_intake.py"
   >
     Healthcare intake flow collecting patient information and symptoms.
   </Card>
   <Card
     title="Insurance Quote"
     icon="shield"
-    href="https://github.com/pipecat-ai/pipecat-flows/blob/main/examples/insurance_quote.py"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/flows/insurance_quote.py"
   >
     Guided flow for collecting insurance quote details with state management.
   </Card>
   <Card
     title="LLM Switching"
     icon="arrows-rotate"
-    href="https://github.com/pipecat-ai/pipecat-flows/blob/main/examples/llm_switching.py"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/flows/llm_switching.py"
   >
     Switch between LLM providers mid-conversation based on task requirements.
   </Card>
   <Card
     title="Warm Transfer"
     icon="phone-arrow-right"
-    href="https://github.com/pipecat-ai/pipecat-flows/blob/main/examples/warm_transfer.py"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/flows/warm_transfer.py"
   >
     Transfer a conversation to a human agent with context handoff.
   </Card>
 </CardGroup>
 
 <Tip>
-  All examples are available in the [pipecat-flows GitHub
-  repository](https://github.com/pipecat-ai/pipecat-flows/tree/main/examples).
+  All examples are available in the [Pipecat repository on
+  GitHub](https://github.com/pipecat-ai/pipecat/tree/main/examples/flows).
 </Tip>

--- a/pipecat-flows/guides/context-strategies.mdx
+++ b/pipecat-flows/guides/context-strategies.mdx
@@ -32,7 +32,7 @@ Flows provides three built-in ways to manage conversation context as you move be
 Context strategies can be defined globally in the FlowManager constructor:
 
 ```python
-from pipecat_flows import ContextStrategy, ContextStrategyConfig
+from pipecat.flows import ContextStrategy, ContextStrategyConfig
 
 # Global strategy configuration
 flow_manager = FlowManager(

--- a/pipecat-flows/guides/functions.mdx
+++ b/pipecat-flows/guides/functions.mdx
@@ -68,7 +68,7 @@ A function that doesn't need to change conversational state can return `None` fo
 By default, a function is not cancelled when the user interrupts, and it uses the LLM service's global timeout. To override either, decorate the function with `@flows_tool_options`:
 
 ```python
-from pipecat_flows import flows_tool_options
+from pipecat.flows import flows_tool_options
 
 # This lookup is only useful for the current turn, so cancel it if the user
 # interrupts and the conversation moves on.
@@ -92,7 +92,7 @@ Direct functions cover most cases. Reach for `FlowsFunctionSchema` when you need
 A `FlowsFunctionSchema` spells out the function's name, description, and parameters by hand, and takes the `handler` that runs when the LLM calls the function:
 
 ```python
-from pipecat_flows import FlowsFunctionSchema
+from pipecat.flows import FlowsFunctionSchema
 
 async def record_favorite_color(
     args: FlowArgs, flow_manager: FlowManager

--- a/pipecat-flows/guides/quickstart.mdx
+++ b/pipecat-flows/guides/quickstart.mdx
@@ -8,17 +8,16 @@ This guide walks through the Hello World example — a two-node conversation flo
 <Card
   title="Hello World Example"
   icon="rocket"
-  href="https://github.com/pipecat-ai/pipecat-flows/tree/main/examples/quickstart"
+  href="https://github.com/pipecat-ai/pipecat/blob/main/examples/flows/hello_world.py"
 >
   View the full source code on GitHub
 </Card>
 
 ## Prerequisites
 
-Install Pipecat Flows and Pipecat with the services used in this example:
+Pipecat Flows is included with Pipecat. Install Pipecat with the services used in this example:
 
 ```bash
-uv add pipecat-ai-flows
 uv add "pipecat-ai[daily,google,cartesia,silero]"
 ```
 
@@ -38,7 +37,7 @@ A flow is a graph of nodes. Each node gives the LLM a task and the functions it 
 The initial node sets the bot's personality via `role_message`, gives it a task via `task_messages`, and lists the function the LLM will call when the user answers:
 
 ```python
-from pipecat_flows import FlowManager, NodeConfig
+from pipecat.flows import FlowManager, NodeConfig
 
 def create_initial_node() -> NodeConfig:
     return NodeConfig(
@@ -153,7 +152,7 @@ That's it! When a user connects, the bot greets them, asks for their favorite co
 
 <Info>
   See the [full source
-  code](https://github.com/pipecat-ai/pipecat-flows/blob/main/examples/quickstart/hello_world.py)
+  code](https://github.com/pipecat-ai/pipecat/blob/main/examples/flows/hello_world.py)
   for the complete runnable example.
 </Info>
 

--- a/pipecat-flows/introduction.mdx
+++ b/pipecat-flows/introduction.mdx
@@ -15,11 +15,11 @@ Pipecat Flows is best suited for use cases where:
 - **Your bot handles complex tasks** that can be broken down into smaller, manageable pieces
 - **You want to improve LLM accuracy** by focusing the model on one specific task at a time instead of managing multiple responsibilities simultaneously
 
-## How Pipecat and Pipecat Flows Work Together
+## How Pipecat Flows Builds on the Pipeline
 
-**Pipecat** defines the core capabilities of your bot — the pipeline and processors that enable receiving audio, transcribing input, running LLM completions, converting responses to audio, and sending audio back to the user.
+A Pipecat **pipeline** provides your bot's core mechanics — receiving audio, transcribing input, running LLM completions, converting responses to audio, and sending audio back to the user.
 
-**Pipecat Flows** complements Pipecat by providing structure to a conversation, managing context and tools as the conversation progresses from one state to another. This is separate from the core pipeline, allowing you to separate conversation logic from pipeline mechanics.
+**Pipecat Flows** builds on that pipeline to structure the conversation, managing context and tools as it moves from one state to the next. This keeps your conversation logic cleanly separated from the pipeline mechanics.
 
 <Warning>
   **Pipecat Flows needs a text LLM that supports function calling** — use a
@@ -37,11 +37,7 @@ Pipecat Flows is best suited for use cases where:
 
 ## Installation
 
-```bash
-uv add pipecat-ai-flows
-```
-
-You'll also need Pipecat with dependencies for your transport, STT, LLM, and TTS providers:
+Pipecat Flows is included with Pipecat. Install Pipecat with the dependencies for your transport, STT, LLM, and TTS providers:
 
 ```bash
 uv add "pipecat-ai[daily,openai,deepgram,cartesia,silero]"
@@ -74,7 +70,7 @@ The [Pipecat Flows Visual Editor](https://flows.pipecat.ai/) lets you design con
   <Card
     title="GitHub"
     icon="github"
-    href="https://github.com/pipecat-ai/pipecat-flows"
+    href="https://github.com/pipecat-ai/pipecat"
   >
     Source code, issues, and contributions
   </Card>

--- a/pipecat-flows/migration/migration-1.0.mdx
+++ b/pipecat-flows/migration/migration-1.0.mdx
@@ -13,8 +13,9 @@ Before upgrading, search your codebase for the deprecated imports and patterns l
 </Warning>
 
 <Note>
-  Pipecat Flows is now part of core Pipecat. Import it from `pipecat.flows`
-  (previously `pipecat_flows`). The examples below use the new import path.
+  As of `pipecat-ai` 1.5.0, Pipecat Flows is part of core Pipecat, and its
+  import path is now `pipecat.flows` (previously `pipecat_flows`). The examples
+  below have been updated to use the new import path.
 </Note>
 
 ## 1. FlowManager Initialization

--- a/pipecat-flows/migration/migration-1.0.mdx
+++ b/pipecat-flows/migration/migration-1.0.mdx
@@ -12,6 +12,11 @@ Before upgrading, search your codebase for the deprecated imports and patterns l
   If you're also upgrading Pipecat, see the [Pipecat 1.0 migration guide](/pipecat/migration/migration-1.0) first.
 </Warning>
 
+<Note>
+  Pipecat Flows is now part of core Pipecat. Import it from `pipecat.flows`
+  (previously `pipecat_flows`). The examples below use the new import path.
+</Note>
+
 ## 1. FlowManager Initialization
 
 The `tts` parameter was removed from `FlowManager.__init__()`. The built-in `tts_say` action now uses Pipecat's `TTSSpeakFrame` directly and no longer needs a reference to your TTS service.
@@ -135,7 +140,7 @@ The `FlowConfig` type and `flow_config` parameter were removed. Static flows def
 ### Before (1.0)
 
 ```python
-from pipecat_flows import FlowManager, FlowConfig
+from pipecat.flows import FlowManager, FlowConfig
 
 flow_config: FlowConfig = {
     "initial_node": "greeting",
@@ -164,7 +169,7 @@ await flow_manager.initialize()
 ### After (1.0)
 
 ```python
-from pipecat_flows import FlowManager, NodeConfig
+from pipecat.flows import FlowManager, NodeConfig
 
 def create_greeting_node() -> NodeConfig:
     return {
@@ -224,7 +229,7 @@ node_config = {
 **Using `FlowsFunctionSchema`:**
 
 ```python
-from pipecat_flows import FlowsFunctionSchema
+from pipecat.flows import FlowsFunctionSchema
 
 node_config = {
     "task_messages": [...],

--- a/pipecat/examples/overview.mdx
+++ b/pipecat/examples/overview.mdx
@@ -145,7 +145,7 @@ Learn how to deploy the SmallWebRTCTransport in a Docker container.
 
 Learn how to use Pipecat Flows to create a structured navigation flow. This example shows a simple restaurant reservation flow.
 
-[View Example →](https://github.com/pipecat-ai/pipecat-flows/blob/main/examples/restaurant_reservation.py)
+[View Example →](https://github.com/pipecat-ai/pipecat/blob/main/examples/flows/restaurant_reservation.py)
 
 </Update>
 

--- a/pipecat/get-started/introduction.mdx
+++ b/pipecat/get-started/introduction.mdx
@@ -56,7 +56,7 @@ Pipecat is an open source Python framework for building voice and multimodal AI 
   <Card
     title="Conversation Flows"
     icon="diagram-project"
-    href="https://github.com/pipecat-ai/pipecat-flows">
+    href="https://github.com/pipecat-ai/pipecat/tree/main/examples/flows">
     Build structured conversations with Pipecat Flows to complete tasks and improve LLM accuracy
   </Card>
 </CardGroup>


### PR DESCRIPTION
## What & why

Pipecat Flows recently moved from its standalone package/repo into core Pipecat ([pipecat-ai/pipecat#4882](https://github.com/pipecat-ai/pipecat/pull/4882)). Several docs pages still framed Flows as an external add-on you install separately. This PR reframes Flows as built in — it ships with `pipecat-ai`, imports from `pipecat.flows`, and lives in the main repo.

## Changes

- **Install** — drop the separate `uv add pipecat-ai-flows`; show only the `pipecat-ai` install with the note that Flows is included with Pipecat.
- **Imports** — `from pipecat_flows import …` → `from pipecat.flows import …` across guides and API reference.
- **Links** — repoint repo and example links from the standalone `pipecat-ai/pipecat-flows` repo to `pipecat-ai/pipecat` (examples now under `examples/flows/`).
- **API reference** — point the Flows reference card at `reference-server.pipecat.ai/en/latest/api/pipecat.flows.html` (same build as base Pipecat) instead of the old `reference-flows.pipecat.ai`.
- **Wording** — replace "add-on framework" with built-in framing, and rewrite the "How Pipecat and Pipecat Flows Work Together" section to describe Flows as a layer that builds on the pipeline (vs. a separate companion).
- **Migration guide** — add a note that, as of `pipecat-ai` 1.5.0, Flows is part of core Pipecat and imports from `pipecat.flows`; update its examples to the new path. Kept as historical 0.0.x→1.0 content.

## Kept as-is (by decision)

- "Pipecat Flows" stays a top-level docs tab — using Flows materially changes how you design an app.
- The `/pipecat-flows/` URL namespace and redirects are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)