### PR TITLE
Remove 'run the development runner in production' option from self-ho…

### DIFF
--- a/pipecat/deployment/self-hosting.mdx
+++ b/pipecat/deployment/self-hosting.mdx
@@ -9,17 +9,9 @@ There isn't one right answer. The right answer depends on traffic shape, isolati
 
 ## What plays the runner's role
 
-The options below sit on a spectrum from "you run everything yourself" to "a managed runtime runs the bot for you". Strictly speaking, only the first two are self-hosting in the literal sense — the third is an alternative to self-hosting. They're walked through together because the decision space is the same one ("what serves session-start and runs the bot?") and most teams evaluating self-hosting are also weighing whether they want to be in that business at all.
+The options below sit on a spectrum from "you run everything yourself" to "a managed runtime runs the bot for you". Strictly speaking, only the first is self-hosting in the literal sense — the second is an alternative to self-hosting. They're walked through together because the decision space is the same one ("what serves session-start and runs the bot?") and most teams evaluating self-hosting are also weighing whether they want to be in that business at all.
 
-### Option 1 — Run the development runner in production
-
-For very modest traffic, `pipecat.runner.run` is a real option. It's a normal FastAPI/uvicorn app — you can put it behind a reverse proxy, deploy it as a container, and use it. For an internal tool, a prototype, or a low-volume product, that's often enough.
-
-It's worth being honest about what you don't get for free. The runner accepts unauthenticated `POST /start` requests; it has no built-in flow control or backpressure, so a traffic spike that exceeds the host's capacity will degrade silently before it fails; and a single instance is a single point of failure. You can mitigate the SPOF by running multiple instances behind a load balancer (the runner doesn't hold session-routing state of its own as long as your transport choice doesn't require stickiness), but the flow-control gap and the missing request authentication you still have to address yourself.
-
-A practical upper bound per host is "however many concurrent bot subprocesses one host can sustain", which depends heavily on what your pipeline does. CPU-light pipelines that mostly proxy between transport and third-party services can pack many sessions per host; pipelines with local STT/TTS, custom models, or significant VAD work will saturate sooner.
-
-### Option 2 — Build your own dispatcher
+### Option 1 — Build your own dispatcher
 
 You write the HTTP service that receives session-start requests, and you decide how bot processes get into existence. This is the most flexible option and the most work. The two patterns most teams reach for here are:
 
@@ -28,13 +20,13 @@ You write the HTTP service that receives session-start requests, and you decide 
 
 These aren't the only shapes. Some teams build longer-lived orchestrated fleets on Kubernetes (with HPA or KEDA scaling on a custom session-count metric), or use a serverless platform's function-per-invocation model. The right shape is the one whose latency / cost / isolation profile matches the bot you're shipping and the traffic you're seeing.
 
-### Option 3 — Use a managed agent runtime
+### Option 2 — Use a managed agent runtime
 
 This option steps out of self-hosting: a managed platform runs the bot process for you. You supply the bot file (and usually a thin proxy that forwards session-start traffic), and the platform owns the runtime, pool, and lifecycle. This minimizes the operational surface you carry but trades for vendor lock-in and whatever feature ceiling the runtime has. See [Managed agent runtime](./patterns/managed-runtime).
 
 [Pipecat Cloud](/pipecat-cloud/introduction) is one example: Daily's managed runtime, purpose-built for Pipecat. The development runner's session-start API is deliberately shaped the same way as PCC's (`POST /start`, `/sessions/{id}/...`), which means a bot file and client built against the runner work against PCC unchanged. Other managed runtimes — like AWS Bedrock AgentCore — are the same shape, with their own platform-specific tradeoffs.
 
-If you're considering self-hosting partly because you already have an ops team and existing infrastructure to leverage, options 1–2 are probably the right starting point. If you'd rather not build any of that surface, option 3 is the path designed to skip it.
+If you're considering self-hosting partly because you already have an ops team and existing infrastructure to leverage, option 1 is probably the right starting point. If you'd rather not build any of that surface, option 2 is the path designed to skip it.
 
 ## What you'll need to address either way
 


### PR DESCRIPTION
…sting page

The self-hosting options now start with building your own dispatcher; the managed runtime option is renumbered accordingly.