### PR TITLE
Add Noveum Trace to Analytics & Monitoring integrations

### DIFF
--- a/api-reference/server/services/analytics/noveum-trace.mdx
+++ b/api-reference/server/services/analytics/noveum-trace.mdx
@@ -1,0 +1,99 @@
+---
+title: "Noveum Trace"
+description: "Community-maintained observability integration that maps Pipecat pipeline events into Noveum traces and spans"
+---
+
+import { CommunityMaintained } from "/snippets/community-maintained.mdx";
+
+<CommunityMaintained
+  maintainer="Noveum"
+  maintainerUrl="https://github.com/Noveum"
+  repo="https://github.com/Noveum/noveum-trace"
+/>
+
+## Overview
+
+`NoveumPipecatTracer` is an observability integration that maps Pipecat
+pipeline events into [Noveum](https://noveum.ai) traces and spans —
+conversation turns, STT, LLM, TTS, tool/function calls, metrics, errors, and
+optional audio capture. Traces are viewable in the Noveum dashboard for
+debugging, analytics, and evaluation of voice agents.
+
+<CardGroup cols={2}>
+  <Card
+    title="Integration Docs"
+    icon="book"
+    href="https://noveum.ai/en/docs/integration-examples/pipecat/overview"
+  >
+    Noveum Trace documentation for the Pipecat integration
+  </Card>
+  <Card
+    title="Source Repository"
+    icon="github"
+    href="https://github.com/Noveum/noveum-trace"
+  >
+    Source code, examples, and issues for the Noveum Trace SDK
+  </Card>
+  <Card
+    title="PyPI Package"
+    icon="cube"
+    href="https://pypi.org/project/noveum-trace/"
+  >
+    The `noveum-trace` package on PyPI
+  </Card>
+  <Card title="Noveum Platform" icon="chart-line" href="https://noveum.ai">
+    AI observability and evaluation platform for viewing traces
+  </Card>
+</CardGroup>
+
+## Installation
+
+This is a community-maintained package distributed separately from `pipecat-ai`:
+
+```bash
+uv add "noveum-trace[pipecat]"
+```
+
+## Prerequisites
+
+You need a Noveum account and API key. Credentials are configured via
+`noveum_trace.init()` — the tracer itself does not accept `api_key` or
+`project` arguments. Set your API key in the `NOVEUM_API_KEY` environment
+variable or pass it to `init()`.
+
+## Usage
+
+Initialize Noveum Trace, then attach the tracer to your pipeline and task
+using the two-call API:
+
+```python
+import os
+
+import noveum_trace
+from noveum_trace.integrations.pipecat import NoveumPipecatTracer
+
+noveum_trace.init(
+    project="my-voice-agent",
+    api_key=os.environ["NOVEUM_API_KEY"],
+)
+
+tracer = NoveumPipecatTracer(record_audio=True)
+
+pipeline = tracer.observe_pipeline(Pipeline([...]))
+task = await tracer.register_task_handlers(task, transport=transport)
+```
+
+Once attached, conversation turns and per-service spans are exported to your
+Noveum project as the pipeline runs.
+
+<Note>
+  Audio and transcript capture are configurable: `record_audio` controls audio
+  upload and `capture_text` controls transcript/text capture. Review these
+  settings before using the integration with sensitive data.
+</Note>
+
+## Compatibility
+
+Requires `pipecat-ai >= 0.0.108` and Python 3.11+. See the
+[source repository](https://github.com/Noveum/noveum-trace) for the latest
+tested versions and changelog.

--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -19,6 +19,7 @@ Analytics services help you better understand how your service operates.
 | ----------------------------------------------------------------------- | ---------------------------------------------- | ---------- |
 | [Finchvox](/api-reference/server/services/analytics/finchvox)           | `uv add finchvox`                              | Community  |
 | [Future AGI](/api-reference/server/services/analytics/future-agi)       | `uv add traceAI-pipecat`                       | Community  |
+| [Noveum Trace](/api-reference/server/services/analytics/noveum-trace)   | `uv add "noveum-trace[pipecat]"`               | Community  |
 | [OpenInference](/api-reference/server/services/analytics/openinference) | `uv add openinference-instrumentation-pipecat` | Community  |
 | [Roark](/api-reference/server/services/analytics/roark)                 | `uv add pipecat-roark`                         | Community  |
 | [Sentry](/api-reference/server/services/analytics/sentry)               | `uv add "pipecat-ai[sentry]"`                  | Pipecat    |

--- a/docs.json
+++ b/docs.json
@@ -526,6 +526,7 @@
                     "pages": [
                       "api-reference/server/services/analytics/finchvox",
                       "api-reference/server/services/analytics/future-agi",
+                      "api-reference/server/services/analytics/noveum-trace",
                       "api-reference/server/services/analytics/openinference",
                       "api-reference/server/services/analytics/roark",
                       "api-reference/server/services/analytics/sentry"
@@ -1754,6 +1755,10 @@
     {
       "source": "/server/services/analytics/future-agi",
       "destination": "/api-reference/server/services/analytics/future-agi"
+    },
+    {
+      "source": "/server/services/analytics/noveum-trace",
+      "destination": "/api-reference/server/services/analytics/noveum-trace"
     },
     {
       "source": "/server/services/analytics/openinference",


### PR DESCRIPTION
## Summary

Adds Noveum Trace to the Analytics & Monitoring integrations list. Noveum Trace is a
community-maintained observability integration for Pipecat voice agents. It maps Pipecat
pipeline events into Noveum traces and spans — conversation turns, STT, LLM, TTS,
tool/function calls, metrics, errors, and optional audio capture.

## Files changed

- `api-reference/server/services/analytics/noveum-trace.mdx` — new service page (mirrors the existing community analytics pages)
- `api-reference/server/services/supported-services.mdx` — new row in the Analytics & Monitoring table
- `docs.json` — nav entry + redirect for the new page

## Install

```bash
uv add "noveum-trace[pipecat]"
```

## Notes

- Maintained by Noveum (community integration).
- Credentials are configured via `noveum_trace.init()`.
- Audio/transcript capture is configurable (`record_audio` / `capture_text`); review before use with sensitive data.
- Compatible with `pipecat-ai >= 0.0.108` (Python 3.11+), released `noveum-trace` 1.5.21.
- Ran `npx prettier --write` on the changed files.
- Demo video per COMMUNITY_INTEGRATIONS.md to follow shortly in a comment.

## Links

- Docs: https://noveum.ai/en/docs/integration-examples/pipecat/overview
- Repo: https://github.com/Noveum/noveum-trace
- PyPI: https://pypi.org/project/noveum-trace/

