### PR TITLE
Add documentation for the Hecttor audio filter

### DIFF
--- a/api-reference/server/utilities/audio/hecttor-filter.mdx
+++ b/api-reference/server/utilities/audio/hecttor-filter.mdx
@@ -1,0 +1,123 @@
+---
+title: "HecttorFilter"
+description: "Audio denoising filter using the Hecttor SDK"
+---
+
+## Overview
+
+`HecttorFilter` is an audio processor that enhances speech in real-time audio streams using the Hecttor SDK's neural network-based denoising. It inherits from `BaseAudioFilter` and processes audio frames to remove background noise before they reach the STT service.
+
+The filter uses Hecttor's ASR-optimized enhancer, which is tuned to preserve the speech characteristics important for transcription accuracy. You can select among several enhancement models and blend the enhanced output with the original audio.
+
+To use Hecttor, contact [Hecttor](https://hecttor.ai) for SDK access and an API key.
+
+## Installation
+
+See the [Hecttor guide](/pipecat/features/hecttor) to learn how to install the Hecttor SDK.
+
+## Environment Variables
+
+<ParamField path="HECTTOR_API_KEY" type="string" required>
+  Hecttor API key for authentication and usage tracking. Can also be passed directly via the `api_key` constructor parameter.
+</ParamField>
+
+## Constructor Parameters
+
+<ParamField path="api_key" type="str" default="None">
+  Hecttor API key. If not provided, falls back to the `HECTTOR_API_KEY` environment variable.
+</ParamField>
+
+<ParamField path="model_name" type="str" default='"coda-vi-1.0"'>
+  ASR enhancement model to use. One of `"crest-1.0"`, `"crest-2.0"`, `"mist-1.0"`, `"coda-1.0"`, or `"coda-vi-1.0"`.
+</ParamField>
+
+<ParamField path="chunk_size_ms" type="int" default="20">
+  Chunk size in milliseconds for audio processing. Either `16` or `20`. The `"crest-2.0"`, `"coda-1.0"`, and `"coda-vi-1.0"` models require `20`.
+</ParamField>
+
+<ParamField path="enhancer_weight" type="float" default="None">
+  Blend factor between original and enhanced audio in the range `[0.0, 1.0]`. `1.0` = fully enhanced, `0.0` = original audio. If not set, the model's default weight is used.
+</ParamField>
+
+## Supported Sample Rates
+
+The filter supports the following sample rates (the SDK automatically resamples internally):
+
+- 4000 Hz
+- 8000 Hz
+- 16000 Hz
+- 24000 Hz
+- 32000 Hz
+- 44100 Hz
+- 48000 Hz
+
+## Input Frames
+
+<ParamField path="FilterEnableFrame" type="Frame">
+  Control frame to toggle filtering on/off at runtime.
+
+```python
+from pipecat.frames.frames import FilterEnableFrame
+
+# Disable denoising
+await worker.queue_frame(FilterEnableFrame(False))
+
+# Re-enable denoising
+await worker.queue_frame(FilterEnableFrame(True))
+```
+
+</ParamField>
+
+## Usage Example
+
+### Basic Usage
+
+```python
+from pipecat.audio.filters.hecttor_filter import HecttorFilter
+from pipecat.transports.daily.transport import DailyParams, DailyTransport
+
+transport = DailyTransport(
+    room_url,
+    token,
+    "Respond bot",
+    DailyParams(
+        audio_in_enabled=True,
+        audio_in_filter=HecttorFilter(),  # Enable Hecttor denoising
+        audio_out_enabled=True,
+    ),
+)
+```
+
+### Fine-tuning Enhancement
+
+Use the `enhancer_weight` parameter to blend between original and enhanced audio:
+
+```python
+hecttor_filter = HecttorFilter(
+    model_name="coda-vi-1.0",
+    enhancer_weight=0.8,  # 80% enhanced, 20% original
+)
+```
+
+### Other Transports
+
+The filter works with any transport that supports `audio_in_filter`:
+
+```python
+from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
+
+# Twilio / WebSocket
+params = FastAPIWebsocketParams(
+    audio_in_enabled=True,
+    audio_in_filter=hecttor_filter,
+    audio_out_enabled=True,
+)
+```
+
+## Notes
+
+- The Hecttor SDK is not publicly available on PyPI. Contact [Hecttor](https://hecttor.ai) for SDK access and an API key.
+- The SDK requires outbound HTTPS access for API key authentication on initialization.
+- The filter uses the ASR-optimized enhancer, which is tuned for speech-to-text accuracy.
+- Internal neural network state is maintained across chunks for seamless streaming, and is reset through the filter's `stop()`/`start()` cycle.
+- The filter buffers audio internally to build complete chunks, so it returns empty bytes until enough audio has accumulated.

--- a/api-reference/server/utilities/audio/hecttor-filter.mdx
+++ b/api-reference/server/utilities/audio/hecttor-filter.mdx
@@ -18,25 +18,31 @@ See the [Hecttor guide](/pipecat/features/hecttor) to learn how to install the H
 ## Environment Variables
 
 <ParamField path="HECTTOR_API_KEY" type="string" required>
-  Hecttor API key for authentication and usage tracking. Can also be passed directly via the `api_key` constructor parameter.
+  Hecttor API key for authentication and usage tracking. Can also be passed
+  directly via the `api_key` constructor parameter.
 </ParamField>
 
 ## Constructor Parameters
 
 <ParamField path="api_key" type="str" default="None">
-  Hecttor API key. If not provided, falls back to the `HECTTOR_API_KEY` environment variable.
+  Hecttor API key. If not provided, falls back to the `HECTTOR_API_KEY`
+  environment variable.
 </ParamField>
 
 <ParamField path="model_name" type="str" default='"coda-vi-1.0"'>
-  ASR enhancement model to use. One of `"crest-1.0"`, `"crest-2.0"`, `"mist-1.0"`, `"coda-1.0"`, or `"coda-vi-1.0"`.
+  ASR enhancement model to use. One of `"crest-1.0"`, `"crest-2.0"`,
+  `"mist-1.0"`, `"coda-1.0"`, or `"coda-vi-1.0"`.
 </ParamField>
 
 <ParamField path="chunk_size_ms" type="int" default="20">
-  Chunk size in milliseconds for audio processing. Either `16` or `20`. The `"crest-2.0"`, `"coda-1.0"`, and `"coda-vi-1.0"` models require `20`.
+  Chunk size in milliseconds for audio processing. Either `16` or `20`. The
+  `"crest-2.0"`, `"coda-1.0"`, and `"coda-vi-1.0"` models require `20`.
 </ParamField>
 
 <ParamField path="enhancer_weight" type="float" default="None">
-  Blend factor between original and enhanced audio in the range `[0.0, 1.0]`. `1.0` = fully enhanced, `0.0` = original audio. If not set, the model's default weight is used.
+  Blend factor between original and enhanced audio in the range `[0.0, 1.0]`.
+  `1.0` = fully enhanced, `0.0` = original audio. If not set, the model's
+  default weight is used.
 </ParamField>
 
 ## Supported Sample Rates

--- a/docs.json
+++ b/docs.json
@@ -118,6 +118,7 @@
           {
             "group": "Features",
             "pages": [
+              "pipecat/features/hecttor",
               "pipecat/features/krisp-viva",
               "pipecat/features/whatsapp",
               "pipecat/features/gemini-live",
@@ -560,6 +561,7 @@
                       "api-reference/server/utilities/audio/aic-filter",
                       "api-reference/server/utilities/audio/aic-quail-vad-analyzer",
                       "api-reference/server/utilities/audio/audio-buffer-processor",
+                      "api-reference/server/utilities/audio/hecttor-filter",
                       "api-reference/server/utilities/audio/koala-filter",
                       "api-reference/server/utilities/audio/krisp-viva-filter",
                       "api-reference/server/utilities/audio/krisp-viva-vad-analyzer",

--- a/pipecat/features/hecttor.mdx
+++ b/pipecat/features/hecttor.mdx
@@ -35,9 +35,7 @@ To use Hecttor with Pipecat, you need:
 1. A Hecttor API key
 2. The `hecttor_sdk` Python wheel for your platform
 
-<Tip>
-  Contact [Hecttor](https://hecttor.ai) for SDK access and an API key.
-</Tip>
+<Tip>Contact [Hecttor](https://hecttor.ai) for SDK access and an API key.</Tip>
 
 ## Setup
 

--- a/pipecat/features/hecttor.mdx
+++ b/pipecat/features/hecttor.mdx
@@ -1,0 +1,138 @@
+---
+title: "Hecttor"
+sidebarTitle: "Hecttor"
+description: "Learn how to integrate Hecttor's audio denoising into your Pipecat application"
+---
+
+## Overview
+
+Hecttor's SDK provides real-time audio denoising for Pipecat applications using deep learning. The `HecttorFilter` uses Hecttor's ASR-optimized enhancer, which removes background noise while preserving the speech characteristics important for transcription accuracy — leading to fewer errors and better STT results. Several enhancement models are available, and you can blend the enhanced output with the original audio.
+
+<CardGroup cols={2}>
+  <Card
+    title="HecttorFilter Reference"
+    icon="code"
+    href="/api-reference/server/utilities/audio/hecttor-filter"
+  >
+    API reference for audio denoising
+  </Card>
+  <Card
+    title="Hecttor Example"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-hecttor.py"
+  >
+    Complete example with Hecttor denoising
+  </Card>
+  <Card title="Hecttor" icon="globe" href="https://hecttor.ai">
+    Learn more about Hecttor
+  </Card>
+</CardGroup>
+
+## Prerequisites
+
+To use Hecttor with Pipecat, you need:
+
+1. A Hecttor API key
+2. The `hecttor_sdk` Python wheel for your platform
+
+<Tip>
+  Contact [Hecttor](https://hecttor.ai) for SDK access and an API key.
+</Tip>
+
+## Setup
+
+### Get the Python SDK
+
+Contact [Hecttor](https://hecttor.ai) for SDK access and an API key. You'll
+receive the `hecttor_sdk` wheel file for your platform and Python version.
+
+### Install the SDK
+
+The `hecttor_sdk` package is not published to PyPI, so install the wheel file you received directly:
+
+```bash
+pip install hecttor_sdk-<version>-<python>-<platform>.whl
+```
+
+For example, on macOS ARM64 with Python 3.11:
+
+```bash
+pip install hecttor_sdk-3.1.1-cp311-cp311-macosx_15_0_arm64.whl
+```
+
+### Set up environment variables
+
+Add your Hecttor API key to your `.env` file:
+
+```bash
+HECTTOR_API_KEY=your_api_key_here
+```
+
+## Test the integration
+
+You're ready to test! Try running the [Hecttor example](https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-hecttor.py), which demonstrates audio denoising with Deepgram STT, OpenAI LLM, and Cartesia TTS.
+
+<Tip>
+  Learn how to [run
+  examples](https://github.com/pipecat-ai/pipecat/blob/main/examples/README.md)
+  in Pipecat.
+</Tip>
+
+## Audio Denoising
+
+`HecttorFilter` removes background noise from the user's audio in real-time. Add it to any transport via the `audio_in_filter` parameter.
+
+### Basic Usage
+
+The filter uses Hecttor's ASR-optimized enhancer, which preserves speech features that are important for accurate transcription.
+
+```python
+from pipecat.audio.filters.hecttor_filter import HecttorFilter
+from pipecat.transports.base_transport import TransportParams
+
+hecttor_filter = HecttorFilter(model_name="coda-vi-1.0")
+
+transport = SmallWebRTCTransport(
+    webrtc_connection=webrtc_connection,
+    params=TransportParams(
+        audio_in_enabled=True,
+        audio_in_filter=hecttor_filter,
+        audio_out_enabled=True,
+    ),
+)
+```
+
+### Choosing a Model
+
+The filter supports several ASR enhancement models: `"crest-1.0"`, `"crest-2.0"`, `"mist-1.0"`, `"coda-1.0"`, and `"coda-vi-1.0"` (voice isolation, the default). Select one with the `model_name` parameter:
+
+```python
+hecttor_filter = HecttorFilter(model_name="crest-2.0")
+```
+
+### Fine-tuning Enhancement
+
+Use the `enhancer_weight` parameter to blend between original and enhanced audio:
+
+```python
+hecttor_filter = HecttorFilter(
+    model_name="coda-vi-1.0",
+    enhancer_weight=0.8,  # 80% enhanced, 20% original
+)
+```
+
+### Runtime Toggle
+
+Disable and re-enable denoising at runtime using `FilterEnableFrame`:
+
+```python
+from pipecat.frames.frames import FilterEnableFrame
+
+# Disable denoising
+await worker.queue_frame(FilterEnableFrame(False))
+
+# Re-enable denoising
+await worker.queue_frame(FilterEnableFrame(True))
+```
+
+See the [HecttorFilter reference](/api-reference/server/utilities/audio/hecttor-filter) for all configuration options.


### PR DESCRIPTION
## Description

Documentation for `HecttorFilter`, the [Hecttor](https://hecttor.ai) audio denoising filter added in pipecat-ai/pipecat#5087.

## Changes

| File | Purpose |
| --- | --- |
| `pipecat/features/hecttor.mdx` | Feature guide — SDK setup, model selection, runtime toggle |
| `api-reference/server/utilities/audio/hecttor-filter.mdx` | API reference — constructor parameters, sample rates, usage |
| `docs.json` | Registers both pages in the navigation |

Page placement and structure follow the existing Krisp VIVA pages (`pipecat/features/krisp-viva` and `api-reference/server/utilities/audio/krisp-viva-filter`), since Hecttor has the same shape: a proprietary SDK that isn't installable from PyPI.

No redirects were added — both pages are new, so there are no prior URLs to preserve.

## Notes

Opened as a draft to stay in sync with pipecat-ai/pipecat#5087; ready to merge alongside it.
