### PR TITLE
docs: update for pipecat-flows PR #290

### DIFF
--- a/pipecat-flows/migration/migration-1.0.mdx
+++ b/pipecat-flows/migration/migration-1.0.mdx
@@ -13,9 +13,24 @@ Before upgrading, search your codebase for the deprecated imports and patterns l
 </Warning>
 
 <Note>
-  As of `pipecat-ai` 1.5.0, Pipecat Flows is part of core Pipecat, and its
-  import path is now `pipecat.flows` (previously `pipecat_flows`). The examples
-  below have been updated to use the new import path.
+  As of **`pipecat-ai` 1.5.0**, Pipecat Flows is part of core Pipecat. The standalone **`pipecat-ai-flows` package is deprecated** and frozen at its final release — it will not receive further updates.
+
+  **To migrate:**
+  1. Upgrade to `pipecat-ai >= 1.5.0` (Flows is included — nothing extra to install)
+  2. Uninstall the standalone package: `uv remove pipecat-ai-flows` (or `pip uninstall pipecat-ai-flows`)
+  3. Update imports from `pipecat_flows` to `pipecat.flows`:
+
+  ```python
+  # Before
+  from pipecat_flows import FlowManager, NodeConfig
+  from pipecat_flows.types import ActionConfig, ContextStrategy
+
+  # After
+  from pipecat.flows import FlowManager, NodeConfig
+  from pipecat.flows.types import ActionConfig, ContextStrategy
+  ```
+
+  That's the only change — the API is the same. The examples below use the new import path.
 </Note>
 
 ## 1. FlowManager Initialization


### PR DESCRIPTION
Automated documentation update for [pipecat-flows PR #290](https://github.com/pipecat-ai/pipecat-flows/pull/290).

## Changes
- **`pipecat-flows/migration/migration-1.0.mdx`** — Expanded the migration note to explicitly document that the standalone `pipecat-ai-flows` package is deprecated and frozen as of `pipecat-ai` 1.5.0. Added step-by-step migration instructions: upgrade pipecat-ai, uninstall pipecat-ai-flows, and update imports from `pipecat_flows` to `pipecat.flows`. Includes before/after import examples.

## Context
PR #290 officially marks the standalone `pipecat-ai-flows` package as deprecated and frozen. The package now emits a `DeprecationWarning` on import and pins its pipecat-ai dependency to `<1.5.0` to prevent conflicts with the integrated version.

The docs already used the correct `pipecat.flows` import path throughout (introduction, quickstart, guides, API reference). This update strengthens the migration guide with explicit deprecation notice and uninstall instructions.

## Gaps identified
None — all other doc pages already reflect that Flows is part of Pipecat as of 1.5.0.