### PR TITLE
docs: add Neon AI Gateway configuration

### DIFF
--- a/api-reference/server/services/llm/openai.mdx
+++ b/api-reference/server/services/llm/openai.mdx
@@ -186,6 +186,36 @@ await worker.queue_frame(
   guide](/pipecat/fundamentals/service-settings) for migration details.
 </Tip>
 
+### Neon AI Gateway
+
+[Neon AI Gateway](https://neon.com/docs/ai-gateway/overview) is an OpenAI-compatible inference gateway built into Neon. One Neon credential gives access to models from OpenAI, Google, Meta, Databricks, and Alibaba. Pipecat has no dedicated service for it, so use `OpenAILLMService` with `base_url`.
+
+Each Neon branch has its own gateway host, so take the value from the Neon Console instead of hardcoding one. The gateway serves chat completions at `/v1/chat/completions`, so append `/v1` to the base URL:
+
+```python
+import os
+
+from pipecat.services.openai.llm import OpenAILLMService
+
+llm = OpenAILLMService(
+    api_key=os.getenv("NEON_AI_GATEWAY_TOKEN"),
+    base_url=f"{os.getenv('NEON_AI_GATEWAY_BASE_URL')}/v1",
+    settings=OpenAILLMService.Settings(
+        model="gpt-5-mini",
+        temperature=0.7,
+    ),
+)
+```
+
+Switching providers only means changing `model`, for example to `gemini-3-flash` or `qwen3-next-80b-a3b-instruct`. The [Neon model catalog](https://neon.com/docs/ai-gateway/models) lists every model ID with its context window and supported endpoints. [Models.dev](https://models.dev/providers/neon) publishes the same catalog.
+
+<Note>
+  Neon AI Gateway is in beta. It requires a paid Neon plan, runs only in the AWS
+  US East (Ohio) region (`aws-us-east-2`), and the credential must carry the
+  `ai_gateway:invoke` scope. See [AI Gateway
+  authentication](https://neon.com/docs/ai-gateway/authentication).
+</Note>
+
 ## Notes
 
 - **OpenAI-compatible providers**: Many third-party LLM providers offer OpenAI-compatible APIs. You can use `OpenAILLMService` with them by setting `base_url` to the provider's endpoint.


### PR DESCRIPTION
## What

Adds a "Neon AI Gateway" section to the OpenAI LLM service page, showing how to point `OpenAILLMService` at a Neon branch gateway endpoint.

The repo has no pull request template, so this description follows the checklist in `CONTRIBUTING.md`.

## Why

[Neon AI Gateway](https://neon.com/docs/ai-gateway/overview) is an OpenAI-compatible inference gateway. Pipecat has no `NeonLLMService`, and none is needed: the existing `OpenAILLMService` already accepts `base_url`, which is exactly the mechanism the Notes section of this page recommends for OpenAI-compatible providers. The section documents that path rather than implying a service class that does not exist.

Two details are easy to get wrong without documentation, so the section calls them out:

- The gateway host is per branch. `NEON_AI_GATEWAY_BASE_URL` holds the value for the current branch, and there is no shared endpoint to hardcode.
- That variable is a bare host with no path, so `/v1` has to be appended for chat completions.

## Scope

- No new page under `api-reference/server/services/llm/`. Every file in that directory documents a concrete service class, so a standalone page would suggest a `NeonLLMService` exists.
- No `docs.json` change, since no page was added.
- One file changed, 30 lines added, nothing removed or reworded elsewhere on the page.

## Note on the import path

The snippet uses `from pipecat.services.openai.llm import OpenAILLMService` rather than the flat `from pipecat.services.openai import OpenAILLMService` used earlier on this page. `src/pipecat/services/openai/__init__.py` is empty upstream, and the [1.0 migration guide](https://docs.pipecat.ai/pipecat/migration/migration-1.0#4-service-import-paths) lists the flat form as removed. The two older snippets on this page look stale for the same reason, but they are outside the scope of this change. Happy to fix them in a separate PR if that is useful.

## Source references

- [AI Gateway overview](https://neon.com/docs/ai-gateway/overview) for beta status, paid plan requirement, the `aws-us-east-2` region restriction, and the provider list
- [AI Gateway authentication](https://neon.com/docs/ai-gateway/authentication) for the `ai_gateway:invoke` scope, both environment variables, and the `/v1` dialect path
- [Model catalog](https://neon.com/docs/ai-gateway/models) for the `gpt-5-mini`, `gemini-3-flash`, and `qwen3-next-80b-a3b-instruct` model IDs

## Validation

- `npx prettier --check api-reference/server/services/llm/openai.mdx` passes.
- `mint broken-links` passes across the whole site with no broken links.
- The Python snippet compiles with `python -m py_compile`.
- `base_url` and `OpenAILLMService.Settings(model=..., temperature=...)` were checked against `src/pipecat/services/openai/base_llm.py` and `llm.py` in pipecat-ai/pipecat. `base_url` reaches `BaseOpenAILLMService` through `**kwargs`, and `temperature` is a field on `OpenAILLMSettings`.
- The four external links in the section return 200.

Not run: `mint dev`, so the rendered page was not visually reviewed. The `<Note>` block follows the same form as the existing `<Note>` further up the page.
