### PR TITLE
Gandr TTS: stable default URL, language count, copy fixes

### DIFF
--- a/api-reference/server/services/tts/gandr.mdx
+++ b/api-reference/server/services/tts/gandr.mdx
@@ -61,7 +61,7 @@ uv add pipecat-gandr
   Gandr API key (`gnd_…`). Raises `ValueError` if empty or whitespace.
 </ParamField>
 
-<ParamField path="url" type="str" default="wss://tts-west.gandr.ai/ws">
+<ParamField path="url" type="str" default="wss://tts.gandr.ai/ws">
   WebSocket endpoint. Leave as the default unless you have been given a
   different one.
 </ParamField>
@@ -104,8 +104,8 @@ Passed via `params=GandrTTSService.InputParams(...)`.
 | `voice_id`      | `str`   | `"gandr-mia"`  | A stock voice (see `STOCK_VOICES`) or a `gnd:` cloned-voice identifier.        |
 | `language`      | `str`   | `"en"`         | Bare two-letter code. See [Languages](#languages).                             |
 | `sample_rate`   | `int`   | `None`         | One of 8000, 16000, 22050, 24000. Takes priority over the constructor's value. |
-| `speed`         | `float` | `None`         | 0.6–1.5, pitch preserving.                                                     |
-| `volume`        | `float` | `None`         | 0.5–2.0, soft-ceiling mastered.                                                |
+| `speed`         | `float` | `None`         | 0.6-1.5, pitch preserving.                                                     |
+| `volume`        | `float` | `None`         | 0.5-2.0, soft-ceiling mastered.                                                |
 | `temperature`   | `float` | `None`         | Expression control. Omit to let the service choose.                            |
 | `cfg_weight`    | `float` | `None`         | Expression control. Omit to send nothing at all.                               |
 | `seed`          | `int`   | `None`         | Fixes the render for a reproducible result.                                    |
@@ -116,8 +116,8 @@ Stock voices: `gandr-mia`, `gandr-ava`, `gandr-jenny`, `gandr-dane`,
 
 ### Languages
 
-`language` takes a **bare two-letter code** — `en`, `es`, `fr`, `de`, `pt`,
-`ar`, `zh`, `ja`.
+`language` takes a **bare two-letter code**: 23 languages are supported.
+Examples: `en`, `es`, `fr`, `de`, `pt`, `ar`, `zh`, `ja`.
 
 <Warning>
   A region suffix such as `en-GB` or `zh-CN` is not recognised and the request
@@ -151,13 +151,13 @@ the connection and reopens it, rather than draining audio nobody is going to
 hear.
 
 Set `reconnect_on_interruption=False` to keep the connection instead and
-discard the interrupted render client-side — at the cost of the next turn
+discard the interrupted render client-side, at the cost of the next turn
 waiting for that render to finish.
 
 ## Notes
 
 <Note>
-  **The first turn on a fresh connection is slower** — roughly 700 ms while the
+  **The first turn on a fresh connection is slower**, roughly 700 ms while the
   session voice cache fills. Every turn after it is materially quicker, which
   is why the connection is held warm across turns. A benchmark that measures
   only turn one is measuring the cache filling rather than the engine.


### PR DESCRIPTION
Follow-up to the merged Gandr TTS page, three small fixes before it goes live with the next release.

1. The default url now points at the stable hostname (wss://tts.gandr.ai/ws), matching the OpenAPI contract and the package default. Both names resolve to the same service today, so this is a naming fix, not a behavior change.
2. Language support was under-stated: 23 languages are supported, and the listed codes are examples rather than the full set.
3. A few dashes replaced with plain punctuation for house style.