### PR TITLE
docs: webhook URL takes the organization name, not an org id

### DIFF
--- a/pipecat-cloud/guides/telephony/daily-dial-in.mdx
+++ b/pipecat-cloud/guides/telephony/daily-dial-in.mdx
@@ -20,6 +20,8 @@ Let Pipecat Cloud handle the webhook automatically.
 
 **Using the REST API:**
 
+Get your organization name with `pipecat cloud organizations list`.
+
 ```bash
 curl --location 'https://api.daily.co/v1' \
 --header 'Authorization: Bearer YOUR_DAILY_API_KEY' \
@@ -28,11 +30,13 @@ curl --location 'https://api.daily.co/v1' \
     "properties": {
         "pinless_dialin": [{
             "phone_number": "YOUR_DAILY_NUMBER",
-            "room_creation_api": "https://api.pipecat.daily.co/v1/public/webhooks/{org_id}/{agent_name}/dialin"
+            "room_creation_api": "https://api.pipecat.daily.co/v1/public/webhooks/ORGANIZATION_NAME/AGENT_NAME/dialin"
         }]
     }
 }'
 ```
+
+Use your organization name in the URL, not an ID. `AGENT_NAME` is the name of your deployed agent. If you put an ID in either spot, the webhook returns `404 "Service not found"` and calls will not connect.
 
 ### Option 2: Custom Webhook Server
 

--- a/pipecat-cloud/guides/telephony/daily-dial-in.mdx
+++ b/pipecat-cloud/guides/telephony/daily-dial-in.mdx
@@ -36,7 +36,7 @@ curl --location 'https://api.daily.co/v1' \
 }'
 ```
 
-Use your organization name in the URL, not an ID. `AGENT_NAME` is the name of your deployed agent. If you put an ID in either spot, the webhook returns `404 "Service not found"` and calls will not connect.
+Use your organization name in the URL, not an ID. `AGENT_NAME` is the name of your deployed agent.
 
 ### Option 2: Custom Webhook Server
 

--- a/pipecat-cloud/guides/whatsapp.mdx
+++ b/pipecat-cloud/guides/whatsapp.mdx
@@ -23,7 +23,7 @@ Your webhook URL must point to your deployed Pipecat agent:
 https://api.pipecat.daily.co/v1/public/webhooks/ORGANIZATION_NAME/AGENT_NAME/whatsapp
 ```
 
-- Get your organization name with `pipecat cloud organizations list`. This is a name, not an ID. An ID here returns `404 "Service not found"`.
+- Get your organization name with `pipecat cloud organizations list`.
 - **Important:** Use your **public API key** as the `Verify Token` for Meta Developer Console verification.
 - Always include the `/whatsapp` path at the end of the webhook URL.
 - Make sure your Pipecat agent is **deployed and running**.

--- a/pipecat-cloud/guides/whatsapp.mdx
+++ b/pipecat-cloud/guides/whatsapp.mdx
@@ -20,9 +20,10 @@ In Pipecat Cloud you only need to ensure your bot is deployed and your environme
 Your webhook URL must point to your deployed Pipecat agent:
 
 ```
-https://api.pipecat.daily.co/v1/public/webhooks/$ORGANIZATION_ID/$AGENT_NAME/whatsapp
+https://api.pipecat.daily.co/v1/public/webhooks/ORGANIZATION_NAME/AGENT_NAME/whatsapp
 ```
 
+- Get your organization name with `pipecat cloud organizations list`. This is a name, not an ID. An ID here returns `404 "Service not found"`.
 - **Important:** Use your **public API key** as the `Verify Token` for Meta Developer Console verification.
 - Always include the `/whatsapp` path at the end of the webhook URL.
 - Make sure your Pipecat agent is **deployed and running**.

--- a/pipecat/features/whatsapp.mdx
+++ b/pipecat/features/whatsapp.mdx
@@ -86,7 +86,7 @@ Set up your webhook to receive **WhatsApp call events**.
      ```
      https://api.pipecat.daily.co/v1/public/webhooks/ORGANIZATION_NAME/AGENT_NAME/whatsapp
      ```
-   - Get your organization name with `pipecat cloud organizations list`. This is a name, not an ID. An ID here returns `404 "Service not found"`.
+   - Get your organization name with `pipecat cloud organizations list`.
    - ✅ **Important:** Always include the `/whatsapp` path at the end of your webhook URL.
 
 3. **Enter your Verify Token**

--- a/pipecat/features/whatsapp.mdx
+++ b/pipecat/features/whatsapp.mdx
@@ -84,8 +84,9 @@ Set up your webhook to receive **WhatsApp call events**.
    - Ensure your Pipecat agent is already **deployed and running**.
    - Use the following format for your webhook URL:
      ```
-     https://api.pipecat.daily.co/v1/public/webhooks/$ORGANIZATION_ID/$AGENT_NAME/whatsapp
+     https://api.pipecat.daily.co/v1/public/webhooks/ORGANIZATION_NAME/AGENT_NAME/whatsapp
      ```
+   - Get your organization name with `pipecat cloud organizations list`. This is a name, not an ID. An ID here returns `404 "Service not found"`.
    - ✅ **Important:** Always include the `/whatsapp` path at the end of your webhook URL.
 
 3. **Enter your Verify Token**


### PR DESCRIPTION
## The bug

The Pipecat Cloud "Daily PSTN Dial-in" guide documented the pinless `room_creation_api` webhook URL like this:

```
https://api.pipecat.daily.co/v1/public/webhooks/{org_id}/{agent_name}/dialin
```

That first path segment is not an id. The API resolves the organization by **name**. The route is declared with an `:organizationName` param and the handler looks the org up by its name, so a UUID never matches.

## Customer impact

Someone reads `{org_id}`, pastes their organization UUID, and every dial-in call fails. The webhook returns `404 "Service not found"` and there is nothing useful in the logs to point at the URL. A real customer hit this (T-3093).

## The fix

Placeholders are now `ORGANIZATION_NAME` / `AGENT_NAME`, with a short line saying where the name comes from: `pipecat cloud organizations list`. That matches the `AGENT_NAME.ORGANIZATION_NAME` wording the other telephony pages already use for `serviceHost`.

## Files changed

- `pipecat-cloud/guides/telephony/daily-dial-in.mdx`: the reported bug.
- `pipecat-cloud/guides/whatsapp.mdx`: same URL, same route, was using `$ORGANIZATION_ID`.
- `pipecat/features/whatsapp.mdx`: same as above.

The two WhatsApp pages hit the exact same `/v1/public/webhooks/:organizationName/:serviceName/...` route, so they had the same bug. Fixed them here rather than leaving the copy-pasted version wrong.

