### PR TITLE
Add Acefone/Smartflo community serializer docs

### DIFF
--- a/api-reference/server/services/serializers/acefone.mdx
+++ b/api-reference/server/services/serializers/acefone.mdx
@@ -1,0 +1,152 @@
+---
+title: "Acefone"
+description: "Telephony frame serializer for hosting Pipecat agents on the Acefone / Smartflo (Tata Tele Business) media stream over a websocket"
+---
+
+import { CommunityMaintained } from "/snippets/community-maintained.mdx";
+
+<CommunityMaintained
+  maintainer="monster-anshu"
+  maintainerUrl="https://github.com/monster-anshu"
+  repo="https://github.com/monster-anshu/pipecat-acefone"
+/>
+
+## Overview
+
+`AcefoneFrameSerializer` converts between Pipecat frames and the
+[Acefone](https://acefone.in/) / [Smartflo](https://smartflo.tatatelebusiness.com/)
+(Tata Tele Business) bi-directional audio streaming protocol, enabling real-time
+voice agents over a websocket. It is designed to be wired into a
+`FastAPIWebsocketTransport` so you can host a Pipecat agent on the Acefone/Smartflo
+telephony stack and reach it over an Indian phone number.
+
+It supports both `ULAW` (8kHz G.711 μ-law, the default) and `PCM` (16-bit linear
+PCM) wire formats, DTMF keypad input, interruptions, and optional automatic call
+termination over the same websocket.
+
+<CardGroup cols={2}>
+  <Card
+    title="Source Repository"
+    icon="github"
+    href="https://github.com/monster-anshu/pipecat-acefone"
+  >
+    Source code, examples, and issues for the Acefone/Smartflo integration
+  </Card>
+  <Card
+    title="PyPI Package"
+    icon="cube"
+    href="https://pypi.org/project/pipecat-acefone/"
+  >
+    The `pipecat-acefone` package on PyPI
+  </Card>
+  <Card title="Acefone" icon="phone" href="https://acefone.in/">
+    Learn about Acefone / Smartflo telephony and get a phone number
+  </Card>
+  <Card
+    title="Protocol Docs"
+    icon="book"
+    href="https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document"
+  >
+    Acefone/Smartflo bi-directional audio streaming message formats
+  </Card>
+</CardGroup>
+
+## Installation
+
+This is a community-maintained package distributed separately from `pipecat-ai`:
+
+```bash
+pip install pipecat-acefone
+```
+
+## Prerequisites
+
+To host an agent on the Acefone/Smartflo telephony stack you need:
+
+1. **An Acefone or Smartflo phone number**: with bi-directional audio streaming
+   enabled and pointed at your bot's websocket endpoint.
+2. **A public websocket endpoint**: expose your bot's websocket so Acefone/Smartflo
+   can connect to it (for example, by tunneling with `ngrok` during development).
+
+The serializer itself does not require any API keys — automatic hang-up is
+performed over the same websocket via an `end` event. The provider's message
+formats are documented in the
+[Acefone](https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document)
+and
+[Smartflo](https://docs.smartflo.tatatelebusiness.com/docs/bi-directional-audio-streaming-integration-document)
+docs.
+
+## Configuration
+
+`AcefoneFrameSerializer` takes a single, optional `params` argument:
+
+<ParamField
+  path="params"
+  type="AcefoneFrameSerializer.InputParams"
+  default="InputParams()"
+>
+  Serializer input parameters, including the stream/call identifiers. See
+  [InputParams](#inputparams) below.
+</ParamField>
+
+### InputParams
+
+Passed via the `params` constructor argument using
+`AcefoneFrameSerializer.InputParams(...)`.
+
+| Parameter             | Type                 | Default | Description                                                                                                                    |
+| --------------------- | -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `media_format`        | `AcefoneMediaFormat` | `ULAW`  | Wire audio format. `ULAW` = 8kHz G.711 μ-law; `PCM` = 16-bit linear PCM (`slin16`).                                            |
+| `acefone_sample_rate` | `int`                | `8000`  | Sample rate of the Acefone/Smartflo media stream (Hz).                                                                         |
+| `sample_rate`         | `int`                | `0`     | Pipeline input sample rate override. When `0`, the rate is taken from the `StartFrame` during setup.                           |
+| `stream_sid`          | `str`                | `None`  | The Media Stream SID for the call. Typically parsed from the initial `start` message; captured automatically from it if unset. |
+| `call_sid`            | `str`                | `None`  | The associated Call SID. Required when `auto_hang_up` is enabled.                                                              |
+| `auto_hang_up`        | `bool`               | `False` | Terminate the call via a websocket `end` event on the first `EndFrame`/`CancelFrame`.                                          |
+
+<Note>
+  See the [source repository](https://github.com/monster-anshu/pipecat-acefone)
+  for the authoritative, up-to-date list of parameters and message formats.
+</Note>
+
+## Usage
+
+Wire the serializer into a `FastAPIWebsocketTransport`. The `stream_sid` (and
+`call_sid`, if you enable auto hang-up) is read from the initial websocket `start`
+message Acefone/Smartflo sends when a call connects.
+
+```python
+from pipecat_acefone import AcefoneFrameSerializer, AcefoneMediaFormat
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketTransport,
+    FastAPIWebsocketParams,
+)
+
+serializer = AcefoneFrameSerializer(
+    AcefoneFrameSerializer.InputParams(
+        stream_sid=stream_id,
+        call_sid=call_id,
+        auto_hang_up=True,
+        media_format=AcefoneMediaFormat.ULAW,
+    )
+)
+
+transport = FastAPIWebsocketTransport(
+    websocket=websocket_client,
+    params=FastAPIWebsocketParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        add_wav_header=False,
+        serializer=serializer,
+    ),
+)
+```
+
+See the [source repository](https://github.com/monster-anshu/pipecat-acefone) for a
+complete `bot.py` example, including parsing `stream_sid` from the initial
+websocket messages and running the bot behind an `ngrok` tunnel.
+
+## Compatibility
+
+Tested with Pipecat v1.5.0 and Python 3.11+. Check the [source
+repository](https://github.com/monster-anshu/pipecat-acefone) for the latest tested
+version and changelog.

--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -116,6 +116,7 @@ Serializers convert between frames and media streams, enabling real-time communi
 
 | Service                                                           | Setup                      | Maintainer |
 | ----------------------------------------------------------------- | -------------------------- | ---------- |
+| [Acefone](/api-reference/server/services/serializers/acefone)     | `uv add pipecat-acefone`   | Community  |
 | [Asterisk](/api-reference/server/services/serializers/asterisk)   | `uv add pipecat-asterisk`  | Community  |
 | [AwaazAI](/api-reference/server/services/serializers/awaazai)     | `uv add pipecat-awaazai`   | Community  |
 | [Bandwidth](/api-reference/server/services/serializers/bandwidth) | `uv add pipecat-bandwidth` | Community  |

--- a/docs.json
+++ b/docs.json
@@ -337,6 +337,7 @@
                     "group": "Serializers",
                     "pages": [
                       "api-reference/server/services/serializers/introduction",
+                      "api-reference/server/services/serializers/acefone",
                       "api-reference/server/services/serializers/asterisk",
                       "api-reference/server/services/serializers/awaazai",
                       "api-reference/server/services/serializers/bandwidth",
@@ -1700,6 +1701,10 @@
     {
       "source": "/server/services/tts/voiceai",
       "destination": "/api-reference/server/services/tts/voiceai"
+    },
+    {
+      "source": "/server/services/serializers/acefone",
+      "destination": "/api-reference/server/services/serializers/acefone"
     },
     {
       "source": "/server/services/serializers/asterisk",


### PR DESCRIPTION
Add a community-integration docs page for the pipecat-acefone package (AcefoneFrameSerializer), which serializes the Acefone / Smartflo (Tata Tele Business) bi-directional audio streaming WebSocket protocol.

- New service page under serializers/acefone
- Add Acefone row to the Serializers table in supported-services
- Register the page in docs.json nav and add a redirect

Package repo : [pipecat-acefone](https://github.com/monster-anshu/pipecat-acefone)