### PR TITLE
docs: the Context Hub ships with the Pipecat CLI

### DIFF
--- a/api-reference/cli/context-hub.mdx
+++ b/api-reference/cli/context-hub.mdx
@@ -22,7 +22,7 @@ Clients that ship their own CLI are configured through it, so they own the edit 
 
 Re-running it converges rather than skipping: an entry that already matches is left untouched, and one that doesn't is replaced.
 
-**Exit codes:** `0` when a client was configured, `1` when a client CLI rejected the registration, and `3` when nothing was configured automatically and the config was printed to paste instead — the path Cursor, VS Code, and Zed always take, along with any machine that has no client CLI installed.
+**Exit codes:** `0` when a client was configured, `1` when a client CLI rejected the registration, `3` when nothing was configured automatically and the config was printed to paste instead — the path Cursor, VS Code, and Zed always take, along with any machine that has no client CLI installed — and `4` when replacing a mismatched entry failed and the previous registration couldn't be restored either, leaving that client with nothing registered.
 
 **Usage:**
 
@@ -73,9 +73,10 @@ pipecat context-hub refresh [OPTIONS]
 </ParamField>
 
 <ParamField path="--framework-version" type="string">
-  Pin the framework repo to a specific git tag, e.g. `v0.0.96`. Source chunks
-  come from that version instead of `HEAD`, so results match an older project.
-  Also settable with `PIPECAT_HUB_FRAMEWORK_VERSION`.
+  Pin the framework repo to a specific git tag, e.g. `v1.7.0`, or `latest` for
+  its newest release tag. Source chunks come from that version instead of
+  `HEAD`, so results match the release your project runs rather than whatever is
+  on `main`. Also settable with `PIPECAT_HUB_FRAMEWORK_VERSION`.
 </ParamField>
 
 ## context-hub status
@@ -366,7 +367,7 @@ pipecat context-hub check-deprecation [OPTIONS] SYMBOL
 ```shell
 # Set the hub up for your coding agent, then keep it current
 pipecat context-hub install
-pipecat context-hub refresh
+pipecat context-hub refresh --framework-version latest
 
 # Is this symbol still the right one?
 pipecat context-hub check-deprecation PipelineTask

--- a/api-reference/cli/context-hub.mdx
+++ b/api-reference/cli/context-hub.mdx
@@ -8,13 +8,7 @@ Run the [Pipecat Context Hub](/api-reference/context-hub) through the Pipecat CL
 
 ## Installation
 
-`pipecat context-hub` comes from the `pipecat-ai-context-hub` package, which you co-install with the CLI:
-
-```shell
-uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
-```
-
-Without it, `pipecat context-hub` still lists in `pipecat --help` and prints how to enable it when run. The hub also runs standalone, without the Pipecat CLI — see the [Context Hub reference](/api-reference/context-hub) for that path, the tool list, and custom sources.
+`pipecat context-hub` ships with the CLI, so `uv tool install "pipecat-ai[cli]"` is all it takes. The hub also runs standalone, without the Pipecat CLI — see the [Context Hub reference](/api-reference/context-hub) for that path, the tool list, and custom sources.
 
 <Tip>
   Every command below also works as `pipecat ch`, e.g. `pipecat ch status`.
@@ -25,6 +19,10 @@ Without it, `pipecat context-hub` still lists in `pipecat --help` and prints how
 Register the MCP server with a coding agent and build the index. Configures every detected client CLI (Claude Code, Codex) unless `--client` is given, then runs the first refresh.
 
 Clients that ship their own CLI are configured through it, so they own the edit to their config file. For clients configured by hand (Cursor, VS Code, Zed) the command prints the JSON and where it goes rather than writing a file it doesn't own.
+
+Re-running it converges rather than skipping: an entry that already matches is left untouched, and one that doesn't is replaced.
+
+**Exit codes:** `0` when a client was configured, `1` when a client CLI rejected the registration, and `3` when nothing was configured automatically and the config was printed to paste instead — the path Cursor, VS Code, and Zed always take, along with any machine that has no client CLI installed.
 
 **Usage:**
 
@@ -55,7 +53,7 @@ pipecat context-hub install [OPTIONS]
 
 ## context-hub refresh
 
-Rebuild the index, skipping unchanged sources when possible. The first run downloads local embedding models and indexes every source, so allow several minutes.
+Rebuild the index, skipping unchanged sources when possible. The first run clones the indexed repositories, downloads local embedding models, and embeds roughly 17,000 records — upwards of three minutes and about 900 MB of disk. Later runs re-ingest only the sources whose contents moved, so they usually take one to two minutes.
 
 **Usage:**
 

--- a/api-reference/cli/init.mdx
+++ b/api-reference/cli/init.mdx
@@ -185,7 +185,7 @@ Registration runs without asking: it's instant, idempotent, and needs doing per 
 
 Building the index is the only prompt, and only appears when no index exists yet. It takes upwards of three minutes and about 900 MB of disk, so `init` asks rather than assuming. The index is shared across every project on the machine, so once it exists the question doesn't return.
 
-`pipecat init quickstart` skips this entirely, to stay a short path to a running bot.
+Two paths skip setup: `pipecat init quickstart`, to stay a short path to a running bot; and scaffolding a bot from flags or `--config`, where the generated README carries the instructions instead. If you scaffolded that way — the route a coding agent takes — run `pipecat context-hub install` to wire the hub up.
 
 ## Behavior
 

--- a/api-reference/cli/init.mdx
+++ b/api-reference/cli/init.mdx
@@ -172,7 +172,11 @@ pipecat init [TARGET_DIR] [OPTIONS]
   and coding agents that need to discover valid values at runtime.
 </ParamField>
 
-<ParamField path="--context-hub / --no-context-hub" type="boolean" default="true">
+<ParamField
+  path="--context-hub / --no-context-hub"
+  type="boolean"
+  default="true"
+>
   Register the [Pipecat Context Hub](/api-reference/context-hub) MCP server with
   your coding agents, and offer to build its index.
 </ParamField>
@@ -181,11 +185,11 @@ pipecat init [TARGET_DIR] [OPTIONS]
 
 On the coding-agent path, `init` sets up the Context Hub — the guides it writes tell your agent to query the hub, so it makes sure the hub is there to query.
 
-Registration runs without asking: it's instant, idempotent, and needs doing per project, since Claude Code stores MCP servers per project. `init` reports what came of it — editors configured by hand (Cursor, VS Code, Zed) are pointed at `pipecat context-hub install` to print the config block to paste, and a client that rejects the registration reports why.
+Registration runs without asking: it's instant, idempotent, and needs doing per project, since Claude Code stores MCP servers per project. `init` reports what came of it — it registers with every coding agent CLI it detects (Claude Code, Codex), a client that rejects the registration reports why, and if it finds no agent CLI at all it points you at `pipecat context-hub install` to print the config block for the editors configured by hand (Cursor, VS Code, Zed).
 
-Building the index is the only prompt, and only appears when no index exists yet. It takes upwards of three minutes and about 900 MB of disk, so `init` asks rather than assuming. The index is shared across every project on the machine, so once it exists the question doesn't return.
+Building the index is the only prompt, and only appears when no index exists yet. It takes upwards of three minutes and about 900 MB of disk, so `init` asks rather than assuming. The index is shared across every project on the machine, so once it exists the question doesn't return. A non-interactive run registers but never builds — it prints the `refresh` command instead.
 
-Two paths skip setup: `pipecat init quickstart`, to stay a short path to a running bot; and scaffolding a bot from flags or `--config`, where the generated README carries the instructions instead. If you scaffolded that way — the route a coding agent takes — run `pipecat context-hub install` to wire the hub up.
+Three paths skip setup, since none of them writes the agent-guide start-here: `pipecat init quickstart`, to stay a short path to a running bot; scaffolding a bot from flags or `--config`; and choosing "Scaffold a runnable bot now" in the interactive prompt. In each case the generated README carries the instructions instead. If you scaffolded that way — the route a coding agent takes — run `pipecat context-hub install` to wire the hub up.
 
 ## Behavior
 

--- a/api-reference/cli/init.mdx
+++ b/api-reference/cli/init.mdx
@@ -172,6 +172,21 @@ pipecat init [TARGET_DIR] [OPTIONS]
   and coding agents that need to discover valid values at runtime.
 </ParamField>
 
+<ParamField path="--context-hub / --no-context-hub" type="boolean" default="true">
+  Register the [Pipecat Context Hub](/api-reference/context-hub) MCP server with
+  your coding agents, and offer to build its index.
+</ParamField>
+
+## Context Hub setup
+
+On the coding-agent path, `init` sets up the Context Hub — the guides it writes tell your agent to query the hub, so it makes sure the hub is there to query.
+
+Registration runs without asking: it's instant, idempotent, and needs doing per project, since Claude Code stores MCP servers per project. `init` reports what came of it — editors configured by hand (Cursor, VS Code, Zed) are pointed at `pipecat context-hub install` to print the config block to paste, and a client that rejects the registration reports why.
+
+Building the index is the only prompt, and only appears when no index exists yet. It takes upwards of three minutes and about 900 MB of disk, so `init` asks rather than assuming. The index is shared across every project on the machine, so once it exists the question doesn't return.
+
+`pipecat init quickstart` skips this entirely, to stay a short path to a running bot.
+
 ## Behavior
 
 - **Existing guide files are kept.** Re-running `pipecat init` never overwrites an existing `AGENTS.md`, `CLAUDE.md`, or `GETTING_STARTED.md`, so your edits are safe. If a guide was written by an older Pipecat version, an interactive run offers to refresh it on the spot; a non-interactive run prints how.

--- a/api-reference/cli/overview.mdx
+++ b/api-reference/cli/overview.mdx
@@ -54,7 +54,7 @@ pipecat --version
 
 <Tip>All commands can use either `pipecat` or the shorter `pc` alias.</Tip>
 
-This gives you `pipecat init`, `pipecat eval`, and `pipecat context-hub`. Deploy commands come from a separate package, co-installed with `--with`:
+This gives you `pipecat init`, `pipecat eval`, and `pipecat context-hub`. The Context Hub bundles a local retrieval stack, so it accounts for most of the extra's install size. Deploy commands come from a separate package, co-installed with `--with`:
 
 ```bash
 uv tool install "pipecat-ai[cli]" --with pipecatcloud

--- a/api-reference/cli/overview.mdx
+++ b/api-reference/cli/overview.mdx
@@ -54,31 +54,24 @@ pipecat --version
 
 <Tip>All commands can use either `pipecat` or the shorter `pc` alias.</Tip>
 
-This gives you the built-in `pipecat init` and `pipecat eval` commands. The `cloud` and `mcp` commands each come from a separate package that you co-install with `--with`:
+This gives you `pipecat init`, `pipecat eval`, and `pipecat context-hub`. Deploy commands come from a separate package, co-installed with `--with`:
 
 ```bash
-# Add deploy commands
 uv tool install "pipecat-ai[cli]" --with pipecatcloud
-
-# Add Context Hub commands for your coding agent
-uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
-
-# Or both
-uv tool install "pipecat-ai[cli]" --with pipecatcloud --with pipecat-ai-context-hub
 ```
 
 <Warning>
   `--with` replaces the tool environment rather than adding to it, so every run
-  must name every plugin you want. Installing with only one drops the other.
+  must name every plugin you want.
 </Warning>
 
-Commands from a plugin you haven't installed still appear in `pipecat --help`, and print how to enable themselves when run.
+`pipecat cloud` still appears in `pipecat --help` without that package, and prints how to enable itself when run.
 
 ## Commands
 
 - **[`pipecat init`](/api-reference/cli/init)** - Initialize and scaffold a new Pipecat project, the single entry point for new projects (built in)
 - **[`pipecat eval`](/api-reference/cli/eval)** - Run behavioral evals against your agents
-- **[`pipecat context-hub`](/api-reference/cli/context-hub)** - Query the Pipecat Context Hub and register it with your coding agent (requires `pipecat-ai-context-hub`)
+- **[`pipecat context-hub`](/api-reference/cli/context-hub)** - Query the Pipecat Context Hub and register it with your coding agent (built in)
 - **[`pipecat cloud`](/api-reference/cli/cloud/auth)** - Deploy and manage bots on Pipecat Cloud (requires `pipecatcloud`)
 
 ## Getting Help

--- a/api-reference/context-hub.mdx
+++ b/api-reference/context-hub.mdx
@@ -42,11 +42,17 @@ If the index gets corrupted, force a rebuild:
 pipecat context-hub refresh --force
 ```
 
-If your project targets an older Pipecat version, pin the hub to it so results match what you're running:
+By default `refresh` indexes framework source from `main`, which runs ahead of any release. Pin it so results match the version your project actually runs — `latest` for the newest release tag, or an exact tag when you target an older one:
 
 ```bash
-pipecat context-hub refresh --framework-version v0.0.96
+pipecat context-hub refresh --framework-version latest
+pipecat context-hub refresh --framework-version v1.7.0
 ```
+
+<Note>
+  `--framework-version latest` needs `pipecat-ai-context-hub` 0.5.3 or newer,
+  the floor the `cli` extra pins. Earlier versions reject the value.
+</Note>
 
 ### Without the Pipecat CLI
 

--- a/api-reference/context-hub.mdx
+++ b/api-reference/context-hub.mdx
@@ -18,20 +18,23 @@ Every tool runs two ways: as a one-shot CLI command and as an MCP server. Use th
 
 ## Setup
 
-The hub is published to PyPI as `pipecat-ai-context-hub`. Co-install it with the Pipecat CLI, then let it configure your coding agent and build the index in one step:
+The hub ships with the Pipecat CLI, so installing the CLI is the whole install:
 
 ```bash
-uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
+uv tool install "pipecat-ai[cli]"
+```
+
+If you scaffold with [`pipecat init`](/api-reference/cli/init), setup is already done — it registers the MCP server with the coding agents it finds and offers to build the index. Otherwise, do both in one step:
+
+```bash
 pipecat context-hub install
 ```
 
-`install` registers the MCP server with each coding agent it finds, echoing each command it runs, then builds the index — a few minutes the first time, since it downloads local embedding models. Every hub command is then available as `pipecat context-hub <command>`; see the [`pipecat context-hub` reference](/api-reference/cli/context-hub) for the full flag surface.
+`install` registers the MCP server with each coding agent CLI it finds, echoing each command it runs, then builds the index. Editors configured by hand — Cursor, VS Code, Zed — get the config block printed for you to paste instead; `install` exits `3` to say so, where `0` means a client was configured.
 
-<Warning>
-  `--with` replaces the tool environment rather than adding to it. If you also
-  use `pipecat cloud`, name both plugins: `uv tool install "pipecat-ai[cli]"
-  --with pipecatcloud --with pipecat-ai-context-hub`.
-</Warning>
+The first build takes upwards of three minutes and about 900 MB of disk: it clones the indexed repositories, downloads local embedding models, and embeds roughly 17,000 records. Later refreshes skip unchanged sources, so they usually take one to two minutes.
+
+Every hub command is available as `pipecat context-hub <command>`; see the [`pipecat context-hub` reference](/api-reference/cli/context-hub) for the full flag surface.
 
 If the index gets corrupted, force a rebuild:
 
@@ -50,26 +53,18 @@ pipecat context-hub refresh --framework-version v0.0.96
 The hub runs standalone too. [`uvx`](https://docs.astral.sh/uv/), uv's one-shot runner, fetches and runs it on demand with nothing installed:
 
 ```bash
-uvx pipecat-ai-context-hub refresh   # build local index (~2 min first run)
+uvx pipecat-ai-context-hub refresh   # build local index
 ```
 
 Every command on this page works either way — `pipecat context-hub refresh` and `uvx pipecat-ai-context-hub refresh` are the same command.
 
 <Tip>
   To install it once instead of fetching on demand, run `uv tool install
-  pipecat-ai-context-hub`. This puts the command on your `PATH`, so you drop the
-  `uvx` prefix and call it directly, using the shorter `pipecat-context-hub`
-  name.
+  pipecat-ai-context-hub`. This puts the command on your `PATH` under the
+  shorter `pipecat-context-hub` name, so you drop the `uvx` prefix. The index
+  lives in one place per machine, so a standalone install and the CLI's bundled
+  copy share it rather than each building their own.
 </Tip>
-
-### Which install to choose
-
-The two installs expose different things, because a command is only visible inside the environment its package was installed into:
-
-- **Co-installed with the CLI** (`--with`) gives you `pipecat context-hub`, but does not put `pipecat-context-hub` on your `PATH`.
-- **Installed on its own** (`uv tool install pipecat-ai-context-hub`) gives you `pipecat-context-hub` on your `PATH`, but not `pipecat context-hub`.
-
-Doing both works and gives you both names, at the cost of a second copy on disk — the hub's retrieval stack is around 1 GB, and the two environments share very little. Pick one unless you have a reason not to.
 
 ## Custom sources
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -691,11 +691,12 @@ cd pipecat-quickstart
 ```
 
 <Tip>
-  Planning to build with a coding agent? Co-install the [Pipecat Context
-  Hub](/api-reference/context-hub) — `uv tool install "pipecat-ai[cli]" --with
-  pipecat-ai-context-hub` — so your agent queries current Pipecat APIs instead
-  of its training data. It's a larger download, so skip it if you just want the
-  quickstart running.
+  Planning to build with a coding agent? Set up the [Pipecat Context
+  Hub](/api-reference/context-hub) with `pipecat context-hub install`, so your
+  agent queries current Pipecat APIs instead of its training data. It ships with
+  the CLI, so there's nothing extra to install — but `pipecat init quickstart`
+  deliberately skips the setup to stay a short path to a running bot, so run
+  `install` yourself. Building its index takes a few minutes and about 900 MB.
 </Tip>
 
 2. Configure your API keys
@@ -1082,16 +1083,19 @@ pipecat init
 
 AI coding tools like Claude Code and Codex write your agent code. The agent follows the `AGENTS.md` guide that `init` wrote, so it uses Pipecat conventions, scaffolds the app for you, and verifies its own work. This path also writes `GETTING_STARTED.md`, a short guide to driving the agent well.
 
-### Add the Pipecat Context Hub
+### The Pipecat Context Hub
 
-The Context Hub indexes Pipecat docs, examples, and API source into a local database, so your agent queries live context instead of stale training data. Co-install it with the CLI, then let it set itself up:
+The Context Hub indexes Pipecat docs, examples, and API source into a local database, so your agent queries live context instead of stale training data. It ships with the CLI, and `init` sets it up for you: it registers the MCP server with the coding agents it finds, then offers to build the index.
+
+The build takes upwards of three minutes and about 900 MB of disk, so `init` asks rather than assuming. If you skipped it, run:
 
 ```bash
-uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
-pipecat context-hub install
+pipecat context-hub refresh
 ```
 
-`install` registers the MCP server with each coding agent it finds and builds the index — a few minutes the first time, since it downloads local models. MCP servers load at session start, so do this before opening your coding session.
+If `init` found no coding agent CLI to register with — the case for editors configured by hand, like Cursor, VS Code, and Zed — run `pipecat context-hub install` instead, which prints the config block to paste and builds the index.
+
+Do it before opening your coding session — MCP servers load at session start, and the server won't start against an empty index.
 
 <Card
   title="Pipecat Context Hub reference"
@@ -86563,31 +86567,24 @@ pipecat --version
 
 <Tip>All commands can use either `pipecat` or the shorter `pc` alias.</Tip>
 
-This gives you the built-in `pipecat init` and `pipecat eval` commands. The `cloud` and `mcp` commands each come from a separate package that you co-install with `--with`:
+This gives you `pipecat init`, `pipecat eval`, and `pipecat context-hub`. The Context Hub bundles a local retrieval stack, so it accounts for most of the extra's install size. Deploy commands come from a separate package, co-installed with `--with`:
 
 ```bash
-# Add deploy commands
 uv tool install "pipecat-ai[cli]" --with pipecatcloud
-
-# Add Context Hub commands for your coding agent
-uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
-
-# Or both
-uv tool install "pipecat-ai[cli]" --with pipecatcloud --with pipecat-ai-context-hub
 ```
 
 <Warning>
   `--with` replaces the tool environment rather than adding to it, so every run
-  must name every plugin you want. Installing with only one drops the other.
+  must name every plugin you want.
 </Warning>
 
-Commands from a plugin you haven't installed still appear in `pipecat --help`, and print how to enable themselves when run.
+`pipecat cloud` still appears in `pipecat --help` without that package, and prints how to enable itself when run.
 
 ## Commands
 
 - **[`pipecat init`](/api-reference/cli/init)** - Initialize and scaffold a new Pipecat project, the single entry point for new projects (built in)
 - **[`pipecat eval`](/api-reference/cli/eval)** - Run behavioral evals against your agents
-- **[`pipecat context-hub`](/api-reference/cli/context-hub)** - Query the Pipecat Context Hub and register it with your coding agent (requires `pipecat-ai-context-hub`)
+- **[`pipecat context-hub`](/api-reference/cli/context-hub)** - Query the Pipecat Context Hub and register it with your coding agent (built in)
 - **[`pipecat cloud`](/api-reference/cli/cloud/auth)** - Deploy and manage bots on Pipecat Cloud (requires `pipecatcloud`)
 
 ## Getting Help
@@ -86784,6 +86781,25 @@ pipecat init [TARGET_DIR] [OPTIONS]
   Print all available service options as JSON and exit. Useful for CI scripts
   and coding agents that need to discover valid values at runtime.
 </ParamField>
+
+<ParamField
+  path="--context-hub / --no-context-hub"
+  type="boolean"
+  default="true"
+>
+  Register the [Pipecat Context Hub](/api-reference/context-hub) MCP server with
+  your coding agents, and offer to build its index.
+</ParamField>
+
+## Context Hub setup
+
+On the coding-agent path, `init` sets up the Context Hub — the guides it writes tell your agent to query the hub, so it makes sure the hub is there to query.
+
+Registration runs without asking: it's instant, idempotent, and needs doing per project, since Claude Code stores MCP servers per project. `init` reports what came of it — it registers with every coding agent CLI it detects (Claude Code, Codex), a client that rejects the registration reports why, and if it finds no agent CLI at all it points you at `pipecat context-hub install` to print the config block for the editors configured by hand (Cursor, VS Code, Zed).
+
+Building the index is the only prompt, and only appears when no index exists yet. It takes upwards of three minutes and about 900 MB of disk, so `init` asks rather than assuming. The index is shared across every project on the machine, so once it exists the question doesn't return. A non-interactive run registers but never builds — it prints the `refresh` command instead.
+
+Three paths skip setup, since none of them writes the agent-guide start-here: `pipecat init quickstart`, to stay a short path to a running bot; scaffolding a bot from flags or `--config`; and choosing "Scaffold a runnable bot now" in the interactive prompt. In each case the generated README carries the instructions instead. If you scaffolded that way — the route a coding agent takes — run `pipecat context-hub install` to wire the hub up.
 
 ## Behavior
 
@@ -87181,13 +87197,7 @@ Run the [Pipecat Context Hub](/api-reference/context-hub) through the Pipecat CL
 
 ## Installation
 
-`pipecat context-hub` comes from the `pipecat-ai-context-hub` package, which you co-install with the CLI:
-
-```shell
-uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
-```
-
-Without it, `pipecat context-hub` still lists in `pipecat --help` and prints how to enable it when run. The hub also runs standalone, without the Pipecat CLI — see the [Context Hub reference](/api-reference/context-hub) for that path, the tool list, and custom sources.
+`pipecat context-hub` ships with the CLI, so `uv tool install "pipecat-ai[cli]"` is all it takes. The hub also runs standalone, without the Pipecat CLI — see the [Context Hub reference](/api-reference/context-hub) for that path, the tool list, and custom sources.
 
 <Tip>
   Every command below also works as `pipecat ch`, e.g. `pipecat ch status`.
@@ -87198,6 +87208,10 @@ Without it, `pipecat context-hub` still lists in `pipecat --help` and prints how
 Register the MCP server with a coding agent and build the index. Configures every detected client CLI (Claude Code, Codex) unless `--client` is given, then runs the first refresh.
 
 Clients that ship their own CLI are configured through it, so they own the edit to their config file. For clients configured by hand (Cursor, VS Code, Zed) the command prints the JSON and where it goes rather than writing a file it doesn't own.
+
+Re-running it converges rather than skipping: an entry that already matches is left untouched, and one that doesn't is replaced.
+
+**Exit codes:** `0` when a client was configured, `1` when a client CLI rejected the registration, `3` when nothing was configured automatically and the config was printed to paste instead — the path Cursor, VS Code, and Zed always take, along with any machine that has no client CLI installed — and `4` when replacing a mismatched entry failed and the previous registration couldn't be restored either, leaving that client with nothing registered.
 
 **Usage:**
 
@@ -87228,7 +87242,7 @@ pipecat context-hub install [OPTIONS]
 
 ## context-hub refresh
 
-Rebuild the index, skipping unchanged sources when possible. The first run downloads local embedding models and indexes every source, so allow several minutes.
+Rebuild the index, skipping unchanged sources when possible. The first run clones the indexed repositories, downloads local embedding models, and embeds roughly 17,000 records — upwards of three minutes and about 900 MB of disk. Later runs re-ingest only the sources whose contents moved, so they usually take one to two minutes.
 
 **Usage:**
 
@@ -87248,9 +87262,10 @@ pipecat context-hub refresh [OPTIONS]
 </ParamField>
 
 <ParamField path="--framework-version" type="string">
-  Pin the framework repo to a specific git tag, e.g. `v0.0.96`. Source chunks
-  come from that version instead of `HEAD`, so results match an older project.
-  Also settable with `PIPECAT_HUB_FRAMEWORK_VERSION`.
+  Pin the framework repo to a specific git tag, e.g. `v1.7.0`, or `latest` for
+  its newest release tag. Source chunks come from that version instead of
+  `HEAD`, so results match the release your project runs rather than whatever is
+  on `main`. Also settable with `PIPECAT_HUB_FRAMEWORK_VERSION`.
 </ParamField>
 
 ## context-hub status
@@ -87541,7 +87556,7 @@ pipecat context-hub check-deprecation [OPTIONS] SYMBOL
 ```shell
 # Set the hub up for your coding agent, then keep it current
 pipecat context-hub install
-pipecat context-hub refresh
+pipecat context-hub refresh --framework-version latest
 
 # Is this symbol still the right one?
 pipecat context-hub check-deprecation PipelineTask
@@ -89289,20 +89304,23 @@ Every tool runs two ways: as a one-shot CLI command and as an MCP server. Use th
 
 ## Setup
 
-The hub is published to PyPI as `pipecat-ai-context-hub`. Co-install it with the Pipecat CLI, then let it configure your coding agent and build the index in one step:
+The hub ships with the Pipecat CLI, so installing the CLI is the whole install:
 
 ```bash
-uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
+uv tool install "pipecat-ai[cli]"
+```
+
+If you scaffold with [`pipecat init`](/api-reference/cli/init), setup is already done — it registers the MCP server with the coding agents it finds and offers to build the index. Otherwise, do both in one step:
+
+```bash
 pipecat context-hub install
 ```
 
-`install` registers the MCP server with each coding agent it finds, echoing each command it runs, then builds the index — a few minutes the first time, since it downloads local embedding models. Every hub command is then available as `pipecat context-hub <command>`; see the [`pipecat context-hub` reference](/api-reference/cli/context-hub) for the full flag surface.
+`install` registers the MCP server with each coding agent CLI it finds, echoing each command it runs, then builds the index. Editors configured by hand — Cursor, VS Code, Zed — get the config block printed for you to paste instead; `install` exits `3` to say so, where `0` means a client was configured.
 
-<Warning>
-  `--with` replaces the tool environment rather than adding to it. If you also
-  use `pipecat cloud`, name both plugins: `uv tool install "pipecat-ai[cli]"
-  --with pipecatcloud --with pipecat-ai-context-hub`.
-</Warning>
+The first build takes upwards of three minutes and about 900 MB of disk: it clones the indexed repositories, downloads local embedding models, and embeds roughly 17,000 records. Later refreshes skip unchanged sources, so they usually take one to two minutes.
+
+Every hub command is available as `pipecat context-hub <command>`; see the [`pipecat context-hub` reference](/api-reference/cli/context-hub) for the full flag surface.
 
 If the index gets corrupted, force a rebuild:
 
@@ -89310,37 +89328,35 @@ If the index gets corrupted, force a rebuild:
 pipecat context-hub refresh --force
 ```
 
-If your project targets an older Pipecat version, pin the hub to it so results match what you're running:
+By default `refresh` indexes framework source from `main`, which runs ahead of any release. Pin it so results match the version your project actually runs — `latest` for the newest release tag, or an exact tag when you target an older one:
 
 ```bash
-pipecat context-hub refresh --framework-version v0.0.96
+pipecat context-hub refresh --framework-version latest
+pipecat context-hub refresh --framework-version v1.7.0
 ```
+
+<Note>
+  `--framework-version latest` needs `pipecat-ai-context-hub` 0.5.3 or newer,
+  the floor the `cli` extra pins. Earlier versions reject the value.
+</Note>
 
 ### Without the Pipecat CLI
 
 The hub runs standalone too. [`uvx`](https://docs.astral.sh/uv/), uv's one-shot runner, fetches and runs it on demand with nothing installed:
 
 ```bash
-uvx pipecat-ai-context-hub refresh   # build local index (~2 min first run)
+uvx pipecat-ai-context-hub refresh   # build local index
 ```
 
 Every command on this page works either way — `pipecat context-hub refresh` and `uvx pipecat-ai-context-hub refresh` are the same command.
 
 <Tip>
   To install it once instead of fetching on demand, run `uv tool install
-  pipecat-ai-context-hub`. This puts the command on your `PATH`, so you drop the
-  `uvx` prefix and call it directly, using the shorter `pipecat-context-hub`
-  name.
+  pipecat-ai-context-hub`. This puts the command on your `PATH` under the
+  shorter `pipecat-context-hub` name, so you drop the `uvx` prefix. The index
+  lives in one place per machine, so a standalone install and the CLI's bundled
+  copy share it rather than each building their own.
 </Tip>
-
-### Which install to choose
-
-The two installs expose different things, because a command is only visible inside the environment its package was installed into:
-
-- **Co-installed with the CLI** (`--with`) gives you `pipecat context-hub`, but does not put `pipecat-context-hub` on your `PATH`.
-- **Installed on its own** (`uv tool install pipecat-ai-context-hub`) gives you `pipecat-context-hub` on your `PATH`, but not `pipecat context-hub`.
-
-Doing both works and gives you both names, at the cost of a second copy on disk — the hub's retrieval stack is around 1 GB, and the two environments share very little. Pick one unless you have a reason not to.
 
 ## Custom sources
 

--- a/pipecat/get-started/build-your-next-bot.mdx
+++ b/pipecat/get-started/build-your-next-bot.mdx
@@ -40,16 +40,17 @@ pipecat init
 
 AI coding tools like Claude Code and Codex write your agent code. The agent follows the `AGENTS.md` guide that `init` wrote, so it uses Pipecat conventions, scaffolds the app for you, and verifies its own work. This path also writes `GETTING_STARTED.md`, a short guide to driving the agent well.
 
-### Add the Pipecat Context Hub
+### The Pipecat Context Hub
 
-The Context Hub indexes Pipecat docs, examples, and API source into a local database, so your agent queries live context instead of stale training data. Co-install it with the CLI, then let it set itself up:
+The Context Hub indexes Pipecat docs, examples, and API source into a local database, so your agent queries live context instead of stale training data. It ships with the CLI, and `init` sets it up for you: it registers the MCP server with the coding agents it finds, then offers to build the index.
+
+The build takes upwards of three minutes and about 900 MB of disk, so `init` asks rather than assuming. If you skipped it, run:
 
 ```bash
-uv tool install "pipecat-ai[cli]" --with pipecat-ai-context-hub
-pipecat context-hub install
+pipecat context-hub refresh
 ```
 
-`install` registers the MCP server with each coding agent it finds and builds the index — a few minutes the first time, since it downloads local models. MCP servers load at session start, so do this before opening your coding session.
+Do it before opening your coding session — MCP servers load at session start, and the server won't start against an empty index.
 
 <Card
   title="Pipecat Context Hub reference"

--- a/pipecat/get-started/build-your-next-bot.mdx
+++ b/pipecat/get-started/build-your-next-bot.mdx
@@ -50,6 +50,8 @@ The build takes upwards of three minutes and about 900 MB of disk, so `init` ask
 pipecat context-hub refresh
 ```
 
+If `init` found no coding agent CLI to register with — the case for editors configured by hand, like Cursor, VS Code, and Zed — run `pipecat context-hub install` instead, which prints the config block to paste and builds the index.
+
 Do it before opening your coding session — MCP servers load at session start, and the server won't start against an empty index.
 
 <Card

--- a/pipecat/get-started/quickstart.mdx
+++ b/pipecat/get-started/quickstart.mdx
@@ -74,11 +74,10 @@ cd pipecat-quickstart
 ```
 
 <Tip>
-  Planning to build with a coding agent? Co-install the [Pipecat Context
-  Hub](/api-reference/context-hub) — `uv tool install "pipecat-ai[cli]" --with
-  pipecat-ai-context-hub` — so your agent queries current Pipecat APIs instead
-  of its training data. It's a larger download, so skip it if you just want the
-  quickstart running.
+  Planning to build with a coding agent? Set up the [Pipecat Context
+  Hub](/api-reference/context-hub) with `pipecat context-hub install`, so your
+  agent queries current Pipecat APIs instead of its training data. It ships with
+  the CLI and installs when running `pipecat init`.
 </Tip>
 
 2. Configure your API keys

--- a/pipecat/get-started/quickstart.mdx
+++ b/pipecat/get-started/quickstart.mdx
@@ -77,7 +77,9 @@ cd pipecat-quickstart
   Planning to build with a coding agent? Set up the [Pipecat Context
   Hub](/api-reference/context-hub) with `pipecat context-hub install`, so your
   agent queries current Pipecat APIs instead of its training data. It ships with
-  the CLI and installs when running `pipecat init`.
+  the CLI, so there's nothing extra to install — but `pipecat init quickstart`
+  deliberately skips the setup to stay a short path to a running bot, so run
+  `install` yourself. Building its index takes a few minutes and about 900 MB.
 </Tip>
 
 2. Configure your API keys


### PR DESCRIPTION
The Context Hub now ships inside `pipecat-ai[cli]`, so `uv tool install "pipecat-ai[cli]"` is the whole install. These pages still taught a `--with` co-install, weighed two install paths against each other, and warned that `--with` replaces the tool environment — a choice that no longer exists.

Depends on [pipecat-ai/pipecat#5122](https://github.com/pipecat-ai/pipecat/pull/5122); land after that releases.

## What changed

| Page | |
|---|---|
| `api-reference/context-hub.mdx` | Setup is the CLI install. Removed the `--with` warning and the whole "Which install to choose" section; kept the `uvx` path for using the hub without the CLI |
| `api-reference/cli/context-hub.mdx` | `## Installation` down to a line. Added `install`'s exit codes and that re-running converges rather than skipping |
| `api-reference/cli/overview.mdx` | `context-hub` moves from "(requires `pipecat-ai-context-hub`)" to "(built in)"; the `--with` example reverts to `pipecatcloud` only |
| `api-reference/cli/init.mdx` | New "Context Hub setup" section, plus the `--context-hub/--no-context-hub` flag |
| `pipecat/get-started/build-your-next-bot.mdx` | "Add the Context Hub" becomes "The Context Hub" — `init` does it for you |
| `pipecat/get-started/quickstart.mdx` | Drops the co-install; says why `quickstart` doesn't stop to ask |

## Two additions beyond the rename

**`pipecat init` performs the setup**, and no page said so. It registers the MCP server with the coding agent CLIs it finds and offers to build the index. That is the largest user-visible change in the release, so `init.mdx` gains a section and the getting-started pages stop instructing people to do it by hand.

**`install`'s exit codes are documented**, including `3`. It is the only way a caller distinguishes "configured a client" from "printed the config for you to paste" — both print, and neither is an error. Cursor, VS Code, and Zed always take the second path.

## Corrected figures

The old text said "~2 min first run" in one place and "allow several minutes" in another, and no page mentioned the disk cost.

Measured cold: **17,359 records, 922 MB**, in 2m46s and 3m48s across two runs on the same machine — both with a warm model cache, so a genuine first run also pays a ~186 MB model download. A later refresh with one source changed took **77s**.

So the first build is stated as a floor — **upwards of three minutes and about 900 MB of disk** — rather than a target. The total is dominated by embedding ~17k records on the CPU, so it tracks single-core speed; a point estimate would be wrong for most readers. This matches the `3+ minutes` the CLI prompt shows. Refresh is documented separately at one to two minutes, since it re-ingests only sources whose contents moved.

## Also corrected

`context-hub.mdx` claimed a standalone install plus the CLI's copy costs "a second copy on disk — the two environments share very little." They share the **index**, which is the ~900 MB part; only the package duplicates.

## Checks

`mint` isn't installed locally, so internal links were verified by hand — every target exists. Worth a `mint broken-links` run before merge.
