### PR TITLE
docs: update for Gnani TTS

### DIFF
--- a/api-reference/server/services/stt/gnani.mdx
+++ b/api-reference/server/services/stt/gnani.mdx
@@ -55,7 +55,7 @@ and `InterimTranscriptionFrame` when the API sets `is_final: false`.
     icon="cube"
     href="https://pypi.org/project/gnani-vachana/"
   >
-    Core Gnani Vachana Python SDK (>= 0.7.3) installed as a dependency
+    Core Gnani Vachana Python SDK (>= 0.7.9) installed as a dependency
   </Card>
 </CardGroup>
 
@@ -77,7 +77,7 @@ pip install "pipecat-ai[gnani]"
 ```
 
 This also installs the [`gnani-vachana`](https://pypi.org/project/gnani-vachana/)
-(>= 0.7.3) core SDK. The Python import package name remains `gnani`.
+(>= 0.7.9) core SDK. The Python import package name remains `gnani`.
 
 <Note>
   **Import paths:** use `from pipecat_gnani import …` with the standalone
@@ -239,6 +239,6 @@ Tested with the latest **Pipecat** main branch (**v1.5.0+**) using both
 `pipecat-gnani` and the core **`pipecat-ai[gnani]`** extra
 (`pipecat.services.gnani`), including the upstream
 [`voice-gnani.py`](https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-gnani.py)
-eval example. Requires **`gnani-vachana` >= 0.7.3**. Check the [source
+eval example. Requires **`gnani-vachana` >= 0.7.9**. Check the [source
 repository](https://github.com/Gnani-AI-Mintlify/pipecat-gnani) for the latest
 tested version and changelog.

--- a/api-reference/server/services/tts/gnani.mdx
+++ b/api-reference/server/services/tts/gnani.mdx
@@ -54,7 +54,7 @@ lowest latency with interruption support via `InterruptibleTTSService`.
     icon="cube"
     href="https://pypi.org/project/gnani-vachana/"
   >
-    Core Gnani Vachana Python SDK (>= 0.7.3) installed as a dependency
+    Core Gnani Vachana Python SDK (>= 0.7.9) installed as a dependency
   </Card>
 </CardGroup>
 
@@ -76,7 +76,7 @@ pip install "pipecat-ai[gnani]"
 ```
 
 This also installs the [`gnani-vachana`](https://pypi.org/project/gnani-vachana/)
-(>= 0.7.3) core SDK. The Python import package name remains `gnani`.
+(>= 0.7.9) core SDK. The Python import package name remains `gnani`.
 
 <Note>
   **Import paths:** use `from pipecat_gnani import …` with the standalone
@@ -110,17 +110,18 @@ SSE for chunked streaming, and WebSocket for interruptible real-time synthesis.
 </ParamField>
 
 <ParamField path="voice_id" type="str" default="Pranav">
-  Voice name for synthesis. Options include `Pranav`, `Kaveri`, `Shubhra`, and
-  `Deepak`.
+  Voice name for synthesis. For `timbre-v2.0`: `Pranav`, `Kaveri`, `Shubhra`,
+  `Deepak`. For `timbre-v2.5`: 42 voices across 11 language groups — see
+  [Available voices](#available-voices) below.
 </ParamField>
 
-<ParamField path="model" type="str" default="vachana-voice-v3">
-  TTS model identifier.
+<ParamField path="model" type="str" default="timbre-v2.0">
+  TTS model identifier. One of `timbre-v2.0` or `timbre-v2.5`.
 </ParamField>
 
 <ParamField path="sample_rate" type="int" default="None">
-  Output sample rate in Hz. One of `8000`, `16000`, `22050`, or `44100`. When
-  omitted, negotiated from `StartFrame`.
+  Output sample rate in Hz. One of `8000`, `16000`, `22050`, `24000`, `44100`,
+  or `48000`. When omitted, negotiated from `StartFrame`.
 </ParamField>
 
 <ParamField path="settings" type="Settings" default="None">
@@ -139,19 +140,24 @@ Runtime-configurable settings passed via the `settings` constructor argument
 using `GnaniHttpTTSService.Settings(...)`, `GnaniSSETTSService.Settings(...)`,
 or `GnaniTTSService.Settings(...)`.
 
-| Parameter      | Type   | Default              | Description                                                    |
-| -------------- | ------ | -------------------- | -------------------------------------------------------------- |
-| `voice`        | `str`  | `"Pranav"`           | Voice identifier (Pranav, Kaveri, Shubhra, Deepak).            |
-| `model`        | `str`  | `"vachana-voice-v3"` | TTS model identifier.                                          |
-| `encoding`     | `str`  | `"linear_pcm"`       | Audio encoding (`linear_pcm` or `oggopus`).                    |
-| `container`    | `str`  | `"wav"`              | Audio container (`raw`, `mp3`, `wav`, `mulaw`, `ogg`).         |
-| `sample_width` | `int`  | `2`                  | Sample width in bytes (1–4).                                   |
-| `bitrate`      | `str`  | `None`               | MP3 bitrate (`96k`, `128k`, `192k`). Only used when `container=mp3`. |
+| Parameter      | Type       | Default          | Description                                                                            |
+| -------------- | ---------- | ---------------- | -------------------------------------------------------------------------------------- |
+| `voice`        | `str`      | `"Pranav"`       | Voice identifier. See [Available voices](#available-voices).                            |
+| `model`        | `str`      | `"timbre-v2.0"`  | TTS model (`timbre-v2.0` or `timbre-v2.5`).                                            |
+| `language`     | `Language` | `None`           | Synthesis language (`timbre-v2.5` only). BCP-47 code, e.g. `Language.HI_IN`.           |
+| `encoding`     | `str`      | `"linear_pcm"`   | Audio encoding (`linear_pcm`, `oggopus`, `pcm_mulaw`, `pcm_alaw`).                    |
+| `container`    | `str`      | `"wav"`          | Audio container (`raw`, `mp3`, `wav`, `ogg`, `mulaw`, `alaw`).                         |
+| `sample_width` | `int`      | `2`              | Sample width in bytes (1–4).                                                           |
+| `bitrate`      | `str`      | `None`           | MP3 bitrate (`32k`, `64k`, `96k`, `128k`, `192k`). Only used when `container=mp3`.    |
 
 <Note>
-  TTS does **not** send a `language` parameter — voice selection determines
-  synthesis language. When using `encoding="oggopus"`, set `container="raw"`
-  (the API rejects `oggopus` with `container="ogg"`).
+  For `timbre-v2.0`, voice selection determines synthesis language — no
+  `language` parameter is sent. For `timbre-v2.5`, set `language` explicitly to
+  control the synthesis language (e.g. `Language.HI_IN` for Hindi).
+
+  When using `encoding="oggopus"`, set `container="raw"` (the API rejects
+  `oggopus` with `container="ogg"`). For telephony A-law output, use
+  `container="alaw"` with `sample_rate=8000`.
 </Note>
 
 <Note>
@@ -160,6 +166,34 @@ or `GnaniTTSService.Settings(...)`.
   repository](https://github.com/Gnani-AI-Mintlify/pipecat-gnani) and [Gnani TTS
   docs](https://docs.gnani.ai/api/TTS/tts-inference) for the authoritative,
   up-to-date voice and language lists.
+</Note>
+
+## Available voices
+
+### `timbre-v2.0` (4 voices)
+
+`Pranav`, `Kaveri`, `Shubhra`, `Deepak`
+
+### `timbre-v2.5` (42 voices)
+
+| Language   | Voices                                                        |
+| ---------- | ------------------------------------------------------------- |
+| Hindi      | Nalini, Bhavna, Yashvi, Urmila, Jwala, Chitra, Ambuja, Deepak, Roopesh, Vikrant, Hemraj, Jalaj, Omkar |
+| English    | Kaveri, Trupti, Devika, Pranav, Shlok, Girish                 |
+| Tamil      | Asmita, Trisha, Brinda, Vedika, Noopur                        |
+| Telugu     | Suhana, Lehara, Lavanya, Yukti, Varuni                        |
+| Kannada    | Saanvi, Kavin                                                 |
+| Malayalam  | Reshma, Riyaan                                                |
+| Marathi    | Zahira, Ishaan                                                |
+| Bengali    | Kirra, Dhruva                                                 |
+| Gujarati   | Falak, Veera                                                  |
+| Punjabi    | Mehuli, Zayan                                                 |
+| Hinglish   | Poorvi                                                        |
+
+<Note>
+  `timbre-v2.5` requires a `language` parameter (BCP-47 code, e.g. `hi-IN`)
+  when using multilingual voices. Some voices (like Pranav, Kaveri, Deepak)
+  appear in both models — select the model to pick the voice variant.
 </Note>
 
 ## Usage
@@ -177,6 +211,28 @@ tts = GnaniTTSService(
     sample_rate=16000,
     settings=GnaniTTSService.Settings(
         voice="Pranav",
+    ),
+)
+
+# ... add tts to your pipeline
+```
+
+### Using timbre-v2.5 with language
+
+```python
+import os
+
+from pipecat.transcriptions.language import Language
+from pipecat.services.gnani import GnaniTTSService
+# or: from pipecat_gnani import GnaniTTSService
+
+tts = GnaniTTSService(
+    api_key=os.getenv("GNANI_API_KEY"),
+    sample_rate=16000,
+    settings=GnaniTTSService.Settings(
+        model="timbre-v2.5",
+        voice="Nalini",
+        language=Language.HI_IN,
     ),
 )
 
@@ -258,6 +314,6 @@ Tested with the latest **Pipecat** main branch (**v1.5.0+**) using both
 `pipecat-gnani` and the core **`pipecat-ai[gnani]`** extra
 (`pipecat.services.gnani`), including the upstream
 [`voice-gnani.py`](https://github.com/pipecat-ai/pipecat/blob/main/examples/voice/voice-gnani.py)
-eval example. Requires **`gnani-vachana` >= 0.7.3**. Check the [source
+eval example. Requires **`gnani-vachana` >= 0.7.9**. Check the [source
 repository](https://github.com/Gnani-AI-Mintlify/pipecat-gnani) for the latest
 tested version and changelog.


### PR DESCRIPTION
- Updated dependency version for the Core Gnani Vachana Python SDK from >= 0.7.3 to >= 0.7.9 in both STT and TTS documentation.
- Revised TTS model identifier from "vachana-voice-v3" to "timbre-v2.0" and added details for the new "timbre-v2.5" model, including available voices and language parameters.
- Enhanced parameter descriptions and added examples for using the new TTS model with language support.