### PR TITLE
docs: cover `pipecat mcp` and the Context Hub CLI plugin

### DIFF
--- a/api-reference/cli/mcp.mdx
+++ b/api-reference/cli/mcp.mdx
@@ -1,0 +1,396 @@
+---
+title: mcp
+description: "Query the Pipecat Context Hub from the CLI, and register it as an MCP server for your coding agent"
+---
+
+Run the [Pipecat Context Hub](/api-reference/context-hub) through the Pipecat CLI. `pipecat mcp install` registers the hub as an MCP server with your coding agent and builds the local index; the query commands print the same JSON the MCP tools return, for one-shot lookups from a shell.
+
+## Installation
+
+`pipecat mcp` comes from the `pipecat-ai-context-hub` package, which you co-install with the CLI:
+
+```shell
+uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
+```
+
+Without it, `pipecat mcp` still lists in `pipecat --help` and prints how to enable it when run. The hub also runs standalone, without the Pipecat CLI — see the [Context Hub reference](/api-reference/context-hub) for that path, the tool list, and custom sources.
+
+<Note>
+  Not to be confused with [`MCPClient`](/api-reference/server/utilities/mcp/mcp)
+  and the `pipecat-ai[mcp]` extra, which let a *bot* connect to MCP servers at
+  runtime. `pipecat mcp` is a developer tool for your own coding agent.
+</Note>
+
+## mcp install
+
+Register the MCP server with a coding agent and build the index. Configures every detected client CLI (Claude Code, Codex) unless `--client` is given, then runs the first refresh.
+
+Clients that ship their own CLI are configured through it, so they own the edit to their config file. For clients configured by hand (Cursor, VS Code, Zed) the command prints the JSON and where it goes rather than writing a file it doesn't own.
+
+**Usage:**
+
+```shell
+pipecat mcp install [OPTIONS]
+```
+
+**Options:**
+
+<ParamField path="--client" type="string">
+  Client to configure: `claude-code`, `codex`, `cursor`, `vscode`, or `zed`.
+  Repeatable. Defaults to every detected client CLI.
+</ParamField>
+
+<ParamField path="--no-refresh" type="flag">
+  Skip building the index. Run `pipecat mcp refresh` before your first query.
+</ParamField>
+
+<ParamField path="--print-config" type="flag">
+  Only print the MCP config and the server command; change nothing.
+</ParamField>
+
+<Tip>
+  MCP servers load when your coding tool starts a session, so run this before
+  opening the session you want to use it in.
+</Tip>
+
+## mcp refresh
+
+Rebuild the index, skipping unchanged sources when possible. The first run downloads local embedding models and indexes every source, so allow several minutes.
+
+**Usage:**
+
+```shell
+pipecat mcp refresh [OPTIONS]
+```
+
+**Options:**
+
+<ParamField path="--force" type="flag">
+  Force a full refresh, ignoring cached state.
+</ParamField>
+
+<ParamField path="--reset-index" type="flag">
+  Delete local index state before rebuilding. Use this when the persisted index
+  is unhealthy.
+</ParamField>
+
+<ParamField path="--framework-version" type="string">
+  Pin the framework repo to a specific git tag, e.g. `v0.0.96`. Source chunks
+  come from that version instead of `HEAD`, so results match an older project.
+  Also settable with `PIPECAT_HUB_FRAMEWORK_VERSION`.
+</ParamField>
+
+## mcp status
+
+Report index health: freshness, record counts, the pipecat version the index was built from, and reranker state. Prints JSON.
+
+**Usage:**
+
+```shell
+pipecat mcp status
+```
+
+## mcp serve
+
+Start the MCP server over stdio. `pipecat mcp start` is an alias. You rarely run this by hand — your coding tool starts it, using the config `pipecat mcp install` wrote.
+
+Exits `2` if the index is empty or cannot be opened, rather than starting against an index that would answer every query with nothing.
+
+**Usage:**
+
+```shell
+pipecat mcp serve
+```
+
+## mcp search-docs
+
+Semantic search over the indexed Pipecat docs.
+
+**Usage:**
+
+```shell
+pipecat mcp search-docs [OPTIONS] QUERY
+```
+
+**Arguments:**
+
+<ParamField path="QUERY" type="string" required>
+  What to search for. Use ` + ` or ` & ` to search several concepts at once,
+  e.g. `"TTS + STT"` — each is searched separately and the results interleaved.
+</ParamField>
+
+**Options:**
+
+<ParamField path="--area" type="string">
+  Docs path prefix, e.g. `guides` or `server/services`.
+</ParamField>
+
+<ParamField path="--limit" type="integer" default="10">
+  Maximum hits to return (1-50).
+</ParamField>
+
+## mcp search-api
+
+Search framework internals: classes, signatures, frames, inheritance.
+
+**Usage:**
+
+```shell
+pipecat mcp search-api [OPTIONS] QUERY
+```
+
+**Arguments:**
+
+<ParamField path="QUERY" type="string" required>
+  What to search for.
+</ParamField>
+
+**Options:**
+
+<ParamField path="--module" type="string">
+  Module path prefix, e.g. `pipecat.services`.
+</ParamField>
+
+<ParamField path="--class-name" type="string">
+  Class name prefix, e.g. `DailyTransport`.
+</ParamField>
+
+<ParamField path="--chunk-type" type="string">
+  One of `module_overview`, `class_overview`, `method`, `function`,
+  `type_definition`.
+</ParamField>
+
+<ParamField path="--is-dataclass" type="flag">
+  Only dataclass types.
+</ParamField>
+
+<ParamField path="--yields" type="string">
+  Methods yielding a frame type.
+</ParamField>
+
+<ParamField path="--calls" type="string">
+  Methods calling a specific method.
+</ParamField>
+
+<ParamField path="--pipecat-version" type="string">
+  Score results for compatibility with this `pipecat-ai` version.
+</ParamField>
+
+<ParamField path="--compatible-only" type="flag">
+  Exclude results requiring a newer version. Needs `--pipecat-version`.
+</ParamField>
+
+<ParamField path="--limit" type="integer" default="10">
+  Maximum hits to return (1-50).
+</ParamField>
+
+## mcp search-examples
+
+Find working Pipecat examples for a capability.
+
+**Usage:**
+
+```shell
+pipecat mcp search-examples [OPTIONS] QUERY
+```
+
+**Arguments:**
+
+<ParamField path="QUERY" type="string" required>
+  The capability to find examples for.
+</ParamField>
+
+**Options:**
+
+<ParamField path="--repo" type="string">
+  Filter by repo slug, e.g. `pipecat-ai/pipecat-examples`.
+</ParamField>
+
+<ParamField path="--language" type="string">
+  `python` or `typescript` — the only parsed languages.
+</ParamField>
+
+<ParamField path="--domain" type="string">
+  `backend` (Python bot/pipeline code), `frontend` (JS/TS client), `config`, or
+  `infra`.
+</ParamField>
+
+<ParamField path="--tag" type="string">
+  Capability tag. Repeatable.
+</ParamField>
+
+<ParamField path="--execution-mode" type="string">
+  `local` or `cloud`, inferred from capability tags.
+</ParamField>
+
+<ParamField path="--pipecat-version" type="string">
+  Score results for compatibility with this `pipecat-ai` version.
+</ParamField>
+
+<ParamField path="--compatible-only" type="flag">
+  Exclude results requiring a newer version. Needs `--pipecat-version`.
+</ParamField>
+
+<ParamField path="--limit" type="integer" default="10">
+  Maximum hits to return (1-50).
+</ParamField>
+
+<ParamField path="--foundational-class" type="string">
+  Legacy filter, deprecated. Only pre-reorg examples carry it, so filtering on
+  it silently excludes new-layout examples. Prefer `--domain` and `--tag`.
+</ParamField>
+
+## mcp get-doc
+
+Fetch a full docs page, or one section of it, by ID or path. Use after `search-docs`.
+
+**Usage:**
+
+```shell
+pipecat mcp get-doc [OPTIONS]
+```
+
+**Options:**
+
+<ParamField path="--doc-id" type="string">
+  Chunk ID from a `search-docs` hit.
+</ParamField>
+
+<ParamField path="--path" type="string">
+  Docs path, e.g. `/guides/telephony/overview`.
+</ParamField>
+
+<ParamField path="--section" type="string">
+  Return only this section heading.
+</ParamField>
+
+## mcp get-example
+
+Fetch the full source files of an example. Use after `search-examples`.
+
+**Usage:**
+
+```shell
+pipecat mcp get-example [OPTIONS] EXAMPLE_ID
+```
+
+**Arguments:**
+
+<ParamField path="EXAMPLE_ID" type="string" required>
+  Example ID from a `search-examples` hit.
+</ParamField>
+
+**Options:**
+
+<ParamField path="--no-readme" type="flag">
+  Skip the example's README content.
+</ParamField>
+
+## mcp get-code-snippet
+
+Get a targeted code snippet by symbol, by intent, or by path and line range.
+
+**Usage:**
+
+```shell
+pipecat mcp get-code-snippet [OPTIONS]
+```
+
+**Options:**
+
+<ParamField path="--symbol" type="string">
+  Symbol name, e.g. `DailyTransport.send_dtmf`.
+</ParamField>
+
+<ParamField path="--intent" type="string">
+  Intent description; searches example code.
+</ParamField>
+
+<ParamField path="--path" type="string">
+  File path. Combine with `--line-start` for a range lookup.
+</ParamField>
+
+<ParamField path="--line-start" type="integer">
+  First line of the range.
+</ParamField>
+
+<ParamField path="--line-end" type="integer">
+  Last line of the range.
+</ParamField>
+
+<ParamField path="--module" type="string">
+  Module path prefix filter, in symbol mode.
+</ParamField>
+
+<ParamField path="--class-name" type="string">
+  Class name prefix filter, in symbol mode.
+</ParamField>
+
+<ParamField path="--content-type" type="string">
+  `source` for framework code, `code` for examples.
+</ParamField>
+
+<ParamField path="--pipecat-version" type="string">
+  Score results for compatibility with this `pipecat-ai` version.
+</ParamField>
+
+<ParamField path="--max-lines" type="integer" default="100">
+  Maximum lines to return (1-500).
+</ParamField>
+
+## mcp check-deprecation
+
+Check whether a module path, class, or method is deprecated. The fastest way to catch a symbol that moved or was replaced.
+
+**Usage:**
+
+```shell
+pipecat mcp check-deprecation [OPTIONS] SYMBOL
+```
+
+**Arguments:**
+
+<ParamField path="SYMBOL" type="string" required>
+  Module path, class, or method, e.g. `PipelineTask` or
+  `pipecat.services.grok.llm`.
+</ParamField>
+
+**Options:**
+
+<ParamField path="--at-version" type="string">
+  Evaluate the symbol's lifecycle at this version, e.g. `2.0.0`. A symbol can be
+  current, deprecated, or removed at different versions. Defaults to the version
+  the index was built from.
+</ParamField>
+
+## Examples
+
+```shell
+# Set the hub up for your coding agent, then keep it current
+pipecat mcp install
+pipecat mcp refresh
+
+# Is this symbol still the right one?
+pipecat mcp check-deprecation PipelineTask
+
+# Find a working example, then read it
+pipecat mcp search-examples "twilio bot" --domain backend
+pipecat mcp get-example <example-id>
+
+# Look up an exact signature
+pipecat mcp search-api "WebsocketServerParams" --limit 3
+
+# Index health, including the pipecat version it was built from
+pipecat mcp status
+```
+
+## Next Steps
+
+<Card
+  title="Pipecat Context Hub"
+  icon="database"
+  href="/api-reference/context-hub"
+>
+  What the hub indexes, the MCP tool list, custom sources, and setup without the
+  Pipecat CLI
+</Card>

--- a/api-reference/cli/overview.mdx
+++ b/api-reference/cli/overview.mdx
@@ -19,6 +19,13 @@ description: "Command-line tool for scaffolding and deploying Pipecat bots"
     Test your agents with scripted scenarios and an LLM judge
   </Card>
   <Card
+    title="Give Your Agent Context"
+    icon="database"
+    href="/api-reference/cli/mcp"
+  >
+    Index current Pipecat docs and API source for your coding agent
+  </Card>
+  <Card
     title="Deploy to Cloud"
     icon="rocket"
     href="/api-reference/cli/cloud/auth"
@@ -47,17 +54,31 @@ pipecat --version
 
 <Tip>All commands can use either `pipecat` or the shorter `pc` alias.</Tip>
 
-This gives you the built-in `pipecat init` and `pipecat eval` commands. The `cloud` command is provided by a separate package that you co-install with `--with`:
+This gives you the built-in `pipecat init` and `pipecat eval` commands. The `cloud` and `mcp` commands each come from a separate package that you co-install with `--with`:
 
 ```bash
 # Add deploy commands
 uv tool install "pipecat-ai[cli]" --with pipecatcloud
+
+# Add Context Hub commands for your coding agent
+uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
+
+# Or both
+uv tool install "pipecat-ai[cli]" --with pipecatcloud --with pipecat-ai-context-hub
 ```
+
+<Warning>
+  `--with` replaces the tool environment rather than adding to it, so every run
+  must name every plugin you want. Installing with only one drops the other.
+</Warning>
+
+Commands from a plugin you haven't installed still appear in `pipecat --help`, and print how to enable themselves when run.
 
 ## Commands
 
 - **[`pipecat init`](/api-reference/cli/init)** - Initialize and scaffold a new Pipecat project, the single entry point for new projects (built in)
 - **[`pipecat eval`](/api-reference/cli/eval)** - Run behavioral evals against your agents
+- **[`pipecat mcp`](/api-reference/cli/mcp)** - Query the Pipecat Context Hub and register it with your coding agent (requires `pipecat-ai-context-hub`)
 - **[`pipecat cloud`](/api-reference/cli/cloud/auth)** - Deploy and manage bots on Pipecat Cloud (requires `pipecatcloud`)
 
 ## Getting Help
@@ -68,6 +89,7 @@ View help for any command:
 pipecat --help
 pipecat init --help
 pipecat eval --help
+pipecat mcp --help
 pipecat cloud --help
 ```
 

--- a/api-reference/context-hub.mdx
+++ b/api-reference/context-hub.mdx
@@ -9,13 +9,51 @@ Pipecat's docs, examples, and API surface change often and span several reposito
 
 Every tool runs two ways: as a one-shot CLI command and as an MCP server. Use the CLI for a quick lookup. Add the MCP server when a session needs repeated, exploratory queries.
 
+<Note>
+  This is a tool for *your* coding agent, not something your bot uses at
+  runtime. For a bot that connects to MCP servers, see
+  [`MCPClient`](/api-reference/server/utilities/mcp/mcp) and the
+  `pipecat-ai[mcp]` extra.
+</Note>
+
 ## Setup
 
-The hub is published to PyPI as `pipecat-ai-context-hub` and runs with [`uv`](https://docs.astral.sh/uv/), no clone required. The examples on this page use `uvx`, uv's one-shot runner, which fetches and runs the hub on demand. Build the local index once:
+The hub is published to PyPI as `pipecat-ai-context-hub`. Co-install it with the Pipecat CLI, then let it configure your coding agent and build the index in one step:
+
+```bash
+uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
+pipecat mcp install
+```
+
+`install` registers the MCP server with each coding agent it finds, echoing each command it runs, then builds the index — a few minutes the first time, since it downloads local embedding models. Every hub command is then available as `pipecat mcp <command>`; see the [`pipecat mcp` reference](/api-reference/cli/mcp) for the full flag surface.
+
+<Warning>
+  `--with` replaces the tool environment rather than adding to it. If you also
+  use `pipecat cloud`, name both plugins: `uv tool install "pipecat-ai[cli]"
+  --with pipecatcloud --with pipecat-ai-context-hub`.
+</Warning>
+
+If the index gets corrupted, force a rebuild:
+
+```bash
+pipecat mcp refresh --force
+```
+
+If your project targets an older Pipecat version, pin the hub to it so results match what you're running:
+
+```bash
+pipecat mcp refresh --framework-version v0.0.96
+```
+
+### Without the Pipecat CLI
+
+The hub runs standalone too. [`uvx`](https://docs.astral.sh/uv/), uv's one-shot runner, fetches and runs it on demand with nothing installed:
 
 ```bash
 uvx pipecat-ai-context-hub refresh   # build local index (~2 min first run)
 ```
+
+Every command on this page works either way — `pipecat mcp refresh` and `uvx pipecat-ai-context-hub refresh` are the same command.
 
 <Tip>
   To install it once instead of fetching on demand, run `uv tool install
@@ -24,17 +62,14 @@ uvx pipecat-ai-context-hub refresh   # build local index (~2 min first run)
   name.
 </Tip>
 
-If the index gets corrupted, you can force a rebuild:
+### Which install to choose
 
-```bash
-uvx pipecat-ai-context-hub refresh --force
-```
+The two installs expose different things, because a command is only visible inside the environment its package was installed into:
 
-If your project targets an older Pipecat version, pin the hub to it so results match what you're running:
+- **Co-installed with the CLI** (`--with`) gives you `pipecat mcp`, but does not put `pipecat-context-hub` on your `PATH`.
+- **Installed on its own** (`uv tool install pipecat-ai-context-hub`) gives you `pipecat-context-hub` on your `PATH`, but not `pipecat mcp`.
 
-```bash
-uvx pipecat-ai-context-hub refresh --framework-version v0.0.96
-```
+Doing both works and gives you both names, at the cost of a second copy on disk — the hub's retrieval stack is around 1 GB, and the two environments share very little. Pick one unless you have a reason not to.
 
 ## Custom sources
 
@@ -91,14 +126,26 @@ To make your coding agent reach for these tools automatically, add the [recommen
 Every tool is also a one-shot CLI command, so you can query the index from a shell with no MCP setup. Reach for this when you need a single answer fast, like a deprecation check, an API signature, or an index health check. Each command prints the tool's JSON to stdout:
 
 ```bash
-uvx pipecat-ai-context-hub check-deprecation PipelineTask     # is this symbol deprecated?
-uvx pipecat-ai-context-hub search-api "WebsocketServerParams"  # find an API signature
-uvx pipecat-ai-context-hub status                              # index health / freshness
+pipecat mcp check-deprecation PipelineTask      # is this symbol deprecated?
+pipecat mcp search-api "WebsocketServerParams"  # find an API signature
+pipecat mcp status                              # index health / freshness
 ```
+
+Or, without the Pipecat CLI, the same commands under `uvx pipecat-ai-context-hub`. The [`pipecat mcp` reference](/api-reference/cli/mcp) documents every command and flag.
 
 ## MCP server
 
 For a longer build or debugging session where the model probes the index repeatedly, add the hub as an MCP server instead of shelling out per query. It keeps the index warm for the whole session and exposes the same tools to your coding tool directly.
+
+`pipecat mcp install` does this for you wherever the client ships its own CLI, and prints the config to paste where it doesn't:
+
+```bash
+pipecat mcp install                     # every detected client, then build the index
+pipecat mcp install --client cursor     # print the config for one client
+pipecat mcp install --print-config      # show what would be registered, change nothing
+```
+
+To register by hand instead:
 
 <Tabs>
   <Tab title="Claude Code">
@@ -146,6 +193,22 @@ For a longer build or debugging session where the model probes the index repeate
 A newly added MCP server loads when your coding tool starts a session, so add it before opening the session you want to use it in.
 
 See the [repo docs](https://github.com/pipecat-ai/pipecat-context-hub) for additional configuration options.
+
+## Keeping the index current
+
+A stale index is invisible: your agent answers just as confidently from month-old APIs, and you find out when the generated code doesn't match the version you're running. So the Pipecat CLI checks on the way past and prints a one-line notice on stderr when something needs attention:
+
+```
+⚠ Pipecat Context Hub index is 42 days old — run `pipecat mcp refresh` so coding agents don't cite stale APIs.
+⚠ Pipecat Context Hub index was built for pipecat-ai 1.2.0, but this project uses 1.6.0 — run `pipecat mcp refresh` so coding agents match your version.
+```
+
+The version comparison is deliberately quiet. It compares only major and minor, so a patch or dev release never triggers it, and it stays silent when your project has an editable Pipecat checkout or when the index is _ahead_ of your project — an index built from `main` legitimately runs ahead of a released version.
+
+The notice is silent when no index exists, so it never appears for people who don't use the hub. Two environment variables tune it:
+
+- `PIPECAT_HUB_STALE_AFTER_DAYS` — index age in days before it's called stale. Defaults to `7`; `0` disables the age check.
+- `PIPECAT_HUB_CHECK=0` — turn the notice off entirely.
 
 ## Next steps
 

--- a/api-reference/server/utilities/mcp/mcp.mdx
+++ b/api-reference/server/utilities/mcp/mcp.mdx
@@ -7,6 +7,13 @@ description: "Service to connect to MCP (Model Context Protocol) servers"
 
 MCP is an open standard for enabling AI agents to interact with external data and tools. `MCPClient` provides a way to access and call tools via MCP. For example, instead of writing bespoke function call implementations for an external API, you may use an MCP server that provides a bridge to the API. _Be aware there may be security implications._ See [MCP documenation](https://github.com/modelcontextprotocol) for more details.
 
+<Note>
+  `MCPClient` and the `pipecat-ai[mcp]` extra are for a bot connecting to MCP
+  servers at runtime. The similarly named [`pipecat
+  mcp`](/api-reference/cli/mcp) CLI command is unrelated — it's a developer tool
+  that gives *your coding agent* current Pipecat context.
+</Note>
+
 The client maintains a persistent connection to the MCP server and must be used as an async context manager or explicitly started and closed:
 
 ```python

--- a/docs.json
+++ b/docs.json
@@ -901,6 +901,7 @@
                 "pages": [
                   "api-reference/cli/init",
                   "api-reference/cli/eval",
+                  "api-reference/cli/mcp",
                   {
                     "group": "cloud",
                     "pages": [

--- a/pipecat/get-started/build-your-next-bot.mdx
+++ b/pipecat/get-started/build-your-next-bot.mdx
@@ -42,26 +42,20 @@ AI coding tools like Claude Code and Codex write your agent code. The agent foll
 
 ### Add the Pipecat Context Hub
 
-The Context Hub indexes Pipecat docs, examples, and API source into a local database, so your agent queries live context instead of stale training data. Build the index, then add it as an MCP server:
+The Context Hub indexes Pipecat docs, examples, and API source into a local database, so your agent queries live context instead of stale training data. Co-install it with the CLI, then let it set itself up:
 
 ```bash
-uvx pipecat-ai-context-hub@latest refresh   # build local index (~2 min first run)
+uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
+pipecat mcp install
 ```
 
-<Tabs>
-  <Tab title="Claude Code">
-    ```bash
-    claude mcp add pipecat-context-hub -- uvx pipecat-ai-context-hub serve
-    ```
-  </Tab>
-  <Tab title="Codex">
-    ```bash
-    codex mcp add pipecat-context-hub -- uvx pipecat-ai-context-hub serve
-    ```
-  </Tab>
-</Tabs>
+`install` registers the MCP server with each coding agent it finds and builds the index — a few minutes the first time, since it downloads local models. MCP servers load at session start, so do this before opening your coding session.
 
-<Card title="Pipecat Context Hub reference" icon="database" href="/api-reference/context-hub">
+<Card
+  title="Pipecat Context Hub reference"
+  icon="database"
+  href="/api-reference/context-hub"
+>
   Full setup, the tool list, CLI lookups, and MCP config for Cursor and VS Code
 </Card>
 
@@ -71,10 +65,11 @@ Open Claude Code or Codex in your project and prompt it to build. The agent foll
 
 <Note>
   Prefer to feed context by hand? Pipecat docs support the [llms.txt
-  standard](https://llmstxt.org/): [`llms.txt`](https://docs.pipecat.ai/llms.txt)
-  is a structured index of all pages, and
-  [`llms-full.txt`](https://docs.pipecat.ai/llms-full.txt) is the full
-  documentation in a single file, useful for tools that ingest docs in bulk.
+  standard](https://llmstxt.org/):
+  [`llms.txt`](https://docs.pipecat.ai/llms.txt) is a structured index of all
+  pages, and [`llms-full.txt`](https://docs.pipecat.ai/llms-full.txt) is the
+  full documentation in a single file, useful for tools that ingest docs in
+  bulk.
 </Note>
 
 ## Scaffold it yourself

--- a/pipecat/get-started/quickstart.mdx
+++ b/pipecat/get-started/quickstart.mdx
@@ -72,6 +72,14 @@ pipecat init quickstart
 cd pipecat-quickstart
 ```
 
+<Tip>
+  Planning to build with a coding agent? Co-install the [Pipecat Context
+  Hub](/api-reference/context-hub) — `uv tool install "pipecat-ai[cli]" --with
+  pipecat-ai-context-hub` — so your agent queries current Pipecat APIs instead
+  of its training data. It's a larger download, so skip it if you just want the
+  quickstart running.
+</Tip>
+
 2. Configure your API keys
 
 Create your environment file:


### PR DESCRIPTION
**Draft until the Pipecat release carrying these features.** Everything is written and verified; it describes behaviour that is only partly shipped.

## Why

The Context Hub is now a Pipecat CLI plugin. `api-reference/context-hub.mdx` — the only page covering it — was written for the standalone `uvx` workflow, and the CLI reference didn't mention the hub at all. A reader following the current docs gets four manual setup steps and no freshness signal.

## Structure

Two pages, each owning one job:

- **`api-reference/cli/mcp.mdx`** (new) — command reference: flags, arguments, examples, exit codes. Sits under CLI › Commands beside `init` and `eval`, following `eval.mdx`'s shape exactly.
- **`api-reference/context-hub.mdx`** — concepts: what the hub indexes, the tool list, custom sources, MCP-client setup.

Each links to the other. That split is what keeps them from drifting into near-duplicates; the test for any paragraph is "is this a flag, or a concept?"

## What's new on the Context Hub page

Setup leads with the co-install and `pipecat mcp install`, keeping a shorter `uvx` path — a reader can arrive here from an MCP-client angle rather than a Pipecat-CLI one.

Two things it never explained, both of which cost real time to discover:

- **The two installs expose different commands.** A `--with` co-install gives `pipecat mcp` but does *not* put `pipecat-context-hub` on `PATH`; separate `uv tool install`s give the reverse. Entry points are only visible inside the environment their package was installed into.
- **`--with` replaces the tool environment** rather than adding to it, so installing with one plugin silently drops the other.

Plus the CLI's freshness notice, with the two variables that tune it.

## The `mcp` name collides

`api-reference/server/utilities/mcp/mcp.mdx` documents `MCPClient` — a *bot* connecting to MCP servers — installed with `uv add "pipecat-ai[mcp]"`. Against `pipecat mcp` and `uv tool install ... --with pipecat-ai-context-hub`, that's a same-word, different-concept pair in the same tab with near-identical install strings. Site search and the kapa widget will conflate them, so both pages now carry a one-line disambiguation.

## Verification

- `mint broken-links` — clean.
- `npx prettier --write` on every touched file.
- Every command the docs mention (12) and every flag the new page documents were checked programmatically against the released `pipecat-ai-context-hub` 0.3.1. Nothing fictional, and no undocumented flags either.

## Publish preconditions

| Behaviour documented | Ships in | Status |
|---|---|---|
| `pipecat mcp <command>`, `install`, `start` | hub 0.3.1 | released |
| `mcp` listed in `pipecat --help` when not installed | pipecat #5122 | open |
| Freshness notice | pipecat #5122 | open |

So: merge after a Pipecat release containing [#5122](https://github.com/pipecat-ai/pipecat/pull/5122). Until then the freshness-notice section and the "listed whether or not it's installed" line describe unreleased behaviour.