### PR TITLE
docs: update Gnani STT and TTS services documentation

### DIFF
--- a/api-reference/server/services/stt/gnani.mdx
+++ b/api-reference/server/services/stt/gnani.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Gnani"
-description: "Speech-to-text services for Gnani Vachana — REST and WebSocket streaming for Indian languages"
+description: "Speech-to-text services for Gnani — REST and WebSocket streaming for Indian languages"
 ---
 
 import { CommunityMaintained } from "/snippets/community-maintained.mdx";
@@ -14,7 +14,7 @@ import { CommunityMaintained } from "/snippets/community-maintained.mdx";
 ## Overview
 
 `GnaniHttpSTTService` and `GnaniSTTService` transcribe speech using
-[Gnani Vachana](https://gnani.ai/), a production speech AI platform for 10+
+[Gnani](https://gnani.ai/), a production speech AI platform for 10+
 Indian languages with real-time streaming and multilingual transcription.
 
 Use `GnaniHttpSTTService` for REST-based file transcription of VAD-segmented
@@ -55,7 +55,7 @@ and `InterimTranscriptionFrame` when the API sets `is_final: false`.
     icon="cube"
     href="https://pypi.org/project/gnani-vachana/"
   >
-    Core Gnani Vachana Python SDK (>= 0.7.9) installed as a dependency
+    Core Gnani Python SDK (>= 0.7.9) installed as a dependency
   </Card>
 </CardGroup>
 
@@ -81,14 +81,14 @@ Before using the Gnani STT services, you need:
 
 ### Required Environment Variables
 
-- `GNANI_API_KEY`: Your Gnani Vachana API key for authentication
+- `GNANI_API_KEY`: Your Gnani API key for authentication
 
 ## Configuration
 
 ### `GnaniHttpSTTService` (REST)
 
 <ParamField path="api_key" type="str" required>
-  Gnani Vachana API key for authentication.
+  Gnani API key for authentication.
 </ParamField>
 
 <ParamField path="aiohttp_session" type="aiohttp.ClientSession" required>
@@ -107,7 +107,7 @@ Before using the Gnani STT services, you need:
 ### `GnaniSTTService` (WebSocket)
 
 <ParamField path="api_key" type="str" required>
-  Gnani Vachana API key for authentication.
+  Gnani API key for authentication.
 </ParamField>
 
 <ParamField path="sample_rate" type="int" default="None">

--- a/api-reference/server/services/tts/gnani.mdx
+++ b/api-reference/server/services/tts/gnani.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Gnani"
-description: "Text-to-speech services for Gnani Vachana — REST, SSE, and WebSocket streaming for Indian languages"
+description: "Text-to-speech services for Gnani — REST, SSE, and WebSocket streaming for Indian languages"
 ---
 
 import { CommunityMaintained } from "/snippets/community-maintained.mdx";
@@ -14,7 +14,7 @@ import { CommunityMaintained } from "/snippets/community-maintained.mdx";
 ## Overview
 
 `GnaniHttpTTSService`, `GnaniSSETTSService`, and `GnaniTTSService` synthesize
-speech using [Gnani Vachana](https://gnani.ai/), a production speech AI platform
+speech using [Gnani](https://gnani.ai/), a production speech AI platform
 for 10+ Indian languages with real-time streaming and low-latency synthesis.
 
 Use the REST service for simple request/response synthesis, the SSE service for
@@ -54,7 +54,7 @@ lowest latency with interruption support via `InterruptibleTTSService`.
     icon="cube"
     href="https://pypi.org/project/gnani-vachana/"
   >
-    Core Gnani Vachana Python SDK (>= 0.7.9) installed as a dependency
+    Core Gnani Python SDK (>= 0.7.9) installed as a dependency
   </Card>
 </CardGroup>
 
@@ -80,7 +80,7 @@ Before using the Gnani TTS services, you need:
 
 ### Required Environment Variables
 
-- `GNANI_API_KEY`: Your Gnani Vachana API key for authentication
+- `GNANI_API_KEY`: Your Gnani API key for authentication
 
 ## Configuration
 
@@ -91,7 +91,7 @@ SSE for chunked streaming, and WebSocket for interruptible real-time synthesis.
 ### Shared constructor parameters
 
 <ParamField path="api_key" type="str" required>
-  Gnani Vachana API key for authentication.
+  Gnani API key for authentication.
 </ParamField>
 
 <ParamField path="voice_id" type="str" default="Pranav">


### PR DESCRIPTION
Revised descriptions to remove "Vachana" from references to Gnani services. Updated API key authentication descriptions for clarity. This change enhances consistency across documentation for both speech-to-text and text-to-speech services.