### PR TITLE
docs(pipecat-cloud): correct the readyz recycle claim and document warm instance reuse (T-3090)

### DIFF
--- a/pipecat-cloud/fundamentals/health-checks.mdx
+++ b/pipecat-cloud/fundamentals/health-checks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Health Checks
-description: "Report agent readiness and liveness, and recycle instances on your own schedule"
+description: "Report agent readiness and liveness to control which instances receive new sessions"
 ---
 
 Pipecat Cloud continuously checks the health of each agent instance through two HTTP endpoints that the base image exposes for you: a **readiness** check and a **liveness** check. You don't need to add these endpoints yourself — they're built in — but you can customize the readiness check to control when an instance should receive new sessions.
@@ -31,6 +31,14 @@ Readiness is the signal Pipecat Cloud uses to decide whether an instance should 
 - When an instance reports **not ready**, Pipecat Cloud **stops routing new sessions to it**. Any session already running on that instance is **unaffected** and continues to completion.
 
 This makes the readiness check a clean way to take an instance out of rotation without disrupting active calls — for example, while it finishes a graceful shutdown.
+
+## What readiness does not do
+
+Reporting not-ready takes an instance out of rotation. It does not replace it.
+
+Pipecat Cloud does not start a fresh instance to stand in for one that reports not-ready, and the instance does not restart itself. Its process keeps running with whatever state it already had.
+
+So `readyz()` is not a way to recycle an instance. If your agent needs a fresh process, for example to clear memory it could not release, reporting not-ready will not give you one. There is no per-instance recycle setting today. Instances are replaced when you deploy again, which discards instances created before that deployment. See [Instance reuse and memory](./scaling#instance-reuse-and-memory) for what carries over when an instance serves another session.
 
 ## Customizing the readiness check
 

--- a/pipecat-cloud/fundamentals/logging.mdx
+++ b/pipecat-cloud/fundamentals/logging.mdx
@@ -65,6 +65,14 @@ async def bot(args: PipecatRunnerArguments):
 
 Pipecat Cloud tracks CPU and memory usage for each session, which can be helpful for troubleshooting performance issues. You can view these metrics in two ways:
 
+<Note>
+  These figures are measured for the whole agent instance, not for one session on
+  its own. An instance can serve several sessions one after another in the same
+  process, so a session can start with a high memory figure that came from
+  earlier work on that instance. See [Instance reuse and
+  memory](./scaling#instance-reuse-and-memory).
+</Note>
+
 ### Dashboard
 
 Navigate to your agent in the Pipecat Cloud dashboard, then go to **Sessions** and click on a specific **Session ID** to view CPU and memory usage graphs.

--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -115,6 +115,19 @@ pipecat cloud deploy [agent-name] --max-agents 25
 </Step>
 </Steps>
 
+### Instance reuse and memory
+
+When an instance serves another session, it is the same instance as before: the same container, running the same Python process that handled the previous session. Nothing is reset in between sessions.
+
+That means anything a session does not release stays in memory for the next one. Common examples are objects still referenced by module-level or global variables, cached clients, and background threads or tasks that were never stopped.
+
+Two things follow from this:
+
+- Memory can build up across sessions on an instance that stays warm for a long time. If memory climbs session after session, look for state your agent holds onto after its pipeline ends. Release clients, close connections, stop your own tasks and threads, and avoid keeping per-session data in globals.
+- The CPU and memory figures reported for a session cover the whole instance, not that session alone. A reused instance can start a session with a high memory figure that reflects earlier work in the same process. See [CPU and memory metrics](./logging#cpu-and-memory-metrics).
+
+There is no setting today that gives an instance a fresh process after a set number of sessions or a set age. Reporting not-ready from [`readyz()`](./health-checks) stops new sessions being routed to an instance, but it does not replace the instance or restart its process. Deploying again is what replaces instances.
+
 <Note>
   <b>Your are billed for warm agent instances</b>, even if they are not handling
   active sessions. Developers should consider their deployment strategy when

--- a/pipecat-cloud/guides/capacity-planning.mdx
+++ b/pipecat-cloud/guides/capacity-planning.mdx
@@ -49,7 +49,8 @@ When an active session ends, the agent instance behavior is governed by a cooldo
 
 - The agent instance remains available in your warm capacity pool for a 5-minute cooldown period
 - During this time, it can immediately serve another request without any cold start
-- After the 5-minute cooldown expires, if the agent instance hasn't been used, it will be terminated
+- After the 5-minute cooldown expires, if the agent instance hasn't been used, it will be terminated. This applies to instances above your reserved count
+- Your reserved agents (`min-agents`) are not affected by the cooldown. Pipecat Cloud keeps that many instances warm, so a reserved instance stays running even when it sits idle, and it can serve session after session for as long as it lives. See [Instance reuse and memory](../fundamentals/scaling#instance-reuse-and-memory) for what that means for memory
 - This cooldown provides a buffer in your warm capacity pool, helping to smooth transitions between traffic peaks
 
 ## Planning for Traffic Patterns


### PR DESCRIPTION
Draft. Three related Pipecat Cloud doc gaps found while working Daily support ticket **T-3090** ("unexpected memory growth", a customer running `min-agents 1` whose warm instance served sessions back to back for days).

### 1. Correction: the health checks page overpromised a recycle

This one is a fix to a page that currently says something the product does not do. The subtitle promised "recycle instances on your own schedule", and the body read as if returning `False` from `readyz()` was a supported way to recycle an instance.

It is not. Reporting not-ready does stop new sessions being routed to that instance (that part of the page was right and is unchanged), but nothing then replaces the instance, so `readyz()` on its own never gets you a fresh process.

Changes:
- Subtitle no longer promises a recycle.
- New "What readiness does not do" section states the limitation plainly, and says there is no per-instance recycle setting today.

### 2. New: a reused warm instance is the same container and the same process

Nothing public said this, and it is the single most useful missing fact for anyone debugging memory on Pipecat Cloud. The scaling page said an instance "is returned to the pool and can immediately serve another session" without saying that reuse means the same container and the same Python process, so whatever a session does not release stays for the next one.

Changes:
- New "Instance reuse and memory" section on the scaling page, with what to check when memory climbs session after session.
- Note on the logging page that reported CPU and memory figures are for the whole instance, not one session, so a reused instance can start with a high memory figure.

### 3. Scope fix: the cooldown sentence read as universal

The capacity planning page said an unused instance is terminated after the 5-minute cooldown. That does not hold at or below the reserved floor set by `min-agents`, which is exactly the case the T-3090 customer was in. Scoped the sentence to instances above the reserved count and added a line saying reserved agents are not cycled away by the cooldown.

### Files

- `pipecat-cloud/fundamentals/health-checks.mdx`
- `pipecat-cloud/fundamentals/scaling.mdx`
- `pipecat-cloud/fundamentals/logging.mdx`
- `pipecat-cloud/guides/capacity-planning.mdx`

No roadmap language anywhere: the missing recycle is stated as a current limitation only.
