### PR TITLE
Add Boson Higgs Realtime community integration

### DIFF
--- a/api-reference/server/services/s2s/boson.mdx
+++ b/api-reference/server/services/s2s/boson.mdx
@@ -1,0 +1,172 @@
+---
+title: "Boson Higgs Realtime"
+sidebarTitle: "Boson Higgs Realtime"
+description: "Real-time speech-to-speech service powered by Boson AI's Higgs Realtime API"
+---
+
+import { CommunityMaintained } from "/snippets/community-maintained.mdx";
+
+<CommunityMaintained
+  maintainer="Boson AI"
+  maintainerUrl="https://github.com/boson-ai"
+  repo="https://github.com/boson-ai/pipecat-boson"
+/>
+
+## Overview
+
+`BosonRealtimeLLMService` connects a Pipecat pipeline to Boson AI's Higgs
+Realtime API. It accepts live audio or text and streams audio or text responses
+without requiring separate STT, LLM, and TTS services.
+
+The community integration supports voice activity detection, interruption
+handling, user transcriptions, function calling, and text-only responses.
+
+## Installation
+
+Install the community-maintained package from PyPI:
+
+```bash
+uv add pipecat-boson
+```
+
+## Configuration
+
+Set your Boson API key and the Higgs Realtime endpoint in the server
+environment:
+
+```bash
+export BOSON_API_KEY=bai-xxxx
+export BOSON_REALTIME_URL=wss://api.boson.ai/v1/realtime/
+export BOSON_REALTIME_MODEL=higgs-realtime
+```
+
+Create the service and add it to your Pipecat pipeline in place of separate
+STT, LLM, and TTS services:
+
+```python
+import os
+
+from pipecat_boson.realtime import BosonRealtimeLLMService
+
+
+llm = BosonRealtimeLLMService(
+    url=os.environ["BOSON_REALTIME_URL"],
+    api_key=os.environ["BOSON_API_KEY"],
+    model=os.getenv("BOSON_REALTIME_MODEL", "higgs-realtime"),
+    voice="default",
+    instructions="You are a concise and helpful voice assistant.",
+)
+```
+
+### Common parameters
+
+<ParamField path="url" type="str" required>
+  Higgs Realtime WebSocket endpoint.
+</ParamField>
+
+<ParamField path="api_key" type="str" required>
+  Boson API key. It is required when using the hosted API.
+</ParamField>
+
+<ParamField path="model" type="str" default="higgs-realtime">
+  Higgs Realtime model ID.
+</ParamField>
+
+<ParamField path="voice" type="str" default="default">
+  Voice preset or voice ID used for audio responses.
+</ParamField>
+
+<ParamField path="instructions" type="str">
+  System instructions used to initialize the realtime session.
+</ParamField>
+
+<ParamField
+  path="output_modalities"
+  type="List[Literal['audio', 'text']]"
+  default="['audio']"
+>
+  Response modality. Choose exactly one of audio or text.
+</ParamField>
+
+<ParamField path="turn_detection" type="Dict" default="server_vad">
+  OpenAI-compatible server or semantic VAD configuration.
+</ParamField>
+
+<ParamField path="input_audio_transcription" type="Dict">
+  Optional input transcription configuration. A non-empty model enables user
+  transcript frames.
+</ParamField>
+
+<ParamField path="tools" type="Any">
+  Python functions or Pipecat-compatible tool definitions available to the
+  model.
+</ParamField>
+
+See the integration README for the complete constructor and session
+configuration reference.
+
+### Minimal pipeline
+
+The following example assumes `transport` is an existing Pipecat audio
+transport:
+
+```python
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+)
+
+
+context = LLMContext()
+user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+    context,
+    realtime_service_mode=True,
+)
+
+pipeline = Pipeline(
+    [
+        transport.input(),
+        user_aggregator,
+        llm,
+        transport.output(),
+        assistant_aggregator,
+    ]
+)
+```
+
+## Compatibility
+
+The current package supports `pipecat-ai>=1.4.0,<2` and is tested with Pipecat
+v1.6.0. Refer to the integration repository for the latest compatibility
+information.
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card
+    title="Integration guide"
+    icon="github"
+    href="https://github.com/boson-ai/pipecat-boson#readme"
+  >
+    Setup instructions, complete examples, configuration options, and
+    troubleshooting
+  </Card>
+  <Card
+    title="PyPI package"
+    icon="cube"
+    href="https://pypi.org/project/pipecat-boson/"
+  >
+    Package releases and installation metadata
+  </Card>
+  <Card title="Boson documentation" icon="book" href="https://docs.boson.ai/">
+    Higgs Realtime API documentation
+  </Card>
+  <Card
+    title="Boson API keys"
+    icon="key"
+    href="https://docs.boson.ai/authentication"
+  >
+    Create and configure a Boson API key
+  </Card>
+</CardGroup>

--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -118,6 +118,7 @@ Realtime LLMs (speech-to-speech) are multi-modal models that take in audio, vide
 | Service                                                                        | Setup                                 | Maintainer |
 | ------------------------------------------------------------------------------ | ------------------------------------- | ---------- |
 | [AWS Nova Sonic](/api-reference/server/services/s2s/aws)                       | `uv add "pipecat-ai[aws-nova-sonic]"` | Pipecat    |
+| [Boson Higgs Realtime](/api-reference/server/services/s2s/boson)               | `uv add pipecat-boson`                | Community  |
 | [Gemini Live](/api-reference/server/services/s2s/gemini-live)                  | `uv add "pipecat-ai[google]"`         | Pipecat    |
 | [Gemini Live Vertex AI](/api-reference/server/services/s2s/gemini-live-vertex) | `uv add "pipecat-ai[google]"`         | Pipecat    |
 | [Grok Voice Agent](/api-reference/server/services/s2s/grok)                    | `uv add "pipecat-ai[grok]"`           | Pipecat    |

--- a/docs.json
+++ b/docs.json
@@ -493,6 +493,7 @@
                     "group": "Realtime LLM",
                     "pages": [
                       "api-reference/server/services/s2s/aws",
+                      "api-reference/server/services/s2s/boson",
                       "api-reference/server/services/s2s/gemini-live",
                       "api-reference/server/services/s2s/gemini-live-vertex",
                       "api-reference/server/services/s2s/grok",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -29743,6 +29743,7 @@ Realtime LLMs (speech-to-speech) are multi-modal models that take in audio, vide
 | Service                                                                        | Setup                                 | Maintainer |
 | ------------------------------------------------------------------------------ | ------------------------------------- | ---------- |
 | [AWS Nova Sonic](/api-reference/server/services/s2s/aws)                       | `uv add "pipecat-ai[aws-nova-sonic]"` | Pipecat    |
+| [Boson Higgs Realtime](/api-reference/server/services/s2s/boson)               | `uv add pipecat-boson`                | Community  |
 | [Gemini Live](/api-reference/server/services/s2s/gemini-live)                  | `uv add "pipecat-ai[google]"`         | Pipecat    |
 | [Gemini Live Vertex AI](/api-reference/server/services/s2s/gemini-live-vertex) | `uv add "pipecat-ai[google]"`         | Pipecat    |
 | [Grok Voice Agent](/api-reference/server/services/s2s/grok)                    | `uv add "pipecat-ai[grok]"`           | Pipecat    |
@@ -57175,6 +57176,170 @@ llm = AWSNovaSonicLLMService(
 - **Connection resilience**: If a connection error occurs while the service wants to stay connected, it automatically resets the conversation and reconnects.
 - **System instruction precedence**: The `system_instruction` from service settings takes precedence over an initial system message in the LLM context. A warning is logged when both are set. Tools provided in the LLM context take precedence over those provided at initialization time.
 - **Audio format**: Uses LPCM (Linear PCM) audio format for both input and output. Input defaults to 16kHz and output defaults to 24kHz.
+
+# Boson Higgs Realtime
+Source: https://docs.pipecat.ai/api-reference/server/services/s2s/boson.md
+
+Real-time speech-to-speech service powered by Boson AI's Higgs Realtime API
+
+## Overview
+
+`BosonRealtimeLLMService` connects a Pipecat pipeline to Boson AI's Higgs
+Realtime API. It accepts live audio or text and streams audio or text responses
+without requiring separate STT, LLM, and TTS services.
+
+The community integration supports voice activity detection, interruption
+handling, user transcriptions, function calling, and text-only responses.
+
+## Installation
+
+Install the community-maintained package from PyPI:
+
+```bash
+uv add pipecat-boson
+```
+
+## Configuration
+
+Set your Boson API key and the Higgs Realtime endpoint in the server
+environment:
+
+```bash
+export BOSON_API_KEY=bai-xxxx
+export BOSON_REALTIME_URL=wss://api.boson.ai/v1/realtime/
+export BOSON_REALTIME_MODEL=higgs-realtime
+```
+
+Create the service and add it to your Pipecat pipeline in place of separate
+STT, LLM, and TTS services:
+
+```python
+import os
+
+from pipecat_boson.realtime import BosonRealtimeLLMService
+
+
+llm = BosonRealtimeLLMService(
+    url=os.environ["BOSON_REALTIME_URL"],
+    api_key=os.environ["BOSON_API_KEY"],
+    model=os.getenv("BOSON_REALTIME_MODEL", "higgs-realtime"),
+    voice="default",
+    instructions="You are a concise and helpful voice assistant.",
+)
+```
+
+### Common parameters
+
+<ParamField path="url" type="str" required>
+  Higgs Realtime WebSocket endpoint.
+</ParamField>
+
+<ParamField path="api_key" type="str" required>
+  Boson API key. It is required when using the hosted API.
+</ParamField>
+
+<ParamField path="model" type="str" default="higgs-realtime">
+  Higgs Realtime model ID.
+</ParamField>
+
+<ParamField path="voice" type="str" default="default">
+  Voice preset or voice ID used for audio responses.
+</ParamField>
+
+<ParamField path="instructions" type="str">
+  System instructions used to initialize the realtime session.
+</ParamField>
+
+<ParamField
+  path="output_modalities"
+  type="List[Literal['audio', 'text']]"
+  default="['audio']"
+>
+  Response modality. Choose exactly one of audio or text.
+</ParamField>
+
+<ParamField path="turn_detection" type="Dict" default="server_vad">
+  OpenAI-compatible server or semantic VAD configuration.
+</ParamField>
+
+<ParamField path="input_audio_transcription" type="Dict">
+  Optional input transcription configuration. A non-empty model enables user
+  transcript frames.
+</ParamField>
+
+<ParamField path="tools" type="Any">
+  Python functions or Pipecat-compatible tool definitions available to the
+  model.
+</ParamField>
+
+See the integration README for the complete constructor and session
+configuration reference.
+
+### Minimal pipeline
+
+The following example assumes `transport` is an existing Pipecat audio
+transport:
+
+```python
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+)
+
+
+context = LLMContext()
+user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
+    context,
+    realtime_service_mode=True,
+)
+
+pipeline = Pipeline(
+    [
+        transport.input(),
+        user_aggregator,
+        llm,
+        transport.output(),
+        assistant_aggregator,
+    ]
+)
+```
+
+## Compatibility
+
+The current package supports `pipecat-ai>=1.4.0,<2` and is tested with Pipecat
+v1.6.0. Refer to the integration repository for the latest compatibility
+information.
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card
+    title="Integration guide"
+    icon="github"
+    href="https://github.com/boson-ai/pipecat-boson#readme"
+  >
+    Setup instructions, complete examples, configuration options, and
+    troubleshooting
+  </Card>
+  <Card
+    title="PyPI package"
+    icon="cube"
+    href="https://pypi.org/project/pipecat-boson/"
+  >
+    Package releases and installation metadata
+  </Card>
+  <Card title="Boson documentation" icon="book" href="https://docs.boson.ai/">
+    Higgs Realtime API documentation
+  </Card>
+  <Card
+    title="Boson API keys"
+    icon="key"
+    href="https://docs.boson.ai/authentication"
+  >
+    Create and configure a Boson API key
+  </Card>
+</CardGroup>
 
 # Gemini Live
 Source: https://docs.pipecat.ai/api-reference/server/services/s2s/gemini-live.md

--- a/llms.txt
+++ b/llms.txt
@@ -430,6 +430,7 @@ LLM, transports, serializers), pipelines, frames, workers, and utilities.
 ##### Realtime LLM
 
 - [AWS Nova Sonic](https://docs.pipecat.ai/api-reference/server/services/s2s/aws.md): AWSNovaSonicLLMService provides real-time speech-to-speech (S2S) conversation with AWS's Nova Sonic model.
+- [Boson Higgs Realtime](https://docs.pipecat.ai/api-reference/server/services/s2s/boson.md): Real-time speech-to-speech service powered by Boson AI's Higgs Realtime API
 - [Gemini Live](https://docs.pipecat.ai/api-reference/server/services/s2s/gemini-live.md): GeminiLiveLLMService connects Pipecat to Google's Gemini Live API for real-time speech-to-speech multimodal conversation.
 - [Gemini Live Vertex AI](https://docs.pipecat.ai/api-reference/server/services/s2s/gemini-live-vertex.md): GeminiLiveVertexLLMService runs Gemini Live speech-to-speech conversation through Vertex AI with Google Cloud authentication.
 - [Grok Realtime](https://docs.pipecat.ai/api-reference/server/services/s2s/grok.md): GrokRealtimeLLMService provides real-time multimodal speech-to-speech conversation using xAI's Grok Realtime API.


### PR DESCRIPTION
Adds [Boson Higgs Realtime](https://www.boson.ai/) as a community-maintained speech-to-speech integration for Pipecat.

The [`pipecat-boson`](https://github.com/boson-ai/pipecat-boson) package provides `BosonRealtimeLLMService`, which connects Pipecat directly to the Higgs Realtime API without requiring separate STT, LLM, and TTS services. It supports realtime voice conversations, interruptions, user transcripts, and function calling.

- Repository: https://github.com/boson-ai/pipecat-boson
- PyPI: https://pypi.org/project/pipecat-boson/
- Maintainer: Boson AI
- Tested with Pipecat v1.6.0

This PR adds the Boson service page, lists it under Realtime LLM services, and registers the page in the docs navigation. The plugin repository README remains the source of truth for the full setup and configuration reference.

### Demo

https://drive.google.com/file/d/1y7NNRXdKCo_3oflv5ecdnzr_pjumFCb7/view

Happy to adjust anything to better match the docs conventions. Thanks!
