### PR TITLE
docs: qualify the 10 second cold start number

### DIFF
--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -144,9 +144,25 @@ Pipecat Cloud aims to mitigate cold starts as much as possible through [auto-sca
 
 <AccordionGroup>
 <Accordion title="How long does a cold start take?">
-The exact duration of a cold start depends on multiple factors, such as the size of your agent image and the complexity of your agent. In general, cold starts take around 10 seconds. Once you have a running instance of a deployed image, new sessions start immediately with no cold start delay.
+Around 10 seconds is a best case: a small agent image with an agent that finishes its setup work fast. Treat it as a floor, not a promise.
+
+Two things move the number a lot:
+
+- **Image size.** The image has to be pulled and started before your agent runs. A large image can push a cold start to a minute or more.
+- **Startup work in your agent.** Anything your agent does before it can take a session adds to the wait. Loading models, downloading weights, and opening connections all count.
+
+Once you have a running instance of a deployed image, new sessions start immediately with no cold start delay.
 
 For developers, especially during test and development, using scale-to-zero with cold starts is a good place to start as it saves money. Once you understand your utilization pattern, you can build a strategy around optimizing start times by maintaining warm agent instances.
+
+</Accordion>
+<Accordion title="My cold start takes much longer than 10 seconds. Why?">
+A cold start that runs far longer than 10 seconds, say 30 seconds or a minute or more, usually comes down to your image or your agent's startup code. Things to check:
+
+- **How big is your image?** Every megabyte has to be pulled before your agent can run. Drop what the bot does not need at runtime, and use multi-stage builds to keep build tools out of the final image.
+- **What runs at import time in `bot.py`?** Everything at the module level runs before the instance can accept a session. So an import that loads a model, or a model you create outside your `bot()` function, is part of the cold start. It is not only the code inside `bot()` that costs you time.
+- **Are you fetching model files at runtime?** Bake model and VAD weights into the image at build time. Then the instance starts with the files already on disk instead of downloading them on the first call.
+- **Do you need instant starts?** Keep at least one warm instance with `min-agents`, and plan a waiting experience (a hold message on phone calls, a "connecting" state in web apps) for the times a cold start still happens.
 
 </Accordion>
 <Accordion title="Mitigation strategies">
@@ -267,7 +283,7 @@ Most surprise charges come from **reserved session minutes**: a warm instance bi
 
 ### Scale-to-zero in development
 
-If you don't need instant start times while testing, set `min-agents` to 0 to remove all reserved charges. The first call after an idle period takes a ~10-second [cold start](#cold-starts); subsequent calls are instant while an instance stays warm.
+If you don't need instant start times while testing, set `min-agents` to 0 to remove all reserved charges. The first call after an idle period pays a [cold start](#cold-starts): around 10 seconds at best, and longer for a large image or an agent that does heavy setup work. Later calls are instant while an instance stays warm.
 
 ```shell
 pipecat cloud deploy [agent-name] --min-agents 0

--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -149,7 +149,7 @@ Around 10 seconds is a best case: a small agent image with an agent that finishe
 A cold start that runs far longer than 10 seconds, say 30 seconds or a minute or more, usually comes down to your image or your agent's startup code. Things to check:
 
 - **How big is your image?** Every megabyte has to be pulled before your agent can run. Drop what the bot does not need at runtime, and use multi-stage builds to keep build tools out of the final image.
-- **What runs at import time in `bot.py`?** Everything at the module level runs before the instance can accept a session. So an import that loads a model, or a model you create outside your `bot()` function, is part of the cold start. It is not only the code inside `bot()` that costs you time.
+- **What runs at import time in `bot.py`?** Everything at the module level runs before the instance can accept a session. So an import that takes time to load is part of the cold start. It is not only the code inside `bot()` that costs you time.
 - **Are you fetching model files at runtime?** Bake model and VAD weights into the image at build time. Then the instance starts with the files already on disk instead of downloading them on the first call.
 - **Do you need instant starts?** Keep at least one warm instance with `min-agents`, and plan a waiting experience (a hold message on phone calls, a "connecting" state in web apps) for the times a cold start still happens.
 

--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -146,17 +146,6 @@ Pipecat Cloud aims to mitigate cold starts as much as possible through [auto-sca
 <Accordion title="How long does a cold start take?">
 Around 10 seconds is a best case: a small agent image with an agent that finishes its setup work fast. Treat it as a floor, not a promise.
 
-Two things move the number a lot:
-
-- **Image size.** The image has to be pulled and started before your agent runs. A large image can push a cold start to a minute or more.
-- **Startup work in your agent.** Anything your agent does before it can take a session adds to the wait. Loading models, downloading weights, and opening connections all count.
-
-Once you have a running instance of a deployed image, new sessions start immediately with no cold start delay.
-
-For developers, especially during test and development, using scale-to-zero with cold starts is a good place to start as it saves money. Once you understand your utilization pattern, you can build a strategy around optimizing start times by maintaining warm agent instances.
-
-</Accordion>
-<Accordion title="My cold start takes much longer than 10 seconds. Why?">
 A cold start that runs far longer than 10 seconds, say 30 seconds or a minute or more, usually comes down to your image or your agent's startup code. Things to check:
 
 - **How big is your image?** Every megabyte has to be pulled before your agent can run. Drop what the bot does not need at runtime, and use multi-stage builds to keep build tools out of the final image.
@@ -164,7 +153,11 @@ A cold start that runs far longer than 10 seconds, say 30 seconds or a minute or
 - **Are you fetching model files at runtime?** Bake model and VAD weights into the image at build time. Then the instance starts with the files already on disk instead of downloading them on the first call.
 - **Do you need instant starts?** Keep at least one warm instance with `min-agents`, and plan a waiting experience (a hold message on phone calls, a "connecting" state in web apps) for the times a cold start still happens.
 
+Once you have a running instance of a deployed image, new sessions start immediately with no cold start delay.
+
+For developers, especially during test and development, using scale-to-zero with cold starts is a good place to start as it saves money. Once you understand your utilization pattern, you can build a strategy around optimizing start times by maintaining warm agent instances.
 </Accordion>
+
 <Accordion title="Mitigation strategies">
 To avoid cold starts, you can:
 

--- a/pipecat-cloud/guides/capacity-planning.mdx
+++ b/pipecat-cloud/guides/capacity-planning.mdx
@@ -59,7 +59,6 @@ To determine the optimal reserved instance count for your deployment, consider:
 1. **Peak Concurrent Sessions**: How many simultaneous sessions do you expect during peak periods?
 
 2. **Growth Rate**: How quickly do new sessions start during peak periods?
-
    - If new sessions start faster than the ~30 second warm-up time for auto-scaled agent instances, you'll need more reserved capacity
 
 3. **Cold Start Tolerance**: How important is immediate response for your use case?
@@ -78,14 +77,6 @@ To determine the optimal reserved instance count for your deployment, consider:
 - **Time-Based Scaling**: Consider modifying your reserved count for known high-traffic periods
 - **Cap session duration**: Use [`--max-session-duration`](/api-reference/cli/cloud/deploy#param-max-session-duration) as a safety net against runaway sessions. If your application's calls are meant to be short, setting a tight cap (e.g. 120s for a 60s use case) prevents a buggy bot from racking up hours of charges.
 - **Monitoring**: Regularly review your warm capacity utilization to optimize your configuration
-
-<Info>
-  Around 10 seconds is a best case cold start: a small agent image with an agent
-  that starts up fast. Image size and the setup work your agent does before it
-  can take a session both push that number up, to a minute or more for a large
-  image. See [cold starts](/pipecat-cloud/fundamentals/scaling#cold-starts) for
-  what affects it and how to bring it down.
-</Info>
 
 ## Calculating Optimal Reserved Agents
 

--- a/pipecat-cloud/guides/capacity-planning.mdx
+++ b/pipecat-cloud/guides/capacity-planning.mdx
@@ -77,6 +77,9 @@ To determine the optimal reserved instance count for your deployment, consider:
 - **Time-Based Scaling**: Consider modifying your reserved count for known high-traffic periods
 - **Cap session duration**: Use [`--max-session-duration`](/api-reference/cli/cloud/deploy#param-max-session-duration) as a safety net against runaway sessions. If your application's calls are meant to be short, setting a tight cap (e.g. 120s for a 60s use case) prevents a buggy bot from racking up hours of charges.
 - **Monitoring**: Regularly review your warm capacity utilization to optimize your configuration
+<Info>
+  Cold start times vary widely. See [Cold-starts](../fundamentals/scaling#cold-starts) for best-case timing and what can push it to a minute or more.
+</Info>
 
 ## Calculating Optimal Reserved Agents
 

--- a/pipecat-cloud/guides/capacity-planning.mdx
+++ b/pipecat-cloud/guides/capacity-planning.mdx
@@ -59,6 +59,7 @@ To determine the optimal reserved instance count for your deployment, consider:
 1. **Peak Concurrent Sessions**: How many simultaneous sessions do you expect during peak periods?
 
 2. **Growth Rate**: How quickly do new sessions start during peak periods?
+
    - If new sessions start faster than the ~30 second warm-up time for auto-scaled agent instances, you'll need more reserved capacity
 
 3. **Cold Start Tolerance**: How important is immediate response for your use case?
@@ -78,7 +79,13 @@ To determine the optimal reserved instance count for your deployment, consider:
 - **Cap session duration**: Use [`--max-session-duration`](/api-reference/cli/cloud/deploy#param-max-session-duration) as a safety net against runaway sessions. If your application's calls are meant to be short, setting a tight cap (e.g. 120s for a 60s use case) prevents a buggy bot from racking up hours of charges.
 - **Monitoring**: Regularly review your warm capacity utilization to optimize your configuration
 
-<Info>A cold start typically takes around 10 seconds.</Info>
+<Info>
+  Around 10 seconds is a best case cold start: a small agent image with an agent
+  that starts up fast. Image size and the setup work your agent does before it
+  can take a session both push that number up, to a minute or more for a large
+  image. See [cold starts](/pipecat-cloud/fundamentals/scaling#cold-starts) for
+  what affects it and how to bring it down.
+</Info>
 
 ## Calculating Optimal Reserved Agents
 


### PR DESCRIPTION
## Problem

The docs state a flat "around 10 seconds" for a Pipecat Cloud cold start. A repo-wide grep found the claim in exactly three places, all in `pipecat-cloud/`:

1. `pipecat-cloud/fundamentals/scaling.mdx` (the `#cold-starts` accordion, "How long does a cold start take?")
2. `pipecat-cloud/fundamentals/scaling.mdx` (the `#controlling-costs` section, "a ~10-second cold start")
3. `pipecat-cloud/guides/capacity-planning.mdx` (a bare `<Info>` line under cost-efficient scaling strategies)

Found while working support ticket T-3095. A customer running a 1.5 GB image measured a 65 second cold start and had planned their user experience around the 10 second number. The scaling page does mention elsewhere that duration "depends on multiple factors", but the headline number is what people plan against, and one of the three spots had no qualifier at all.

## Changes

* 10 seconds is now framed as a best case (small image, agent that starts up fast) rather than a typical value, and the docs say plainly that image size and agent setup work can push it to a minute or more.
* New accordion on the scaling page titled "My cold start takes much longer than 10 seconds. Why?" so the page is findable by the symptom. It gives four things a customer can act on:
  * Trim the image, use multi-stage builds.
  * Everything at the module level in `bot.py` runs before the instance can accept a session, so an import that loads a model, or a model created outside `bot()`, is part of the cold start. It is not only the code inside `bot()`.
  * Bake model and VAD weights into the image at build time instead of fetching them on the first call.
  * Keep a warm instance with `min-agents` and plan a waiting experience for the times a cold start still happens.
* The capacity planning callout now links to the cold starts section instead of dead-ending on a bare number.

## Deliberately not done

No replacement range like "30 to 50 seconds" is published. There is no instrumented measurement or SLO for bot start time to back a new authoritative number, so this PR qualifies the existing one and names the factors instead of inventing a spec.

No customer or ticket is named in the doc text.

## Notes

Prettier run on both files. Draft PR: not ready for review.
