### PR TITLE
docs(pipecat-cloud): add Controlling costs section to scaling

### DIFF
--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -259,16 +259,16 @@ Your bill comes from two things: **active session minutes** (instances handling 
 
 Here are the levers to keep costs in check, from most to least impactful.
 
-### Scale to zero in development
+### Scale-to-zero in development
 
-If you are testing and do not need instant start times, set `min-agents` to 0. This removes all reserved charges. Your first call after an idle period takes about a 10 second [cold start](#cold-starts), then calls are instant while an instance stays warm.
+If you are testing and do not need instant start times, set `min-agents` to 0. This removes all reserved charges. Your first call after an idle period takes about a 10-second [cold start](#cold-starts), then calls are instant while an instance stays warm.
 
 ```shell
 pipecat cloud deploy [agent-name] --min-agents 0
 ```
 
 <Warning>
-  Each warm instance bills around the clock. One instance left at `--min-agents 1` runs 1,440 minutes a day. Two deployments, each holding one warm instance, add up to about 86,400 reserved minutes over a month, even with zero active sessions.
+  Each warm instance bills around the clock. One instance left at `--min-agents 1` is billed for 1,440 reserved minutes a day. Two deployments, each holding one warm instance, add up to about 86,400 reserved minutes over a month, even with zero active sessions.
 </Warning>
 
 ### Right-size min-agents in production

--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -252,3 +252,52 @@ Reserved session minutes are optional and controlled by setting `--min-agents` i
   Both active and reserved session time is measured to the second and billed in
   minutes.
 </Note>
+
+## Controlling costs
+
+Your bill comes from two things: **active session minutes** (instances handling live sessions) and **reserved session minutes** (warm instances you keep running with `min-agents`). Reserved minutes are the usual cause of a "why am I being charged when my app is idle?" surprise, because a warm instance bills around the clock whether or not anyone uses it.
+
+Here are the levers to keep costs in check, from most to least impactful.
+
+### Scale to zero in development
+
+If you are testing and do not need instant start times, set `min-agents` to 0. This removes all reserved charges. Your first call after an idle period takes about a 10 second [cold start](#cold-starts), then calls are instant while an instance stays warm.
+
+```shell
+pipecat cloud deploy [agent-name] --min-agents 0
+```
+
+<Warning>
+  Each warm instance bills around the clock. One instance left at `--min-agents 1` runs 1,440 minutes a day. Two deployments, each holding one warm instance, add up to about 86,400 reserved minutes over a month, even with zero active sessions.
+</Warning>
+
+### Right-size min-agents in production
+
+For production, set `min-agents` to cover your baseline traffic and let the free [auto-scaling buffer](#auto-scaling-buffer) handle spikes. You do not need to pre-warm for your peak. See [Capacity Planning](../guides/capacity-planning) for how to pick the number.
+
+### Cap concurrency with max-agents
+
+`max-agents` sets a hard limit on how many instances, and therefore concurrent sessions, your pool can run. It doubles as a cost ceiling: requests past the limit get a `429` instead of spinning up more paid instances.
+
+```shell
+pipecat cloud deploy [agent-name] --max-agents 25
+```
+
+### Cap runaway sessions with max-session-duration
+
+A buggy agent that never ends its pipeline can rack up active minutes. Set `--max-session-duration` as a safety net so any session is force-closed after a set time. If your calls are meant to be short, a tight cap protects you from a session that runs away.
+
+```shell
+# Force-close any session after 5 minutes
+pipecat cloud deploy [agent-name] --max-session-duration 300
+```
+
+See [session duration limits](./active-sessions#session-duration-limits) for the default and allowed range.
+
+### Delete deployments you are not using
+
+Reserved charges keep accruing as long as a deployment holds warm instances. If you are done with an app, delete the deployment to stop it completely.
+
+### Set a spend limit as a backstop
+
+You can set a spend limit in the Pipecat Cloud Dashboard under **Settings > Billing** as a safety net against unexpected charges. Treat it as a backstop, not a substitute for right-sizing `min-agents`: the levers above are what actually control what you spend.

--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -255,25 +255,25 @@ Reserved session minutes are optional and controlled by setting `--min-agents` i
 
 ## Controlling costs
 
-Your bill comes from two things: **active session minutes** (instances handling live sessions) and **reserved session minutes** (warm instances you keep running with `min-agents`). Reserved minutes are the usual cause of a "why am I being charged when my app is idle?" surprise, because a warm instance bills around the clock whether or not anyone uses it.
-
-Here are the levers to keep costs in check, from most to least impactful.
+Most surprise charges come from **reserved session minutes**: a warm instance bills around the clock whether or not anyone uses it. The levers below are ordered from most to least impactful.
 
 ### Scale-to-zero in development
 
-If you are testing and do not need instant start times, set `min-agents` to 0. This removes all reserved charges. Your first call after an idle period takes about a 10-second [cold start](#cold-starts), then calls are instant while an instance stays warm.
+If you don't need instant start times while testing, set `min-agents` to 0 to remove all reserved charges. The first call after an idle period takes a ~10-second [cold start](#cold-starts); subsequent calls are instant while an instance stays warm.
 
 ```shell
 pipecat cloud deploy [agent-name] --min-agents 0
 ```
 
 <Warning>
-  Each warm instance bills around the clock. One instance left at `--min-agents 1` is billed for 1,440 reserved minutes a day. Two deployments, each holding one warm instance, add up to about 86,400 reserved minutes over a month, even with zero active sessions.
+  Each warm instance bills around the clock. A single instance kept warm with
+  `--min-agents 1` accrues 1,440 reserved minutes a day, even with zero active
+  sessions.
 </Warning>
 
 ### Right-size min-agents in production
 
-For production, set `min-agents` to cover your baseline traffic and let the free [auto-scaling buffer](#auto-scaling-buffer) handle spikes. You do not need to pre-warm for your peak. See [Capacity Planning](../guides/capacity-planning) for how to pick the number.
+For production, set `min-agents` to cover your baseline traffic and let the free [auto-scaling buffer](#auto-scaling-buffer) handle spikes. See [Capacity Planning](../guides/capacity-planning) for how to pick the number.
 
 ### Cap concurrency with max-agents
 
@@ -285,7 +285,7 @@ pipecat cloud deploy [agent-name] --max-agents 25
 
 ### Cap runaway sessions with max-session-duration
 
-A buggy agent that never ends its pipeline can rack up active minutes. Set `--max-session-duration` as a safety net so any session is force-closed after a set time. If your calls are meant to be short, a tight cap protects you from a session that runs away.
+A buggy agent that never ends its pipeline can rack up active minutes. Set `--max-session-duration` as a safety net so any session is force-closed after a set time.
 
 ```shell
 # Force-close any session after 5 minutes
@@ -296,8 +296,8 @@ See [session duration limits](./active-sessions#session-duration-limits) for the
 
 ### Delete deployments you are not using
 
-Reserved charges keep accruing as long as a deployment holds warm instances. If you are done with an app, delete the deployment to stop it completely.
+A deployment with warm instances accrues reserved charges until you delete it. If you're done with an app, delete the deployment.
 
 ### Set a spend limit as a backstop
 
-You can set a spend limit in the Pipecat Cloud Dashboard under **Settings > Billing** as a safety net against unexpected charges. Treat it as a backstop, not a substitute for right-sizing `min-agents`: the levers above are what actually control what you spend.
+As a final safety net, set a spend limit in the Pipecat Cloud Dashboard under **Settings > Billing**. It caps the damage from a misconfiguration but doesn't replace right-sizing `min-agents`.


### PR DESCRIPTION
## What

Adds a **Controlling costs** section to the Pipecat Cloud scaling page (`pipecat-cloud/fundamentals/scaling.mdx`), right after the existing "Usage summary" billing block.

It pulls the existing cost levers into one place, ordered by impact:

- Scale to zero in development (`--min-agents 0`) to remove reserved charges
- Right-size `min-agents` in production
- Cap concurrency with `max-agents`
- Cap runaway sessions with `--max-session-duration`
- Delete unused deployments
- Set a dashboard spend limit as a backstop

## Why

Repeat support tickets where a warm reserved agent (or two) runs 24/7 with near-zero usage and surprises the customer on their invoice. Most recent example: a customer billed ~$43/month for 86,400 reserved minutes (two apps each holding one warm agent) with zero active sessions. The doc already explained `min-agents` and scale-to-zero, but had no single "how do I control my bill" answer to point people at.

## Reviewer note (please confirm)

Every claim except the spend limit is verified against the existing docs. The **"Set a spend limit as a backstop"** subsection is the one I could not fully verify: the dashboard billing component only handles payment methods in the source I checked, and the only reference to the feature is Daily's public pricing FAQ. So I kept it deliberately vague (where to find it, "backstop") and did **not** describe what happens when the limit is hit.

- If you know the real enforcement behavior (blocks new sessions, pauses, alerts), let's make that subsection specific.
- If the spend limit is not actually live yet, we should drop that subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
