### PR TITLE
Add Hakim community integration (STT + TTS)

### DIFF
--- a/api-reference/server/services/stt/hakim.mdx
+++ b/api-reference/server/services/stt/hakim.mdx
@@ -1,0 +1,148 @@
+---
+title: "Hakim"
+description: "Speech-to-text service implementation using Hakim's Arabic-first realtime transcription API"
+---
+
+import { CommunityMaintained } from "/snippets/community-maintained.mdx";
+
+<CommunityMaintained
+  maintainer="tryHakimAI"
+  maintainerUrl="https://github.com/tryHakimAI"
+  repo="https://github.com/tryHakimAI/hakim-pipecat"
+/>
+
+## Overview
+
+`HakimSTTService` transcribes audio into text using [Hakim](https://tryhakim.ai)'s
+Arabic-first realtime speech-to-text API. It is a `WebsocketSTTService` that opens
+one persistent connection to `WSS /v1/audio/transcriptions/stream`, forwarding audio
+continuously and relying on Pipecat's own VAD to signal end-of-turn — the same pattern
+used by other continuous-streaming STT plugins in this framework (e.g. AssemblyAI,
+Deepgram).
+
+<CardGroup cols={2}>
+  <Card
+    title="Source Repository"
+    icon="github"
+    href="https://github.com/tryHakimAI/hakim-pipecat"
+  >
+    Source code, examples, and issues for the Hakim integration
+  </Card>
+  <Card title="Hakim Docs" icon="book" href="https://tryhakim.ai/docs">
+    Learn more about Hakim's speech services
+  </Card>
+  <Card
+    title="API Keys"
+    icon="key"
+    href="https://tryhakim.ai"
+  >
+    Create and manage your Hakim API keys from the dashboard (Settings -> API keys)
+  </Card>
+</CardGroup>
+
+## Installation
+
+This is a community-maintained package distributed separately from `pipecat-ai`,
+built and maintained by the Hakim team. It is not yet published to PyPI, so install
+it directly from GitHub:
+
+```bash
+uv pip install git+https://github.com/tryHakimAI/hakim-pipecat.git
+```
+
+## Prerequisites
+
+### Hakim Account Setup
+
+Before using the Hakim STT service, you need:
+
+1. **Hakim Account**: Sign up at [tryhakim.ai](https://tryhakim.ai)
+2. **API Key**: Generate a key (format: `hk_live_...`) from the dashboard
+   (Settings -> API keys), with the `stt:write` scope
+
+### Required Environment Variables
+
+- `HAKIM_API_KEY`: Your Hakim API key. Falls back to this environment variable if
+  `api_key` is not passed to the constructor.
+
+## Configuration
+
+<ParamField path="api_key" type="str" default="None">
+  Hakim API key. Falls back to the `HAKIM_API_KEY` environment variable if not
+  provided.
+</ParamField>
+
+<ParamField path="language" type="Language" default="Language.AR">
+  Language hint for transcription.
+</ParamField>
+
+<ParamField path="input_audio_format" type="str" default="pcm16">
+  Audio format of the input stream. One of `"pcm16"`, `"opus"`, or `"mulaw"`.
+  Pipecat's transport delivers PCM16 by default, so the default matches without
+  any client-side transcoding.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="16000">
+  Must match the sample rate of audio frames actually sent to the service.
+</ParamField>
+
+<ParamField path="region" type="str" default="auto">
+  Pins the session to a specific regional endpoint. One of `"auto"`, `"de"`,
+  `"uae"`, or `"ksa"`. `"auto"` picks the closest healthy region.
+</ParamField>
+
+<ParamField path="base_url" type="str" default="None">
+  Overrides the region table entirely (staging / self-hosted). Takes precedence
+  over `region`.
+</ParamField>
+
+<ParamField path="settings" type="HakimSTTService.Settings" default="None">
+  Runtime-updatable settings. See [Settings](#settings) below.
+</ParamField>
+
+### Settings
+
+Runtime-updatable configuration passed via the `settings` constructor argument
+using `HakimSTTService.Settings(...)`.
+
+| Parameter    | Type   | Default       | Description                                                                                             |
+| ------------ | ------ | ------------- | --------------------------------------------------------------------------------------------------------- |
+| `timestamps` | `str`  | `"segment"`   | One of `"word"`, `"segment"`, or `"none"`.                                                                |
+| `diarize`    | `bool` | `False`       | Speaker diarization. Only useful for stereo audio with one speaker per channel (e.g. call recordings) -- mono `diarize=True` transcribes without speaker labels. |
+| `partials`   | `bool` | `True`        | Whether to emit interim (non-final) transcripts.                                                          |
+
+<Note>
+  See the [source
+  repository](https://github.com/tryHakimAI/hakim-pipecat) for the
+  authoritative, up-to-date configuration options.
+</Note>
+
+## Usage
+
+```python
+import os
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.transcriptions.language import Language
+from hakim_pipecat import HakimSTTService
+
+stt = HakimSTTService(
+    api_key=os.getenv("HAKIM_API_KEY"),
+    language=Language.AR,
+)
+
+pipeline = Pipeline([
+    transport.input(),               # audio/user input
+    stt,                              # Hakim STT transcription
+    context_aggregator.user(),        # add user text to context
+    llm,                              # LLM generates response
+    tts,                               # text to speech synthesis
+    transport.output(),               # stream audio back to user
+    context_aggregator.assistant(),   # store assistant response
+])
+```
+
+## Compatibility
+
+Tested with Pipecat v1.5.0. Check the [source
+repository](https://github.com/tryHakimAI/hakim-pipecat) for the latest tested
+version and changelog.

--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -145,6 +145,7 @@ Speech-to-Text services receive and audio input and output transcriptions.
 | [Google](/api-reference/server/services/stt/google)             | `uv add "pipecat-ai[google]"`                                                 | Pipecat    |
 | [Gradium](/api-reference/server/services/stt/gradium)           | `uv add "pipecat-ai[gradium]"`                                                | Pipecat    |
 | [Groq (Whisper)](/api-reference/server/services/stt/groq)       | `uv add "pipecat-ai[groq]"`                                                   | Pipecat    |
+| [Hakim](/api-reference/server/services/stt/hakim)                | `uv pip install git+https://github.com/tryHakimAI/hakim-pipecat.git`         | Community  |
 | [Mistral](/api-reference/server/services/stt/mistral)           | `uv add "pipecat-ai[mistral]"`                                                | Pipecat    |
 | [Moonshine](/api-reference/server/services/stt/moonshine)       | `uv add "pipecat-ai[moonshine]"`                                              | Pipecat    |
 | [NVIDIA](/api-reference/server/services/stt/nvidia)             | `uv add "pipecat-ai[nvidia]"`                                                 | Pipecat    |
@@ -179,6 +180,7 @@ Text-to-Speech services receive text input and output audio streams or chunks.
 | [Google](/api-reference/server/services/tts/google)               | `uv add "pipecat-ai[google]"`                                                 | Pipecat    |
 | [Gradium](/api-reference/server/services/tts/gradium)             | `uv add "pipecat-ai[gradium]"`                                                | Pipecat    |
 | [Groq](/api-reference/server/services/tts/groq)                   | `uv add "pipecat-ai[groq]"`                                                   | Pipecat    |
+| [Hakim](/api-reference/server/services/tts/hakim)                  | `uv pip install git+https://github.com/tryHakimAI/hakim-pipecat.git`         | Community  |
 | [Hume](/api-reference/server/services/tts/hume)                   | `uv add "pipecat-ai[hume]"`                                                   | Pipecat    |
 | [Inworld](/api-reference/server/services/tts/inworld)             | Built in                                                                      | Pipecat    |
 | [Kokoro](/api-reference/server/services/tts/kokoro)               | `uv add "pipecat-ai[kokoro]"`                                                 | Pipecat    |

--- a/api-reference/server/services/tts/hakim.mdx
+++ b/api-reference/server/services/tts/hakim.mdx
@@ -1,0 +1,152 @@
+---
+title: "Hakim"
+description: "Text-to-speech service implementation using Hakim's Arabic-first realtime synthesis API"
+---
+
+import { CommunityMaintained } from "/snippets/community-maintained.mdx";
+
+<CommunityMaintained
+  maintainer="tryHakimAI"
+  maintainerUrl="https://github.com/tryHakimAI"
+  repo="https://github.com/tryHakimAI/hakim-pipecat"
+/>
+
+## Overview
+
+`HakimTTSService` synthesizes speech from text using [Hakim](https://tryhakim.ai)'s
+Arabic-first realtime text-to-speech API. It subclasses `InterruptibleTTSService`
+(Hakim's realtime TTS has no mid-utterance cancel message and no word-level
+timestamps, so interruption is handled by reconnecting rather than sending a cancel
+frame) and opens one persistent connection to `WSS /v1/audio/speech/stream` -- each
+sentence Pipecat sends to `run_tts` becomes one `speech.create` request on the same
+socket, with no new TCP/TLS handshake per utterance.
+
+<CardGroup cols={2}>
+  <Card
+    title="Source Repository"
+    icon="github"
+    href="https://github.com/tryHakimAI/hakim-pipecat"
+  >
+    Source code, examples, and issues for the Hakim integration
+  </Card>
+  <Card title="Hakim Docs" icon="book" href="https://tryhakim.ai/docs">
+    Learn more about Hakim's speech services
+  </Card>
+  <Card
+    title="API Keys"
+    icon="key"
+    href="https://tryhakim.ai"
+  >
+    Create and manage your Hakim API keys from the dashboard (Settings -> API keys)
+  </Card>
+</CardGroup>
+
+## Installation
+
+This is a community-maintained package distributed separately from `pipecat-ai`,
+built and maintained by the Hakim team. It is not yet published to PyPI, so install
+it directly from GitHub:
+
+```bash
+uv pip install git+https://github.com/tryHakimAI/hakim-pipecat.git
+```
+
+## Prerequisites
+
+### Hakim Account Setup
+
+Before using the Hakim TTS service, you need:
+
+1. **Hakim Account**: Sign up at [tryhakim.ai](https://tryhakim.ai)
+2. **API Key**: Generate a key (format: `hk_live_...`) from the dashboard
+   (Settings -> API keys), with the `tts:write` scope
+3. **A voice**: pick a voice id or slug from the dashboard's Voices page
+
+### Required Environment Variables
+
+- `HAKIM_API_KEY`: Your Hakim API key. Falls back to this environment variable if
+  `api_key` is not passed to the constructor.
+
+## Configuration
+
+<ParamField path="voice" type="str" required>
+  Hakim voice id or slug. Required -- there is no bundled default voice.
+</ParamField>
+
+<ParamField path="api_key" type="str" default="None">
+  Hakim API key. Falls back to the `HAKIM_API_KEY` environment variable if not
+  provided.
+</ParamField>
+
+<ParamField path="model" type="str" default="hakim-fast-v1">
+  One of `"hakim-fast-v1"` (sub-120ms TTFB), `"hakim-v2"` (higher quality +
+  non-verbal tags), or `"hakim-v3"` (adds free-form `voice_prompt` control).
+</ParamField>
+
+<ParamField path="cfg" type="float" default="3.0">
+  Classifier-free-guidance weight, `0.0`-`10.0`.
+</ParamField>
+
+<ParamField path="voice_prompt" type="str" default="None">
+  Free-form voice-character description. Only honoured on `model="hakim-v3"` --
+  dropped elsewhere.
+</ParamField>
+
+<ParamField path="region" type="str" default="auto">
+  Pins the session to a specific regional endpoint. One of `"auto"`, `"de"`,
+  `"uae"`, or `"ksa"`.
+</ParamField>
+
+<ParamField path="base_url" type="str" default="None">
+  Overrides the region table entirely (staging / self-hosted). Takes precedence
+  over `region`.
+</ParamField>
+
+<ParamField path="settings" type="HakimTTSService.Settings" default="None">
+  Runtime-updatable settings. See [Settings](#settings) below.
+</ParamField>
+
+### Settings
+
+Runtime-updatable configuration passed via the `settings` constructor argument
+using `HakimTTSService.Settings(...)`.
+
+| Parameter      | Type    | Default | Description                                                                        |
+| -------------- | ------- | ------- | ------------------------------------------------------------------------------------ |
+| `cfg`          | `float` | `3.0`   | Classifier-free-guidance weight, `0.0`-`10.0`.                                       |
+| `voice_prompt` | `str`   | `None`  | Free-form voice-character description. Only honoured on `model="hakim-v3"`.          |
+
+<Note>
+  See the [source
+  repository](https://github.com/tryHakimAI/hakim-pipecat) for the
+  authoritative, up-to-date configuration options.
+</Note>
+
+## Usage
+
+```python
+import os
+from pipecat.pipeline.pipeline import Pipeline
+from hakim_pipecat import HakimTTSService
+
+tts = HakimTTSService(
+    api_key=os.getenv("HAKIM_API_KEY"),
+    voice="your-voice-id",
+)
+
+pipeline = Pipeline([
+    transport.input(),               # audio/user input
+    stt,                              # speech to text
+    context_aggregator.user(),        # add user text to context
+    llm,                              # LLM generates response
+    tts,                               # Hakim TTS synthesis
+    transport.output(),               # stream audio back to user
+    context_aggregator.assistant(),   # store assistant response
+])
+```
+
+## Compatibility
+
+Tested with Pipecat v1.5.0. Check the [source
+repository](https://github.com/tryHakimAI/hakim-pipecat) for the latest tested
+version and changelog.

--- a/docs.json
+++ b/docs.json
@@ -364,6 +364,7 @@
                       "api-reference/server/services/stt/google",
                       "api-reference/server/services/stt/gradium",
                       "api-reference/server/services/stt/groq",
+                      "api-reference/server/services/stt/hakim",
                       "api-reference/server/services/stt/mistral",
                       "api-reference/server/services/stt/moonshine",
                       "api-reference/server/services/stt/nvidia",
@@ -427,6 +428,7 @@
                       "api-reference/server/services/tts/google",
                       "api-reference/server/services/tts/gradium",
                       "api-reference/server/services/tts/groq",
+                      "api-reference/server/services/tts/hakim",
                       "api-reference/server/services/tts/hume",
                       "api-reference/server/services/tts/inworld",
                       "api-reference/server/services/tts/kokoro",
@@ -1864,6 +1866,10 @@
       "destination": "/api-reference/server/services/stt/groq"
     },
     {
+      "source": "/server/services/stt/hakim",
+      "destination": "/api-reference/server/services/stt/hakim"
+    },
+    {
       "source": "/server/services/stt/nvidia",
       "destination": "/api-reference/server/services/stt/nvidia"
     },
@@ -2018,6 +2024,10 @@
     {
       "source": "/server/services/tts/groq",
       "destination": "/api-reference/server/services/tts/groq"
+    },
+    {
+      "source": "/server/services/tts/hakim",
+      "destination": "/api-reference/server/services/tts/hakim"
     },
     {
       "source": "/server/services/tts/hume",


### PR DESCRIPTION
## Summary

Lists [Hakim](https://tryhakim.ai)'s STT and TTS services as a community integration, per the [Community Integrations Guide](https://github.com/pipecat-ai/pipecat/blob/main/COMMUNITY_INTEGRATIONS.md):

- Adds a row to the Supported Services page for both `HakimSTTService` and `HakimTTSService`.
- Adds dedicated service pages: `api-reference/server/services/stt/hakim.mdx` and `.../tts/hakim.mdx`, following the existing community-page pattern (e.g. Uplift AI's stt/tts pages).
- Registers both pages in `docs.json` navigation, plus legacy redirect entries matching the pattern used by sibling services.

**Source repository**: https://github.com/tryHakimAI/hakim-pipecat (MIT licensed, includes a foundational example, README, CHANGELOG, and docstrings following the project's documented conventions).

We're the team behind Hakim and built/maintain this integration ourselves.

## Demo video

Pending — will add a 30-60s demo video link to this PR description before it's ready for review, per the submission checklist.

## Checklist (per the Community Integrations Guide)

- [x] Source code in a separate repository
- [x] Foundational example (`examples/voice_agent_local.py`, `examples/smoke_test.py`)
- [x] README with install/usage/compatibility/company-attribution
- [x] LICENSE (MIT)
- [x] Docstrings following the project's documented conventions
- [x] CHANGELOG.md
- [x] Demo video (pending)