### PR TITLE
Fix buffer agent timing inconsistency (scaling vs capacity planning)

### DIFF
--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -188,7 +188,7 @@ When your traffic increases and you have active sessions running, our system aut
 For example, with multiple active sessions:
 
 - The system is already spinning up additional buffer agent instances in the background
-- These buffer agent instances become available within ~10 seconds
+- These buffer agent instances become available within ~30 seconds
 - You can continue calling the `/start` endpoint without worrying about configuring additional capacity
 
 This approach means:


### PR DESCRIPTION
## Summary

The auto-scaling buffer section in `pipecat-cloud/fundamentals/scaling.mdx` said buffer agent instances become available within **~10 seconds**, while `pipecat-cloud/guides/capacity-planning.mdx` says **~30 seconds** in four places and bases its reserved-agents formula on that figure (`Optimal Reserved = MAX(Baseline Sessions, CPS x 30)`).

Customers reading both pages get two different answers to "how long until the free buffer catches up?", which changes how many reserved agents they think they need. This came up while answering a support ticket (T-2653).

This PR aligns the scaling page to ~30 seconds, matching the capacity planning guide.

## Note for reviewers

I picked ~30s because the capacity planning guide uses it consistently and its formula depends on it, and the ~10s figure on the scaling page matches the cold start number, so it looks like a copy slip. But I have not verified the real autoscaler timing. If buffer agents actually come up in ~10s, the right fix is the opposite one: update the capacity planning guide and its formula instead. Happy to flip the PR if someone who knows the autoscaler confirms.