### PR TITLE
Add SonexLabs TTS community integration

### DIFF
--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -227,6 +227,7 @@ Text-to-Speech services receive text input and output audio streams or chunks.
 | [Simplismart](/api-reference/server/services/tts/simplismart)     | `uv add pipecat-simplismart`                                                  | Community  |
 | [SLNG](/api-reference/server/services/tts/slng)                   | `uv add pipecat-slng`                                                         | Community  |
 | [Smallest AI](/api-reference/server/services/tts/smallest)        | `uv add "pipecat-ai[smallest]"`                                               | Pipecat    |
+| [SonexLabs](/api-reference/server/services/tts/sonex)             | `uv add pipecat-sonex`                                                        | Community  |
 | [Soniox](/api-reference/server/services/tts/soniox)               | `uv add "pipecat-ai[soniox]"`                                                 | Pipecat    |
 | [Speechmatics](/api-reference/server/services/tts/speechmatics)   | `uv add "pipecat-ai[speechmatics]"`                                           | Pipecat    |
 | [Supertonic](/api-reference/server/services/tts/supertonic)       | `uv add pipecat-supertonic`                                                   | Community  |

--- a/api-reference/server/services/tts/sonex.mdx
+++ b/api-reference/server/services/tts/sonex.mdx
@@ -1,0 +1,98 @@
+---
+title: "SonexLabs Text-to-Speech"
+sidebarTitle: "SonexLabs"
+description: "SonexTTSService converts text to speech with SonexLabs' streaming TTS API."
+---
+
+import { CommunityMaintained } from "/snippets/community-maintained.mdx";
+
+<CommunityMaintained
+  maintainer="ayushi-agarwall"
+  maintainerUrl="https://github.com/ayushi-agarwall"
+  repo="https://github.com/sonexlabs/pipecat-sonex"
+/>
+
+## Overview
+
+`SonexTTSService` converts text into speech using [SonexLabs'](https://sonexlabs.com)
+streaming text-to-speech API. It streams audio over HTTP with connection
+keep-alive for low time-to-first-audio, and supports multiple voices and
+languages, with automatic language detection when none is specified.
+
+<CardGroup cols={2}>
+  <Card
+    title="Source Repository"
+    icon="github"
+    href="https://github.com/sonexlabs/pipecat-sonex"
+  >
+    Source code, examples, and issues for the SonexLabs integration
+  </Card>
+  <Card title="SonexLabs" icon="book" href="https://sonexlabs.com">
+    Learn more about SonexLabs' text-to-speech service
+  </Card>
+</CardGroup>
+
+## Installation
+
+This is a community-maintained package distributed separately from `pipecat-ai`:
+
+```bash
+uv add pipecat-sonex
+```
+
+## Prerequisites
+
+### SonexLabs Account Setup
+
+Before using the SonexLabs text-to-speech service, you need:
+
+1. **SonexLabs Account**: Sign up at [SonexLabs](https://sonexlabs.com)
+2. **API Key**: Generate an API key from your account dashboard
+3. **Voice Selection**: Pick a voice ID from your account's available voices
+
+### Required Environment Variables
+
+- `SONEX_API_KEY`: Your SonexLabs API key for authentication
+
+## Configuration
+
+<ParamField path="api_key" type="str" required>
+  SonexLabs API key.
+</ParamField>
+
+<ParamField path="voice" type="str" required>
+  Voice ID to use for synthesis.
+</ParamField>
+
+<ParamField path="language" type="str" default="None">
+  Optional language override. Leave unset to auto-detect from the input text.
+</ParamField>
+
+<ParamField path="settings" type="SonexTTSService.Settings" default="None">
+  Runtime-configurable settings, such as `speed`.
+</ParamField>
+
+## Usage
+
+```python
+from pipecat_sonex import SonexTTSService
+
+tts = SonexTTSService(
+    api_key=os.getenv("SONEX_API_KEY"),
+    voice=os.getenv("SONEX_VOICE_ID"),
+)
+
+pipeline = Pipeline([
+    transport.input(),
+    stt,
+    context_aggregator.user(),
+    llm,
+    tts,
+    transport.output(),
+    context_aggregator.assistant(),
+])
+```
+
+## Compatibility
+
+Tested with Pipecat v1.7.0.

--- a/docs.json
+++ b/docs.json
@@ -477,6 +477,7 @@
                       "api-reference/server/services/tts/simplismart",
                       "api-reference/server/services/tts/slng",
                       "api-reference/server/services/tts/smallest",
+                      "api-reference/server/services/tts/sonex",
                       "api-reference/server/services/tts/soniox",
                       "api-reference/server/services/tts/speechmatics",
                       "api-reference/server/services/tts/supertonic",
@@ -2127,6 +2128,10 @@
     {
       "source": "/server/services/tts/smallest",
       "destination": "/api-reference/server/services/tts/smallest"
+    },
+    {
+      "source": "/server/services/tts/sonex",
+      "destination": "/api-reference/server/services/tts/sonex"
     },
     {
       "source": "/server/services/tts/speechmatics",


### PR DESCRIPTION
Adds SonexLabs TTS (`pipecat-sonex`) as a community-maintained integration.

- Adds a row to the Supported Services page (Text-to-Speech table)
- Adds a dedicated service page at `api-reference/server/services/tts/sonex.mdx`
- Registers the page in `docs.json` nav and redirects

Source repo: https://github.com/sonexlabs/pipecat-sonex
PyPI: https://pypi.org/project/pipecat-sonex/