### PR TITLE
docs: consistent Title Case for deployment and other page titles

### DIFF
--- a/api-reference/client/js/callbacks.mdx
+++ b/api-reference/client/js/callbacks.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Callbacks and events"
+title: "Callbacks and Events"
 description: "Handle bot events and state changes with callbacks and event listeners in the Pipecat JavaScript client"
 ---
 

--- a/api-reference/pipecat-cloud/rest-reference/endpoint/start.mdx
+++ b/api-reference/pipecat-cloud/rest-reference/endpoint/start.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Start an Agent session"
+title: "Start an Agent Session"
 description: "Start a new session with a deployed agent."
 openapi: "POST /{agentName}/start"
 ---

--- a/api-reference/pipecat-cloud/rest-reference/endpoint/stop.mdx
+++ b/api-reference/pipecat-cloud/rest-reference/endpoint/stop.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Stop an Agent session"
+title: "Stop an Agent Session"
 description: "Stop a running agent session and clean up its resources."
 openapi: "DELETE /agents/{agentName}/sessions/{sessionId}"
 ---

--- a/api-reference/server/links/server-reference.mdx
+++ b/api-reference/server/links/server-reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference docs"
+title: "Reference Docs"
 description: "Auto-generated Python API reference for the Pipecat server framework"
 url: "https://reference-server.pipecat.ai/"
 icon: "book"

--- a/docs.json
+++ b/docs.json
@@ -145,7 +145,7 @@
               "pipecat/deployment/running-bots-locally",
               "pipecat/deployment/running-bots-in-production",
               {
-                "group": "Production hosting patterns",
+                "group": "Production Hosting Patterns",
                 "pages": [
                   "pipecat/deployment/patterns/vm-per-session",
                   "pipecat/deployment/patterns/warm-pool-subprocess",

--- a/pipecat-cloud/fundamentals/health-checks.mdx
+++ b/pipecat-cloud/fundamentals/health-checks.mdx
@@ -1,5 +1,5 @@
 ---
-title: Health checks
+title: Health Checks
 description: "Report agent readiness and liveness, and recycle instances on your own schedule"
 ---
 

--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -84,7 +84,7 @@ pipecat cloud deploy [agent-name] --min-agents 1
 Deployments can optionally be made with a `max-agents` configuration that limits the number of agent instances that your pool can contain.
 This exists as a cost control measure, allowing developers to limit the total number of active sessions that can be run at any one time.
 
-The maximum instance count is a hard limit, meaning requests made to a pool that is at capacity will receive a `429` response. See [starting sessions](./active-sessions#agent-capacity) for more information for how to handle this in your application code.
+The maximum instance count is a hard limit, meaning requests made to a pool that is at capacity will receive a `429` response. See [Starting Sessions](./active-sessions#agent-capacity) for more information for how to handle this in your application code.
 
 ```shell
 # Limit pool to 25 active sessions running concurrently

--- a/pipecat/deployment/overview.mdx
+++ b/pipecat/deployment/overview.mdx
@@ -9,15 +9,15 @@ A Pipecat bot is a Python process. Running one locally is straightforward; runni
 
 It's helpful to separate two things that often get tangled together:
 
-- **Running a bot during development** — getting a bot file to start up, accept a connection, and let you talk to it. Pipecat ships its own server for this; you usually don't need to write one. See [Running bots locally](./running-bots-locally).
-- **Hosting bots in production** — deciding what serves session-start requests at scale, how bot processes get spawned, and how the operational surface (capacity, lifecycle, observability) is handled. This is genuinely several distinct problems and the right answer depends on your bot, your traffic, and what you already know how to operate. See [Running bots in production](./running-bots-in-production).
+- **Running a bot during development** — getting a bot file to start up, accept a connection, and let you talk to it. Pipecat ships its own server for this; you usually don't need to write one. See [Running Bots Locally](./running-bots-locally).
+- **Hosting bots in production** — deciding what serves session-start requests at scale, how bot processes get spawned, and how the operational surface (capacity, lifecycle, observability) is handled. This is genuinely several distinct problems and the right answer depends on your bot, your traffic, and what you already know how to operate. See [Running Bots in Production](./running-bots-in-production).
 
 ## What you'll typically build
 
 Most Pipecat deployments end up with some version of these pieces:
 
 - **A bot** — your `bot.py`. A Python function (`async def bot(runner_args)`) that joins a media session, runs your pipeline, and exits when the session ends.
-- **Something that serves session-start requests** — an HTTP service that receives "start a session" requests from your client, sets up the media transport, and causes a bot process to come into existence ready to accept the user. In development this is the [built-in runner](./running-bots-locally). In production this is a hand-rolled dispatcher, a managed agent runtime, or [Pipecat Cloud](/pipecat-cloud/introduction) — the development runner is a local tool and isn't built for production. See [Running bots in production](./running-bots-in-production) for the tradeoffs.
+- **Something that serves session-start requests** — an HTTP service that receives "start a session" requests from your client, sets up the media transport, and causes a bot process to come into existence ready to accept the user. In development this is the [built-in runner](./running-bots-locally). In production this is a hand-rolled dispatcher, a managed agent runtime, or [Pipecat Cloud](/pipecat-cloud/introduction) — the development runner is a local tool and isn't built for production. See [Running Bots in Production](./running-bots-in-production) for the tradeoffs.
 - **A media transport** — WebRTC, WebSockets, SIP, or whatever the user connects through. Sometimes a service you host, more often a third-party provider (Daily, Twilio, etc.).
 
 The development runner deliberately mimics Pipecat Cloud's session-start API (`POST /start`, `/sessions/{id}/...`), so a bot file that runs locally can run against either with no code changes — and an HTTP service that fronts your fleet in production can offer the same shape if you want clients to be portable.
@@ -28,14 +28,14 @@ If you're starting fresh:
 
 <CardGroup cols={2}>
   <Card
-    title="Running bots locally"
+    title="Running Bots Locally"
     icon="terminal"
     href="./running-bots-locally"
   >
     The bot entry point, the built-in runner, and the supported transports.
   </Card>
   <Card
-    title="Running bots in production"
+    title="Running Bots in Production"
     icon="server"
     href="./running-bots-in-production"
   >
@@ -46,11 +46,11 @@ If you're starting fresh:
 If you already know the basics and want concrete patterns:
 
 <CardGroup cols={2}>
-  <Card title="VM per session" icon="cube" href="./patterns/vm-per-session">
+  <Card title="VM per Session" icon="cube" href="./patterns/vm-per-session">
     Dispatcher calls a cloud machines API to spawn a fresh VM per session.
   </Card>
   <Card
-    title="Warm pool with subprocess workers"
+    title="Warm Pool with Subprocess Workers"
     icon="layer-group"
     href="./patterns/warm-pool-subprocess"
   >
@@ -58,14 +58,14 @@ If you already know the basics and want concrete patterns:
     use.
   </Card>
   <Card
-    title="Managed agent runtime"
+    title="Managed Agent Runtime"
     icon="cloud"
     href="./patterns/managed-runtime"
   >
     Hand the bot lifecycle off to a runtime that owns scaling and dispatch.
   </Card>
   <Card
-    title="Telephony in production"
+    title="Telephony in Production"
     icon="phone"
     href="./telephony-in-production"
   >

--- a/pipecat/deployment/patterns/managed-runtime.mdx
+++ b/pipecat/deployment/patterns/managed-runtime.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Managed agent runtime"
+title: "Managed Agent Runtime"
 description: "Hand the bot lifecycle off to a runtime that owns scaling, dispatch, and execution."
 ---
 

--- a/pipecat/deployment/patterns/vm-per-session.mdx
+++ b/pipecat/deployment/patterns/vm-per-session.mdx
@@ -1,5 +1,5 @@
 ---
-title: "VM per session"
+title: "VM per Session"
 description: "A dispatcher spawns a fresh cloud VM for each session via the provider's machines API."
 ---
 

--- a/pipecat/deployment/patterns/warm-pool-subprocess.mdx
+++ b/pipecat/deployment/patterns/warm-pool-subprocess.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Warm pool with subprocess workers"
+title: "Warm Pool with Subprocess Workers"
 description: "Pre-allocate transport resources and bot subprocesses on a long-lived host; replenish on use."
 ---
 

--- a/pipecat/deployment/running-bots-in-production.mdx
+++ b/pipecat/deployment/running-bots-in-production.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Running bots in production"
+title: "Running Bots in Production"
 description: "What plays the role of the development runner when you run bots in production, and how to think about the choices."
 ---
 
@@ -39,7 +39,7 @@ These aren't the only shapes. Some teams build longer-lived orchestrated fleets 
 
 ### Option 2 — Use a managed agent runtime
 
-This option steps out of self-hosting: a managed platform runs the bot process for you. You supply the bot file (and usually a thin proxy that forwards session-start traffic), and the platform owns the runtime, pool, and lifecycle. This minimizes the operational surface you carry but trades for vendor lock-in and whatever feature ceiling the runtime has. See [Managed agent runtime](./patterns/managed-runtime).
+This option steps out of self-hosting: a managed platform runs the bot process for you. You supply the bot file (and usually a thin proxy that forwards session-start traffic), and the platform owns the runtime, pool, and lifecycle. This minimizes the operational surface you carry but trades for vendor lock-in and whatever feature ceiling the runtime has. See [Managed Agent Runtime](./patterns/managed-runtime).
 
 [Pipecat Cloud](/pipecat-cloud/introduction) is one example: Daily's managed runtime, purpose-built for Pipecat. The development runner's session-start API is deliberately shaped the same way as PCC's (`POST /start`, `/sessions/{id}/...`), which means a bot file and client built against the runner work against PCC unchanged. Other managed runtimes — like AWS Bedrock AgentCore — are the same shape, with their own platform-specific tradeoffs.
 
@@ -121,7 +121,7 @@ Most production deployments hit one or more of:
 
 - **Region selection for latency** — voice is latency-sensitive. Bots placed far from users introduce audible delay even when individual services are fast.
 - **Service quotas** — your cloud provider's machines API, your transport provider's rate limits, and the LLM/TTS providers your pipeline calls all have ceilings you'll find at scale.
-- **Telephony-specific networking** — SIP and PSTN setups can carry their own constraints depending on the carrier. See [Telephony in production](./telephony-in-production).
+- **Telephony-specific networking** — SIP and PSTN setups can carry their own constraints depending on the carrier. See [Telephony in Production](./telephony-in-production).
 
 ## Where to go next
 

--- a/pipecat/deployment/running-bots-locally.mdx
+++ b/pipecat/deployment/running-bots-locally.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Running bots locally"
+title: "Running Bots Locally"
 description: "The bot entry point, the built-in development runner, and the transports it supports."
 ---
 
@@ -11,7 +11,7 @@ This page covers the canonical shape: a bot file with a single async entry point
   The development runner is a **local development tool** — it isn't built or
   supported for production use. See [The runner is a development
   tool](#the-runner-is-a-development-tool-not-a-production-server) below, and
-  [Running bots in production](./running-bots-in-production) for what to reach
+  [Running Bots in Production](./running-bots-in-production) for what to reach
   for instead.
 </Note>
 
@@ -111,4 +111,4 @@ This is the simplest way to extend the runner — for things like health checks,
 
 The development runner is exactly that — a tool for local development. It's deliberately simple: its `POST /start` endpoint accepts session-start requests from anyone, some transport webhooks (like Daily's dial-in webhook) are likewise unauthenticated, and there's no rate limiting or backpressure anywhere. It's also a single process with no lifecycle management. Those are the right tradeoffs on your own machine, and the wrong ones on a public address, where a single request can spin up a bot and create paid rooms on your account.
 
-For anything real, put a proper dispatcher or a managed runtime in front of your bots instead of exposing the runner. The next page, [Running bots in production](./running-bots-in-production), walks through those options — including how to package the bot into a container image — and, if you only need something reachable for a prototype or alpha test, the minimum you'd want in front of the runner and where that stops being enough.
+For anything real, put a proper dispatcher or a managed runtime in front of your bots instead of exposing the runner. The next page, [Running Bots in Production](./running-bots-in-production), walks through those options — including how to package the bot into a container image — and, if you only need something reachable for a prototype or alpha test, the minimum you'd want in front of the runner and where that stops being enough.

--- a/pipecat/deployment/telephony-in-production.mdx
+++ b/pipecat/deployment/telephony-in-production.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Telephony in production"
+title: "Telephony in Production"
 description: "Webhook-driven dispatch, carrier-specific gotchas, and how telephony differs from WebRTC."
 ---
 

--- a/pipecat/learn/agent-handoff.mdx
+++ b/pipecat/learn/agent-handoff.mdx
@@ -171,7 +171,7 @@ async def on_client_connected(transport, client):
     )
 ```
 
-If you need to react to a specific agent registering (for example in a distributed setup), use the `@worker_ready` decorator instead. See [Agent registry and discovery](/pipecat/fundamentals/agent-registry-and-discovery).
+If you need to react to a specific agent registering (for example in a distributed setup), use the `@worker_ready` decorator instead. See [Agent Registry and Discovery](/pipecat/fundamentals/agent-registry-and-discovery).
 
 ## Putting it all together
 


### PR DESCRIPTION
## What

A Title Case **consistency pass** across the docs, covering two separate things under the site's dominant **AP-style Title Case** convention:
1. Page/sidebar titles that were still Sentence cased.
2. Citation-style inline links whose text names a page but was under-capitalized — found via a whole-site sweep, and largely **independent** of (1): most of the linked pages were already correctly titled.

## Why

A scan of all 440 frontmatter titles found **210 of ~221 multi-word titles already use Title Case** (e.g. "Speech to Text", "Building with Gemini Live", "Create an Agent"). Only 11 deviated with Sentence case — 6 of them in the **Deployment** section under the Pipecat tab, which is what prompted this — and a handful of links elsewhere hadn't kept up with their (already Title Case) targets.

## Changes

### 1. Titles → Title Case (11 pages)
- Deployment (Pipecat tab): Running Bots Locally · Running Bots in Production · VM per Session · Warm Pool with Subprocess Workers · Managed Agent Runtime · Telephony in Production
- Plus the matching `<Card>` labels on the Deployment overview and the `"Production Hosting Patterns"` group header in `docs.json` (its sibling "Hosting Platforms" was already Title Case)
- Five other site-wide deviators: Callbacks and Events · Start an Agent Session · Stop an Agent Session · Reference Docs · Health Checks

### 2. Citation-style inline links → Title Case
A whole-site sweep resolved every internal link to its target page and compared the link text against that page's title. Only genuine page citations were changed — some point to pages retitled here, others to pages that were **already** correctly titled:
- `overview` — "See [Running Bots in Production]" (plus the other deployment See-directives and the next-page reference in `running-bots-locally`) → targets retitled here
- `agent-handoff` — "See [Agent Registry and Discovery]" → target already correctly titled
- `scaling` — "See [Starting Sessions]" → target already correctly titled

### Left in prose case (deliberately)
Descriptive/woven references and idea enumerations, where the text names a concept rather than citing a page:
- the two-pattern enumeration in `running-bots-in-production` ("[vm per session] — …", "[warm pool with subprocess workers] — …")
- the "## See also" tradeoff bullet in `warm-pool-subprocess`
- topic-label bullets ("WebSocket authentication" beside "Regional endpoints"; "Twilio WebSocket integration" beside "Daily PSTN integration")
- woven mentions ("use context summarization", "when user mute strategies activate", "the development runner handles…")

## Notes
- Short prepositions/articles stay lowercase (in, of, to, with, an, per), consistent with existing titles.
- No URLs or link targets changed, so no links break.
- Single squashed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)