### PR TITLE
docs(pipecat-cloud): correct what maxSessionDuration actually does (PCC-1066)

### DIFF
--- a/api-reference/cli/cloud/deploy.mdx
+++ b/api-reference/cli/cloud/deploy.mdx
@@ -82,9 +82,8 @@ In addition to this flag, you also need to enable the `KrispVivaFilter()` for yo
 
 <ParamField path="--max-session-duration" type="number" default="7200">
   Maximum session duration in seconds. When a session reaches this limit, the
-  session is stopped: the bot is cancelled and its pipeline shuts down, with no
-  opportunity for the bot to say goodbye first. Valid range: `60` to `14400` (4
-  hours). Defaults to `7200` (2 hours) when unset.
+  session is stopped: the bot is cancelled, with no opportunity for it to say
+  goodbye first. Valid range: `60` to `14400` (4 hours). Defaults to `7200` (2 hours) when unset.
 
 See [Session duration limits](/pipecat-cloud/fundamentals/active-sessions#session-duration-limits)
 for more information.
@@ -318,8 +317,8 @@ agent_profile = "agent-2x"
 
 <ParamField path="max_session_duration" type="number" default="7200">
 Maximum session duration in seconds. When a session reaches this limit, the
-agent's connection is forcibly closed — the session is cut off mid-flight
-with no notice to the bot. Valid range: `60` to `14400` (4 hours). See
+session is stopped: the bot is cancelled, with no opportunity for it to say
+goodbye first. Valid range: `60` to `14400` (4 hours). See
 [Session duration limits](/pipecat-cloud/fundamentals/active-sessions#session-duration-limits)
 for more information.
 

--- a/api-reference/cli/cloud/deploy.mdx
+++ b/api-reference/cli/cloud/deploy.mdx
@@ -82,9 +82,9 @@ In addition to this flag, you also need to enable the `KrispVivaFilter()` for yo
 
 <ParamField path="--max-session-duration" type="number" default="7200">
   Maximum session duration in seconds. When a session reaches this limit, the
-  agent's connection is forcibly closed — the session is cut off mid-flight
-  with no notice to the bot. Valid range: `60` to `14400` (4 hours). Defaults
-  to `7200` (2 hours) when unset.
+  session is stopped: the bot is cancelled and its pipeline shuts down, with no
+  opportunity for the bot to say goodbye first. Valid range: `60` to `14400` (4
+  hours). Defaults to `7200` (2 hours) when unset.
 
 See [Session duration limits](/pipecat-cloud/fundamentals/active-sessions#session-duration-limits)
 for more information.

--- a/api-reference/pipecat-cloud/rest-reference/openapi.json
+++ b/api-reference/pipecat-cloud/rest-reference/openapi.json
@@ -3128,7 +3128,7 @@
           },
           "maxSessionDuration": {
             "type": "integer",
-            "description": "Maximum session duration in seconds. When a session reaches this limit, the session is stopped: the bot is cancelled and its pipeline shuts down, with no opportunity for the bot to say goodbye first. Valid range: 60 to 14400 (4 hours). Defaults to 7200 (2 hours) when unset.",
+            "description": "Maximum session duration in seconds. When a session reaches this limit, the session is stopped: the bot is cancelled, with no opportunity for it to say goodbye first. Valid range: 60 to 14400 (4 hours). Defaults to 7200 (2 hours) when unset.",
             "minimum": 60,
             "maximum": 14400,
             "default": 7200,
@@ -3508,7 +3508,7 @@
           },
           "maxSessionDuration": {
             "type": "integer",
-            "description": "Maximum session duration in seconds. When a session reaches this limit, the session is stopped: the bot is cancelled and its pipeline shuts down, with no opportunity for the bot to say goodbye first. Valid range: 60 to 14400 (4 hours). Defaults to 7200 (2 hours) when unset.",
+            "description": "Maximum session duration in seconds. When a session reaches this limit, the session is stopped: the bot is cancelled, with no opportunity for it to say goodbye first. Valid range: 60 to 14400 (4 hours). Defaults to 7200 (2 hours) when unset.",
             "minimum": 60,
             "maximum": 14400,
             "default": 7200,

--- a/api-reference/pipecat-cloud/rest-reference/openapi.json
+++ b/api-reference/pipecat-cloud/rest-reference/openapi.json
@@ -3128,7 +3128,7 @@
           },
           "maxSessionDuration": {
             "type": "integer",
-            "description": "Maximum session duration in seconds. When a session reaches this limit, the agent's connection is forcibly closed \u2014 the session is cut off mid-flight with no notice to the bot. Valid range: 60 to 14400 (4 hours). Defaults to 7200 (2 hours) when unset.",
+            "description": "Maximum session duration in seconds. When a session reaches this limit, the session is stopped: the bot is cancelled and its pipeline shuts down, with no opportunity for the bot to say goodbye first. Valid range: 60 to 14400 (4 hours). Defaults to 7200 (2 hours) when unset.",
             "minimum": 60,
             "maximum": 14400,
             "default": 7200,
@@ -3508,7 +3508,7 @@
           },
           "maxSessionDuration": {
             "type": "integer",
-            "description": "Maximum session duration in seconds. When a session reaches this limit, the agent's connection is forcibly closed \u2014 the session is cut off mid-flight with no notice to the bot. Valid range: 60 to 14400 (4 hours). Defaults to 7200 (2 hours) when unset.",
+            "description": "Maximum session duration in seconds. When a session reaches this limit, the session is stopped: the bot is cancelled and its pipeline shuts down, with no opportunity for the bot to say goodbye first. Valid range: 60 to 14400 (4 hours). Defaults to 7200 (2 hours) when unset.",
             "minimum": 60,
             "maximum": 14400,
             "default": 7200,

--- a/pipecat-cloud/fundamentals/active-sessions.mdx
+++ b/pipecat-cloud/fundamentals/active-sessions.mdx
@@ -333,7 +333,17 @@ Deleting an agent deployment will block any new sessions from starting, but will
 
 ## Session duration limits
 
-Every service has a maximum session duration. When a session reaches this limit, its connection is forcibly closed — the session is cut off mid-flight with no notice to the bot. This is a platform-level safeguard, not a polite signal: the bot code receives a connection error the next time it tries to send or receive data. If you want the bot to say goodbye gracefully before the cap, you must implement your own timer in bot code that fires slightly earlier.
+Every service has a maximum session duration. When a session reaches this limit, the session is stopped: your `bot()` function is cancelled and the pipeline shuts down.
+
+This is a platform-level safeguard, not a polite signal. The pipeline unwinds cleanly — each processor's `cleanup()` runs — but the bot gets no opportunity to say anything first. If you want it to say goodbye before the cap, implement your own timer in bot code that fires slightly earlier.
+
+<Note>
+  Enforcing the limit inside the bot process requires **base image 0.1.27 or
+  later**. On older base images the limit only closes the platform's connection
+  to your bot, which a bot using an HTTP transport (for example a Daily/WebRTC
+  room) cannot observe — so the session keeps running past its limit. If your
+  agent relies on that, raise `maxSessionDuration` before upgrading.
+</Note>
 
 By default, sessions are capped at **7200 seconds (2 hours)**. You can configure this per service between **60 seconds** and **14400 seconds (4 hours)**:
 

--- a/pipecat-cloud/fundamentals/active-sessions.mdx
+++ b/pipecat-cloud/fundamentals/active-sessions.mdx
@@ -333,16 +333,17 @@ Deleting an agent deployment will block any new sessions from starting, but will
 
 ## Session duration limits
 
-Every service has a maximum session duration. When a session reaches this limit, the session is stopped: your `bot()` function is cancelled and the pipeline shuts down.
+Every service has a maximum session duration. When a session reaches this limit, the session is stopped: your `bot()` function is cancelled.
 
-This is a platform-level safeguard, not a polite signal. The pipeline unwinds cleanly — each processor's `cleanup()` runs — but the bot gets no opportunity to say anything first. If you want it to say goodbye before the cap, implement your own timer in bot code that fires slightly earlier.
+This is a platform-level safeguard, not a polite signal. If your bot runs its pipeline through `PipelineRunner`, the runner absorbs the cancellation and unwinds the pipeline for you, so each processor's `cleanup()` still runs. Otherwise your `bot()` simply sees a `CancelledError` wherever it is currently awaiting, and any cleanup is up to you. Either way the bot gets no opportunity to say anything before the session ends — if you want it to say goodbye, implement your own timer in bot code that fires slightly earlier.
 
 <Note>
   Enforcing the limit inside the bot process requires **base image 0.1.27 or
-  later**. On older base images the limit only closes the platform's connection
-  to your bot, which a bot using an HTTP transport (for example a Daily/WebRTC
-  room) cannot observe — so the session keeps running past its limit. If your
-  agent relies on that, raise `maxSessionDuration` before upgrading.
+  later**. On older base images the limit only closes the platform's own request
+  to your bot. A bot whose session is started by an HTTP request connects its
+  own media transport (a Daily room, for example), so closing that request tells
+  it nothing and the session keeps running past its limit. If your agent relies
+  on that, raise `maxSessionDuration` before upgrading.
 </Note>
 
 By default, sessions are capped at **7200 seconds (2 hours)**. You can configure this per service between **60 seconds** and **14400 seconds (4 hours)**:

--- a/pipecat/learn/pipeline-termination.mdx
+++ b/pipecat/learn/pipeline-termination.mdx
@@ -210,8 +210,9 @@ async def on_client_connected(transport, client):
 <Note>
   On Pipecat Cloud, there is also a platform-level hard cap via
   [`maxSessionDuration`](/pipecat-cloud/fundamentals/active-sessions#session-duration-limits)
-  (default 7200s). That cap is a forced cut with no goodbye, so use the
-  bot-level timer above when you want the bot to speak before the call ends.
+  (default 7200s). That cap cancels the bot and shuts the pipeline down with no
+  goodbye, so use the bot-level timer above when you want the bot to speak
+  before the call ends.
 </Note>
 
 ## Implementation Patterns


### PR DESCRIPTION
Docs half of [PCC-1066](https://linear.app/dailyco/issue/PCC-1066). Companion to [pipecat-cloud-images#102](https://github.com/daily-co/pipecat-cloud-images/pull/102).

## Why

The cap was documented as closing the agent's connection, with the bot "receiving a connection error the next time it tries to send or receive data".

That has never been true for HTTP transports. The platform's `/bot` request is a one-shot POST — the bot never reads or writes on it again, so closing it produces no error the bot can observe and the session simply carries on past its limit. That gap is the bug behind PCC-1066: a customer's session ran ~43 minutes past a 2-hour cap while a second session was placed into the same process.

Base image `0.1.27` enforces the limit inside the bot process, so the outcome the docs already described now actually happens. This PR fixes the four places that described the old mechanism.

## Changes

- **`pipecat-cloud/fundamentals/active-sessions.mdx`** — rewritten to say the bot is cancelled and the pipeline shuts down. Keeps the "not a polite signal / use your own timer" guidance, which is still correct, and adds that the pipeline unwinds cleanly (`cleanup()` runs on each processor) since that is now true and worth knowing. Adds a version note for anyone on an older base image whose sessions currently overrun — they should raise `maxSessionDuration` before upgrading.
- **`api-reference/cli/cloud/deploy.mdx`**, **`openapi.json`** (create + update request schemas) — same correction to the one-line description.
- **`pipecat/learn/pipeline-termination.mdx`** — the cross-reference note.

Left alone: the `maxSessionDuration` **response** field description in `openapi.json`, which describes the configured value rather than the behaviour.

## Sequencing

Safe to merge independently, but the version note names 0.1.27 — ideally land after images#102 is released so the reference is live.
