### PR TITLE
docs: follow the rename to `pipecat context-hub`

### DIFF
--- a/api-reference/cli/context-hub.mdx
+++ b/api-reference/cli/context-hub.mdx
@@ -1,27 +1,25 @@
 ---
-title: mcp
+title: context-hub
 description: "Query the Pipecat Context Hub from the CLI, and register it as an MCP server for your coding agent"
 ---
 
-Run the [Pipecat Context Hub](/api-reference/context-hub) through the Pipecat CLI. `pipecat mcp install` registers the hub as an MCP server with your coding agent and builds the local index; the query commands print the same JSON the MCP tools return, for one-shot lookups from a shell.
+Run the [Pipecat Context Hub](/api-reference/context-hub) through the Pipecat CLI. `pipecat context-hub install` registers the hub as an MCP server with your coding agent and builds the local index; the query commands print the same JSON the MCP tools return, for one-shot lookups from a shell.
 
 ## Installation
 
-`pipecat mcp` comes from the `pipecat-ai-context-hub` package, which you co-install with the CLI:
+`pipecat context-hub` comes from the `pipecat-ai-context-hub` package, which you co-install with the CLI:
 
 ```shell
 uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
 ```
 
-Without it, `pipecat mcp` still lists in `pipecat --help` and prints how to enable it when run. The hub also runs standalone, without the Pipecat CLI — see the [Context Hub reference](/api-reference/context-hub) for that path, the tool list, and custom sources.
+Without it, `pipecat context-hub` still lists in `pipecat --help` and prints how to enable it when run. The hub also runs standalone, without the Pipecat CLI — see the [Context Hub reference](/api-reference/context-hub) for that path, the tool list, and custom sources.
 
-<Note>
-  Not to be confused with [`MCPClient`](/api-reference/server/utilities/mcp/mcp)
-  and the `pipecat-ai[mcp]` extra, which let a *bot* connect to MCP servers at
-  runtime. `pipecat mcp` is a developer tool for your own coding agent.
-</Note>
+<Tip>
+  Every command below also works as `pipecat ch`, e.g. `pipecat ch status`.
+</Tip>
 
-## mcp install
+## context-hub install
 
 Register the MCP server with a coding agent and build the index. Configures every detected client CLI (Claude Code, Codex) unless `--client` is given, then runs the first refresh.
 
@@ -30,7 +28,7 @@ Clients that ship their own CLI are configured through it, so they own the edit 
 **Usage:**
 
 ```shell
-pipecat mcp install [OPTIONS]
+pipecat context-hub install [OPTIONS]
 ```
 
 **Options:**
@@ -41,7 +39,8 @@ pipecat mcp install [OPTIONS]
 </ParamField>
 
 <ParamField path="--no-refresh" type="flag">
-  Skip building the index. Run `pipecat mcp refresh` before your first query.
+  Skip building the index. Run `pipecat context-hub refresh` before your first
+  query.
 </ParamField>
 
 <ParamField path="--print-config" type="flag">
@@ -53,14 +52,14 @@ pipecat mcp install [OPTIONS]
   opening the session you want to use it in.
 </Tip>
 
-## mcp refresh
+## context-hub refresh
 
 Rebuild the index, skipping unchanged sources when possible. The first run downloads local embedding models and indexes every source, so allow several minutes.
 
 **Usage:**
 
 ```shell
-pipecat mcp refresh [OPTIONS]
+pipecat context-hub refresh [OPTIONS]
 ```
 
 **Options:**
@@ -80,36 +79,36 @@ pipecat mcp refresh [OPTIONS]
   Also settable with `PIPECAT_HUB_FRAMEWORK_VERSION`.
 </ParamField>
 
-## mcp status
+## context-hub status
 
 Report index health: freshness, record counts, the pipecat version the index was built from, and reranker state. Prints JSON.
 
 **Usage:**
 
 ```shell
-pipecat mcp status
+pipecat context-hub status
 ```
 
-## mcp serve
+## context-hub serve
 
-Start the MCP server over stdio. `pipecat mcp start` is an alias. You rarely run this by hand — your coding tool starts it, using the config `pipecat mcp install` wrote.
+Start the MCP server over stdio. `pipecat context-hub start` is an alias. You rarely run this by hand — your coding tool starts it, using the config `pipecat context-hub install` wrote.
 
 Exits `2` if the index is empty or cannot be opened, rather than starting against an index that would answer every query with nothing.
 
 **Usage:**
 
 ```shell
-pipecat mcp serve
+pipecat context-hub serve
 ```
 
-## mcp search-docs
+## context-hub search-docs
 
 Semantic search over the indexed Pipecat docs.
 
 **Usage:**
 
 ```shell
-pipecat mcp search-docs [OPTIONS] QUERY
+pipecat context-hub search-docs [OPTIONS] QUERY
 ```
 
 **Arguments:**
@@ -129,14 +128,14 @@ pipecat mcp search-docs [OPTIONS] QUERY
   Maximum hits to return (1-50).
 </ParamField>
 
-## mcp search-api
+## context-hub search-api
 
 Search framework internals: classes, signatures, frames, inheritance.
 
 **Usage:**
 
 ```shell
-pipecat mcp search-api [OPTIONS] QUERY
+pipecat context-hub search-api [OPTIONS] QUERY
 ```
 
 **Arguments:**
@@ -184,14 +183,14 @@ pipecat mcp search-api [OPTIONS] QUERY
   Maximum hits to return (1-50).
 </ParamField>
 
-## mcp search-examples
+## context-hub search-examples
 
 Find working Pipecat examples for a capability.
 
 **Usage:**
 
 ```shell
-pipecat mcp search-examples [OPTIONS] QUERY
+pipecat context-hub search-examples [OPTIONS] QUERY
 ```
 
 **Arguments:**
@@ -240,14 +239,14 @@ pipecat mcp search-examples [OPTIONS] QUERY
   it silently excludes new-layout examples. Prefer `--domain` and `--tag`.
 </ParamField>
 
-## mcp get-doc
+## context-hub get-doc
 
 Fetch a full docs page, or one section of it, by ID or path. Use after `search-docs`.
 
 **Usage:**
 
 ```shell
-pipecat mcp get-doc [OPTIONS]
+pipecat context-hub get-doc [OPTIONS]
 ```
 
 **Options:**
@@ -264,14 +263,14 @@ pipecat mcp get-doc [OPTIONS]
   Return only this section heading.
 </ParamField>
 
-## mcp get-example
+## context-hub get-example
 
 Fetch the full source files of an example. Use after `search-examples`.
 
 **Usage:**
 
 ```shell
-pipecat mcp get-example [OPTIONS] EXAMPLE_ID
+pipecat context-hub get-example [OPTIONS] EXAMPLE_ID
 ```
 
 **Arguments:**
@@ -286,14 +285,14 @@ pipecat mcp get-example [OPTIONS] EXAMPLE_ID
   Skip the example's README content.
 </ParamField>
 
-## mcp get-code-snippet
+## context-hub get-code-snippet
 
 Get a targeted code snippet by symbol, by intent, or by path and line range.
 
 **Usage:**
 
 ```shell
-pipecat mcp get-code-snippet [OPTIONS]
+pipecat context-hub get-code-snippet [OPTIONS]
 ```
 
 **Options:**
@@ -338,14 +337,14 @@ pipecat mcp get-code-snippet [OPTIONS]
   Maximum lines to return (1-500).
 </ParamField>
 
-## mcp check-deprecation
+## context-hub check-deprecation
 
 Check whether a module path, class, or method is deprecated. The fastest way to catch a symbol that moved or was replaced.
 
 **Usage:**
 
 ```shell
-pipecat mcp check-deprecation [OPTIONS] SYMBOL
+pipecat context-hub check-deprecation [OPTIONS] SYMBOL
 ```
 
 **Arguments:**
@@ -367,21 +366,21 @@ pipecat mcp check-deprecation [OPTIONS] SYMBOL
 
 ```shell
 # Set the hub up for your coding agent, then keep it current
-pipecat mcp install
-pipecat mcp refresh
+pipecat context-hub install
+pipecat context-hub refresh
 
 # Is this symbol still the right one?
-pipecat mcp check-deprecation PipelineTask
+pipecat context-hub check-deprecation PipelineTask
 
 # Find a working example, then read it
-pipecat mcp search-examples "twilio bot" --domain backend
-pipecat mcp get-example <example-id>
+pipecat context-hub search-examples "twilio bot" --domain backend
+pipecat context-hub get-example <example-id>
 
 # Look up an exact signature
-pipecat mcp search-api "WebsocketServerParams" --limit 3
+pipecat context-hub search-api "WebsocketServerParams" --limit 3
 
 # Index health, including the pipecat version it was built from
-pipecat mcp status
+pipecat context-hub status
 ```
 
 ## Next Steps

--- a/api-reference/cli/overview.mdx
+++ b/api-reference/cli/overview.mdx
@@ -21,7 +21,7 @@ description: "Command-line tool for scaffolding and deploying Pipecat bots"
   <Card
     title="Give Your Agent Context"
     icon="database"
-    href="/api-reference/cli/mcp"
+    href="/api-reference/cli/context-hub"
   >
     Index current Pipecat docs and API source for your coding agent
   </Card>
@@ -78,7 +78,7 @@ Commands from a plugin you haven't installed still appear in `pipecat --help`, a
 
 - **[`pipecat init`](/api-reference/cli/init)** - Initialize and scaffold a new Pipecat project, the single entry point for new projects (built in)
 - **[`pipecat eval`](/api-reference/cli/eval)** - Run behavioral evals against your agents
-- **[`pipecat mcp`](/api-reference/cli/mcp)** - Query the Pipecat Context Hub and register it with your coding agent (requires `pipecat-ai-context-hub`)
+- **[`pipecat context-hub`](/api-reference/cli/context-hub)** - Query the Pipecat Context Hub and register it with your coding agent (requires `pipecat-ai-context-hub`)
 - **[`pipecat cloud`](/api-reference/cli/cloud/auth)** - Deploy and manage bots on Pipecat Cloud (requires `pipecatcloud`)
 
 ## Getting Help
@@ -89,7 +89,7 @@ View help for any command:
 pipecat --help
 pipecat init --help
 pipecat eval --help
-pipecat mcp --help
+pipecat context-hub --help
 pipecat cloud --help
 ```
 

--- a/api-reference/context-hub.mdx
+++ b/api-reference/context-hub.mdx
@@ -22,10 +22,10 @@ The hub is published to PyPI as `pipecat-ai-context-hub`. Co-install it with the
 
 ```bash
 uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
-pipecat mcp install
+pipecat context-hub install
 ```
 
-`install` registers the MCP server with each coding agent it finds, echoing each command it runs, then builds the index — a few minutes the first time, since it downloads local embedding models. Every hub command is then available as `pipecat mcp <command>`; see the [`pipecat mcp` reference](/api-reference/cli/mcp) for the full flag surface.
+`install` registers the MCP server with each coding agent it finds, echoing each command it runs, then builds the index — a few minutes the first time, since it downloads local embedding models. Every hub command is then available as `pipecat context-hub <command>`; see the [`pipecat context-hub` reference](/api-reference/cli/context-hub) for the full flag surface.
 
 <Warning>
   `--with` replaces the tool environment rather than adding to it. If you also
@@ -36,13 +36,13 @@ pipecat mcp install
 If the index gets corrupted, force a rebuild:
 
 ```bash
-pipecat mcp refresh --force
+pipecat context-hub refresh --force
 ```
 
 If your project targets an older Pipecat version, pin the hub to it so results match what you're running:
 
 ```bash
-pipecat mcp refresh --framework-version v0.0.96
+pipecat context-hub refresh --framework-version v0.0.96
 ```
 
 ### Without the Pipecat CLI
@@ -53,7 +53,7 @@ The hub runs standalone too. [`uvx`](https://docs.astral.sh/uv/), uv's one-shot 
 uvx pipecat-ai-context-hub refresh   # build local index (~2 min first run)
 ```
 
-Every command on this page works either way — `pipecat mcp refresh` and `uvx pipecat-ai-context-hub refresh` are the same command.
+Every command on this page works either way — `pipecat context-hub refresh` and `uvx pipecat-ai-context-hub refresh` are the same command.
 
 <Tip>
   To install it once instead of fetching on demand, run `uv tool install
@@ -66,8 +66,8 @@ Every command on this page works either way — `pipecat mcp refresh` and `uvx p
 
 The two installs expose different things, because a command is only visible inside the environment its package was installed into:
 
-- **Co-installed with the CLI** (`--with`) gives you `pipecat mcp`, but does not put `pipecat-context-hub` on your `PATH`.
-- **Installed on its own** (`uv tool install pipecat-ai-context-hub`) gives you `pipecat-context-hub` on your `PATH`, but not `pipecat mcp`.
+- **Co-installed with the CLI** (`--with`) gives you `pipecat context-hub`, but does not put `pipecat-context-hub` on your `PATH`.
+- **Installed on its own** (`uv tool install pipecat-ai-context-hub`) gives you `pipecat-context-hub` on your `PATH`, but not `pipecat context-hub`.
 
 Doing both works and gives you both names, at the cost of a second copy on disk — the hub's retrieval stack is around 1 GB, and the two environments share very little. Pick one unless you have a reason not to.
 
@@ -126,23 +126,23 @@ To make your coding agent reach for these tools automatically, add the [recommen
 Every tool is also a one-shot CLI command, so you can query the index from a shell with no MCP setup. Reach for this when you need a single answer fast, like a deprecation check, an API signature, or an index health check. Each command prints the tool's JSON to stdout:
 
 ```bash
-pipecat mcp check-deprecation PipelineTask      # is this symbol deprecated?
-pipecat mcp search-api "WebsocketServerParams"  # find an API signature
-pipecat mcp status                              # index health / freshness
+pipecat context-hub check-deprecation PipelineTask      # is this symbol deprecated?
+pipecat context-hub search-api "WebsocketServerParams"  # find an API signature
+pipecat context-hub status                              # index health / freshness
 ```
 
-Or, without the Pipecat CLI, the same commands under `uvx pipecat-ai-context-hub`. The [`pipecat mcp` reference](/api-reference/cli/mcp) documents every command and flag.
+Or, without the Pipecat CLI, the same commands under `uvx pipecat-ai-context-hub`. The [`pipecat context-hub` reference](/api-reference/cli/context-hub) documents every command and flag.
 
 ## MCP server
 
 For a longer build or debugging session where the model probes the index repeatedly, add the hub as an MCP server instead of shelling out per query. It keeps the index warm for the whole session and exposes the same tools to your coding tool directly.
 
-`pipecat mcp install` does this for you wherever the client ships its own CLI, and prints the config to paste where it doesn't:
+`pipecat context-hub install` does this for you wherever the client ships its own CLI, and prints the config to paste where it doesn't:
 
 ```bash
-pipecat mcp install                     # every detected client, then build the index
-pipecat mcp install --client cursor     # print the config for one client
-pipecat mcp install --print-config      # show what would be registered, change nothing
+pipecat context-hub install                     # every detected client, then build the index
+pipecat context-hub install --client cursor     # print the config for one client
+pipecat context-hub install --print-config      # show what would be registered, change nothing
 ```
 
 To register by hand instead:
@@ -199,8 +199,8 @@ See the [repo docs](https://github.com/pipecat-ai/pipecat-context-hub) for addit
 A stale index is invisible: your agent answers just as confidently from month-old APIs, and you find out when the generated code doesn't match the version you're running. So the Pipecat CLI checks on the way past and prints a one-line notice on stderr when something needs attention:
 
 ```
-⚠ Pipecat Context Hub index is 42 days old — run `pipecat mcp refresh` so coding agents don't cite stale APIs.
-⚠ Pipecat Context Hub index was built for pipecat-ai 1.2.0, but this project uses 1.6.0 — run `pipecat mcp refresh` so coding agents match your version.
+⚠ Pipecat Context Hub index is 42 days old — run `pipecat context-hub refresh` so coding agents don't cite stale APIs.
+⚠ Pipecat Context Hub index was built for pipecat-ai 1.2.0, but this project uses 1.6.0 — run `pipecat context-hub refresh` so coding agents match your version.
 ```
 
 The version comparison is deliberately quiet. It compares only major and minor, so a patch or dev release never triggers it, and it stays silent when your project has an editable Pipecat checkout or when the index is _ahead_ of your project — an index built from `main` legitimately runs ahead of a released version.

--- a/api-reference/server/utilities/mcp/mcp.mdx
+++ b/api-reference/server/utilities/mcp/mcp.mdx
@@ -7,13 +7,6 @@ description: "Service to connect to MCP (Model Context Protocol) servers"
 
 MCP is an open standard for enabling AI agents to interact with external data and tools. `MCPClient` provides a way to access and call tools via MCP. For example, instead of writing bespoke function call implementations for an external API, you may use an MCP server that provides a bridge to the API. _Be aware there may be security implications._ See [MCP documenation](https://github.com/modelcontextprotocol) for more details.
 
-<Note>
-  `MCPClient` and the `pipecat-ai[mcp]` extra are for a bot connecting to MCP
-  servers at runtime. The similarly named [`pipecat
-  mcp`](/api-reference/cli/mcp) CLI command is unrelated — it's a developer tool
-  that gives *your coding agent* current Pipecat context.
-</Note>
-
 The client maintains a persistent connection to the MCP server and must be used as an async context manager or explicitly started and closed:
 
 ```python

--- a/docs.json
+++ b/docs.json
@@ -909,7 +909,7 @@
                 "pages": [
                   "api-reference/cli/init",
                   "api-reference/cli/eval",
-                  "api-reference/cli/mcp",
+                  "api-reference/cli/context-hub",
                   {
                     "group": "cloud",
                     "pages": [

--- a/pipecat/get-started/build-your-next-bot.mdx
+++ b/pipecat/get-started/build-your-next-bot.mdx
@@ -46,7 +46,7 @@ The Context Hub indexes Pipecat docs, examples, and API source into a local data
 
 ```bash
 uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
-pipecat mcp install
+pipecat context-hub install
 ```
 
 `install` registers the MCP server with each coding agent it finds and builds the index — a few minutes the first time, since it downloads local models. MCP servers load at session start, so do this before opening your coding session.

--- a/pipecat/get-started/next-steps.mdx
+++ b/pipecat/get-started/next-steps.mdx
@@ -81,11 +81,7 @@ Explore real-world examples and recipes for common use cases.
 Scale your bot with managed hosting or self-hosted infrastructure.
 
 <CardGroup cols={2}>
-  <Card
-    title="Pipecat Cloud"
-    icon="cloud"
-    href="/pipecat-cloud/introduction"
-  >
+  <Card title="Pipecat Cloud" icon="cloud" href="/pipecat-cloud/introduction">
     Managed hosting with auto-scaling and built-in WebRTC
   </Card>
   <Card title="Self-Hosting" icon="server" href="/pipecat/deployment/overview">


### PR DESCRIPTION
Follow-up to #1016, which documented the CLI bridge as `pipecat mcp`. The command is `pipecat context-hub` as of hub 0.4.0 ([pipecat-context-hub#106](https://github.com/pipecat-ai/pipecat-context-hub/pull/106)), with `pipecat ch` as a shorter alias.

## Why the rename

`mcp` named the minority feature — ten of the twelve subcommands have nothing to do with MCP — and collided with pipecat's own `pipecat-ai[mcp]` extra for `MCPClient`, a bot-side service. Every other name for this tool was already `pipecat-context-hub`: the package, the console script, the MCP server, the docs page.

## What changed

- `api-reference/cli/mcp.mdx` → `api-reference/cli/context-hub.mdx`, with headings and examples updated
- The `ch` alias documented in a `<Tip>`, the way `pc` already is on the CLI overview
- References updated across the CLI overview, the Context Hub page, and both getting-started guides
- `docs.json` nav entry

## Both disambiguation notes are gone

They existed *only* because `pipecat mcp` and `pipecat-ai[mcp]` were a same-word pair — and after the rename one had become actively false, describing a "similarly named" command that no longer shares the name. Removing them is the clearest sign the rename was the right call: it deleted the problem rather than documenting around it.

The Context Hub page keeps its orientation note, which says what the tool is *for* rather than which of two names you meant.

## Verification

`mint broken-links` clean. Every command the pages document was re-checked against the renamed branch — all twelve still real.

## Ordering

Merge after hub 0.4.0 publishes. Until then `pipecat context-hub` doesn't exist in any released package, and `main` correctly documents `pipecat mcp` from 0.3.1.