### PR TITLE
docs(quickdial): refresh copy + nudge rebuild of the two pages

### DIFF
--- a/api-reference/server/services/stt/quickdial.mdx
+++ b/api-reference/server/services/stt/quickdial.mdx
@@ -51,7 +51,7 @@ uv add pipecat-quickdial
 
 ## Prerequisites
 
-1. **Quickdial account** — sign up at [web.quickdial.ai](https://web.quickdial.ai) (1000 free credits, no card required).
+1. **Quickdial account** — sign up at [web.quickdial.ai](https://web.quickdial.ai) (100,000 characters free, no card required).
 2. **API key** — create one in the dashboard.
 
 ### Required environment variables

--- a/api-reference/server/services/tts/quickdial.mdx
+++ b/api-reference/server/services/tts/quickdial.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Quickdial"
-description: "Text-to-speech service implementation using Quickdial's real-time CPU-optimized TTS API"
+description: "Text-to-speech service implementation using Quickdial's real-time TTS API"
 ---
 
 import { CommunityMaintained } from "/snippets/community-maintained.mdx";
@@ -15,8 +15,8 @@ import { CommunityMaintained } from "/snippets/community-maintained.mdx";
 
 `QuickdialTTSService` generates speech from text using [Quickdial](https://quickdial.ai/)'s
 real-time text-to-speech API. It extends Pipecat's `TTSService` and pushes
-`TTSAudioRawFrame` audio into the pipeline. Quickdial runs CPU-optimized engines
-(no GPU), streams audio as it's generated, and is priced per character.
+`TTSAudioRawFrame` audio into the pipeline. Quickdial streams audio as it's
+generated and is priced per character.
 
 <CardGroup cols={2}>
   <Card
@@ -51,7 +51,7 @@ uv add pipecat-quickdial
 
 ## Prerequisites
 
-1. **Quickdial account** — sign up at [web.quickdial.ai](https://web.quickdial.ai) (1000 free credits, no card required).
+1. **Quickdial account** — sign up at [web.quickdial.ai](https://web.quickdial.ai) (100,000 characters free, no card required).
 2. **API key** — create one in the dashboard.
 
 ### Required environment variables


### PR DESCRIPTION
Small follow-up to #1003.

**Changes** (both `api-reference/server/services/{tts,stt}/quickdial.mdx`):
- Refresh the free-tier wording: `1000 free credits` → `100,000 characters free` (matches Quickdial's current sign-up allowance).
- TTS page: simplify the overview/description wording (drop the compute-substrate detail), keeping it focused on the real-time streaming + per-character pricing.

**Heads-up on a rendering issue:** since #1003 merged, the two pages 404 on the live docs (`/api-reference/server/services/tts/quickdial` and `/stt/quickdial`), even though the `.mdx` files, `docs.json` nav entries, and `supported-services` references are all on `main` and every sibling page renders fine. Re-touching these files here should re-trigger Mintlify's build for them — but if they still 404 after merge, it may be a build/cache issue worth a look on your side. Thanks!