### PR TITLE
Fix SoundfileMixer docs: it does not resample sound files

### DIFF
--- a/api-reference/server/utilities/audio/soundfile-mixer.mdx
+++ b/api-reference/server/utilities/audio/soundfile-mixer.mdx
@@ -8,24 +8,8 @@ description: "Audio mixer for combining real-time audio with sound files"
 `SoundfileMixer` is an audio mixer that combines incoming audio with audio from files. It supports multiple audio file formats through the soundfile library and can handle runtime volume adjustments and sound switching.
 
 <Warning>
-  **Your sound files must already match the output transport's sample rate. The
-  mixer does not resample them.**
-
-  If a file's sample rate does not match, the mixer skips that file when it loads
-  and logs a warning like this:
-
-  ```
-  Sound file office_ambience.wav has incorrect sample rate 44100 (should be 24000)
-  ```
-
-  Nothing else breaks. Your bot still starts and still talks, so this is easy to
-  miss. You just get no background audio at all for the whole session.
-
-  If your background sound never plays, search your logs for
-  `has incorrect sample rate` first. Then convert the file to the sample rate
-  your transport uses.
-
-  Files must also be mono (single channel).
+  `SoundfileMixer` does not resample sound files. Each file must already match
+  the output transport's sample rate.
 </Warning>
 
 ## Installation
@@ -35,6 +19,16 @@ The soundfile mixer requires additional dependencies:
 ```bash
 uv add "pipecat-ai[soundfile]"
 ```
+
+## Sample Rate Requirements
+
+Sound files must match the output transport's sample rate and be mono (single channel). If a file's sample rate doesn't match, the mixer skips it at load time and logs a warning:
+
+```
+Sound file office_ambience.wav has incorrect sample rate 44100 (should be 24000)
+```
+
+The bot otherwise runs normally, so the only symptom is that background audio never plays. If that happens, check your logs for `has incorrect sample rate` and convert the file to the transport's sample rate.
 
 ## Constructor Parameters
 
@@ -122,9 +116,7 @@ await worker.queue_frame(MixerEnableFrame(True))   # Enable mixing
 ## Notes
 
 - Supports any audio format that soundfile can read
-- Sound files are not resampled. Each file's sample rate must already match the output transport's sample rate
-- Files that do not match are skipped when they load, and they are never mixed in
-- Files must be mono (single channel)
+- Sound files must be mono and match the output transport's sample rate — they are not resampled (see [Sample Rate Requirements](#sample-rate-requirements))
 - Thread-safe for pipeline processing
 - Can dynamically switch between multiple sound files
 - Volume can be adjusted in real-time

--- a/api-reference/server/utilities/audio/soundfile-mixer.mdx
+++ b/api-reference/server/utilities/audio/soundfile-mixer.mdx
@@ -7,6 +7,27 @@ description: "Audio mixer for combining real-time audio with sound files"
 
 `SoundfileMixer` is an audio mixer that combines incoming audio with audio from files. It supports multiple audio file formats through the soundfile library and can handle runtime volume adjustments and sound switching.
 
+<Warning>
+  **Your sound files must already match the output transport's sample rate. The
+  mixer does not resample them.**
+
+  If a file's sample rate does not match, the mixer skips that file when it loads
+  and logs a warning like this:
+
+  ```
+  Sound file office_ambience.wav has incorrect sample rate 44100 (should be 24000)
+  ```
+
+  Nothing else breaks. Your bot still starts and still talks, so this is easy to
+  miss. You just get no background audio at all for the whole session.
+
+  If your background sound never plays, search your logs for
+  `has incorrect sample rate` first. Then convert the file to the sample rate
+  your transport uses.
+
+  Files must also be mono (single channel).
+</Warning>
+
 ## Installation
 
 The soundfile mixer requires additional dependencies:
@@ -19,7 +40,7 @@ uv add "pipecat-ai[soundfile]"
 
 <ParamField path="sound_files" type="Mapping[str, str]" required>
 
-Dictionary mapping sound names to file paths. Files must be mono (single channel).
+Dictionary mapping sound names to file paths. Files must be mono (single channel), and each file's sample rate must match the output transport's sample rate.
 
 </ParamField>
 
@@ -101,7 +122,8 @@ await worker.queue_frame(MixerEnableFrame(True))   # Enable mixing
 ## Notes
 
 - Supports any audio format that soundfile can read
-- Automatically resamples audio files to match output sample rate
+- Sound files are not resampled. Each file's sample rate must already match the output transport's sample rate
+- Files that do not match are skipped when they load, and they are never mixed in
 - Files must be mono (single channel)
 - Thread-safe for pipeline processing
 - Can dynamically switch between multiple sound files


### PR DESCRIPTION
## The problem

The SoundfileMixer page lists this under **Notes**:

> Automatically resamples audio files to match output sample rate

That is false, and it has been false since **v0.0.50** (2024-12-11). The changelog for that release says:

> `SoundfileMixer` doesn't resample input files anymore to avoid startup delays. The sample rate of the provided sound files now need to match the sample rate of the output transport.

The current source backs this up. If a sound file's sample rate does not match the output transport, the mixer logs a warning and stores nothing. The mix step then just passes the audio straight through.

## Why it matters

This fails silently. The bot starts fine, joins fine, and talks fine. The only signal is one warning at startup. The customer gets no background audio for the whole session and has no obvious reason why.

A customer hit this on support ticket. They read this page, saw "automatically resamples", and ruled out sample rate as the cause.

Worth noting: the autogenerated reference docs at reference-server.pipecat.ai already say the right thing. Only this Mintlify page is wrong.

## What changed

- Added a `<Warning>` near the top of the page with the real behavior, the actual warning string customers can grep their logs for (`has incorrect sample rate`), and the fix
- Replaced the false "Automatically resamples" bullet in **Notes** with two accurate bullets
- Added the sample rate requirement to the `sound_files` parameter description, since that is where people look when setting it up

I made the warning prominent rather than a passing bullet because the silent failure is the trap here.
