### PR TITLE
docs(tts): add Speechify TTS service page

### DIFF
--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -208,6 +208,7 @@ Text-to-Speech services receive text input and output audio streams or chunks.
 | [SLNG](/api-reference/server/services/tts/slng)                   | `uv add pipecat-slng`                                                         | Community  |
 | [Smallest AI](/api-reference/server/services/tts/smallest)        | `uv add "pipecat-ai[smallest]"`                                               | Pipecat    |
 | [Soniox](/api-reference/server/services/tts/soniox)               | `uv add "pipecat-ai[soniox]"`                                                 | Pipecat    |
+| [Speechify](/api-reference/server/services/tts/speechify)         | `uv add "pipecat-ai[speechify]"`                                             | Pipecat    |
 | [Speechmatics](/api-reference/server/services/tts/speechmatics)   | `uv add "pipecat-ai[speechmatics]"`                                           | Pipecat    |
 | [Supertonic](/api-reference/server/services/tts/supertonic)       | `uv add pipecat-supertonic`                                                   | Community  |
 | [Together AI](/api-reference/server/services/tts/together)        | `uv add "pipecat-ai[together]"`                                               | Pipecat    |

--- a/api-reference/server/services/tts/speechify.mdx
+++ b/api-reference/server/services/tts/speechify.mdx
@@ -1,0 +1,193 @@
+---
+title: "Speechify"
+description: "Text-to-speech service using Speechify's synthesis API with word-level timing"
+---
+
+## Overview
+
+`SpeechifyTTSService` provides text-to-speech synthesis through Speechify's HTTP API. It synthesizes 24 kHz mono PCM audio and returns word-level speech marks, so transcripts and LLM context stay aligned with spoken audio. Pipecat aggregates incoming text into sentences by default, giving near-streaming time-to-first-audio while preserving word timestamps.
+
+<CardGroup cols={2}>
+  <Card
+    title="Speechify TTS API Reference"
+    icon="code"
+    href="https://reference-server.pipecat.ai/en/latest/api/pipecat.services.speechify.tts.html"
+  >
+    Complete API reference for all parameters and methods
+  </Card>
+  <Card
+    title="Example Implementation"
+    icon="play"
+    href="https://github.com/pipecat-ai/pipecat/blob/main/examples/update-settings/tts/tts-speechify.py"
+  >
+    Complete example with runtime settings updates
+  </Card>
+  <Card
+    title="Speechify Documentation"
+    icon="book"
+    href="https://docs.speechify.ai/docs/api-quickstart"
+  >
+    Official Speechify TTS API documentation
+  </Card>
+  <Card
+    title="Voices"
+    icon="microphone"
+    href="https://docs.speechify.ai/reference/getvoices"
+  >
+    Browse available voices via the /v1/voices endpoint
+  </Card>
+</CardGroup>
+
+## Installation
+
+```bash
+uv add "pipecat-ai[speechify]"
+```
+
+## Prerequisites
+
+1. **Speechify Account**: Sign up at [Speechify](https://speechify.ai)
+2. **API Key**: Generate an API key from your account dashboard
+3. **Voice Selection**: Choose a voice ID from the [`/v1/voices`](https://docs.speechify.ai/reference/getvoices) endpoint
+
+Set the following environment variable:
+
+```bash
+export SPEECHIFY_API_KEY=your_api_key
+```
+
+## Configuration
+
+<ParamField path="api_key" type="str" default="None">
+  Speechify API key. Falls back to the `SPEECHIFY_API_KEY` environment variable
+  when omitted.
+</ParamField>
+
+<ParamField path="voice_id" type="str" default="dominic_32">
+  Voice identifier. See the
+  [`/v1/voices`](https://docs.speechify.ai/reference/getvoices) endpoint for the
+  available voices.
+</ParamField>
+
+<ParamField path="model" type="str" default="simba-3.2">
+  Synthesis model: `simba-english`, `simba-multilingual`, `simba-3.0`, or
+  `simba-3.2`.
+</ParamField>
+
+<ParamField path="language" type="Language | str" default="None">
+  Input language, as a Pipecat `Language` enum or a Speechify BCP-47 code (e.g.
+  `en-US`). Optional; Speechify auto-detects when omitted.
+</ParamField>
+
+<ParamField path="loudness_normalization" type="bool" default="None">
+  Normalize output loudness to a standard level. Adds a small amount of latency
+  when enabled.
+</ParamField>
+
+<ParamField path="text_normalization" type="bool" default="None">
+  Expand numbers, dates, and similar tokens into words before synthesis. Adds a
+  small amount of latency when enabled.
+</ParamField>
+
+<ParamField path="base_url" type="str" default="None">
+  Override the Speechify API base URL.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="None">
+  Output audio sample rate in Hz. Speechify synthesizes at 24 kHz; audio is
+  resampled to this rate when it differs. When `None`, uses the pipeline's
+  configured sample rate.
+</ParamField>
+
+<ParamField path="client" type="AsyncSpeechify" default="None">
+  A preconfigured `AsyncSpeechify` client. When provided, `api_key` and
+  `base_url` are ignored.
+</ParamField>
+
+<ParamField
+  path="text_aggregation_mode"
+  type="TextAggregationMode"
+  default="TextAggregationMode.SENTENCE"
+>
+  Controls how incoming text is aggregated before synthesis. `SENTENCE`
+  (default) buffers text until sentence boundaries, producing more natural
+  speech. `TOKEN` streams tokens directly for lower latency. Import from
+  `pipecat.services.tts_service`.
+</ParamField>
+
+<ParamField path="aggregate_sentences" type="bool" default="None" deprecated>
+  _Deprecated in v0.0.104._ Use `text_aggregation_mode` instead.
+</ParamField>
+
+<ParamField path="settings" type="SpeechifyTTSService.Settings" default="None">
+  Runtime-configurable settings. See [Settings](#settings) below.
+</ParamField>
+
+### Settings
+
+Runtime-configurable settings passed via the `settings` constructor argument using `SpeechifyTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
+
+| Parameter                | Type              | Default     | Description                                                          |
+| ------------------------ | ----------------- | ----------- | ------------------------------------------------------------------- |
+| `model`                  | `str`             | `None`      | Speechify model identifier. _(Inherited from base settings.)_       |
+| `voice`                  | `str`             | `None`      | Voice identifier. _(Inherited from base settings.)_                 |
+| `language`               | `Language \| str` | `None`      | Language code. _(Inherited from base settings.)_                    |
+| `loudness_normalization` | `bool`            | `NOT_GIVEN` | Normalize output loudness to a standard level.                      |
+| `text_normalization`     | `bool`            | `NOT_GIVEN` | Expand numbers, dates, and similar tokens into words before synthesis. |
+
+<Note>
+  `NOT_GIVEN` values use the Speechify API defaults.
+</Note>
+
+## Usage
+
+### Basic Setup
+
+```python
+from pipecat.services.speechify.tts import SpeechifyTTSService
+
+tts = SpeechifyTTSService(
+    api_key=os.getenv("SPEECHIFY_API_KEY"),
+    voice_id="dominic_32",
+    model="simba-3.2",
+)
+```
+
+### With Normalization Options
+
+```python
+from pipecat.transcriptions.language import Language
+
+tts = SpeechifyTTSService(
+    api_key=os.getenv("SPEECHIFY_API_KEY"),
+    voice_id="dominic_32",
+    model="simba-multilingual",
+    language=Language.ES,
+    loudness_normalization=True,
+    text_normalization=True,
+)
+```
+
+### Updating Settings at Runtime
+
+Settings can be changed mid-conversation using `TTSUpdateSettingsFrame`:
+
+```python
+from pipecat.frames.frames import TTSUpdateSettingsFrame
+from pipecat.services.speechify.tts import SpeechifyTTSSettings
+
+await worker.queue_frame(
+    TTSUpdateSettingsFrame(
+        delta=SpeechifyTTSSettings(
+            text_normalization=True,
+        )
+    )
+)
+```
+
+## Notes
+
+- **Word timestamps**: Speechify returns word-level speech marks, which Pipecat converts to word timestamps for accurate transcripts and LLM context alignment.
+- **Sample rate**: Speechify synthesizes at 24 kHz mono. Set `sample_rate` (or the pipeline's output sample rate) to have audio resampled to another rate.
+- **Text aggregation**: Sentence aggregation is enabled by default (`text_aggregation_mode=TextAggregationMode.SENTENCE`). Buffering until sentence boundaries produces more natural speech. Set `text_aggregation_mode=TextAggregationMode.TOKEN` to stream tokens directly for lower latency.
+- **Models**: `simba-english` is optimized for English; `simba-multilingual` supports non-English and mixed input; `simba-3.0` and `simba-3.2` are the latest streaming-native models.

--- a/docs.json
+++ b/docs.json
@@ -457,6 +457,7 @@
                       "api-reference/server/services/tts/slng",
                       "api-reference/server/services/tts/smallest",
                       "api-reference/server/services/tts/soniox",
+                      "api-reference/server/services/tts/speechify",
                       "api-reference/server/services/tts/speechmatics",
                       "api-reference/server/services/tts/supertonic",
                       "api-reference/server/services/tts/together",


### PR DESCRIPTION
## Description

Adds the API-reference documentation for the new `SpeechifyTTSService`, the companion to the code PR [pipecat-ai/pipecat#5107](https://github.com/pipecat-ai/pipecat/pull/5107).

## What's included

- `api-reference/server/services/tts/speechify.mdx` — full service page (overview, installation, configuration params, runtime settings, usage examples, notes), following the `elevenlabs.mdx` house style.
- `docs.json` — registers the page in the TTS nav (alphabetically, between Soniox and Speechmatics).
- `api-reference/server/services/supported-services.mdx` — adds Speechify to the TTS services overview table.

## Notes

- Draft, pending the code PR (pipecat-ai/pipecat#5107) landing so the `pipecat-ai[speechify]` extra and the linked example resolve.
- Built by Speechify. Happy to adjust to match your conventions.

Co-authored-by: vrishab-jpg <296534531+vrishab-jpg@users.noreply.github.com>
