### PR TITLE
docs(rime): migrate Arcana examples to Coda

### DIFF
--- a/api-reference/server/services/tts/rime.mdx
+++ b/api-reference/server/services/tts/rime.mdx
@@ -145,7 +145,8 @@ Before using Rime TTS services, you need:
 
 ### RimeNonJsonTTSService
 
-A non-JSON WebSocket service for models like Arcana that use plain text messages.
+A deprecated non-JSON WebSocket service that uses plain-text messages and raw
+audio responses. Use `RimeTTSService` for current integrations.
 
 <ParamField path="api_key" type="str" required>
   Rime API key for authentication.
@@ -160,7 +161,7 @@ A non-JSON WebSocket service for models like Arcana that use plain text messages
   Rime WebSocket API endpoint.
 </ParamField>
 
-<ParamField path="model" type="str" default="arcana" deprecated>
+<ParamField path="model" type="str" default="coda" deprecated>
   Model ID to use for synthesis. _Deprecated in v0.0.105. Use
   `settings=RimeNonJsonTTSService.Settings(model=...)` instead._
 </ParamField>
@@ -206,23 +207,23 @@ A non-JSON WebSocket service for models like Arcana that use plain text messages
 
 Runtime-configurable settings passed via the `settings` constructor argument using `RimeTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter                  | Type              | Default     | Description                                                                                                                      |
-| -------------------------- | ----------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `model`                    | `str`             | `None`      | Model identifier. _(Inherited.)_                                                                                                 |
-| `voice`                    | `str`             | `None`      | Voice identifier. _(Inherited.)_                                                                                                 |
-| `language`                 | `Language \| str` | `None`      | Language for synthesis. _(Inherited.)_                                                                                           |
-| `segment`                  | `str`             | `NOT_GIVEN` | Segment type for synthesis.                                                                                                      |
-| `speedAlpha`               | `float`           | `NOT_GIVEN` | Speed alpha parameter.                                                                                                           |
-| `reduceLatency`            | `bool`            | `NOT_GIVEN` | Whether to reduce latency.                                                                                                       |
-| `pauseBetweenBrackets`     | `bool`            | `NOT_GIVEN` | Pause between brackets.                                                                                                          |
-| `phonemizeBetweenBrackets` | `bool`            | `NOT_GIVEN` | Phonemize between brackets.                                                                                                      |
-| `noTextNormalization`      | `bool`            | `NOT_GIVEN` | Disable text normalization.                                                                                                      |
-| `saveOovs`                 | `bool`            | `NOT_GIVEN` | Save out-of-vocabulary words.                                                                                                    |
-| `inlineSpeedAlpha`         | `str`             | `NOT_GIVEN` | Inline speed alpha.                                                                                                              |
-| `repetition_penalty`       | `float`           | `NOT_GIVEN` | Token repetition penalty (arcana only, 1.0-2.0).                                                                                 |
-| `temperature`              | `float`           | `NOT_GIVEN` | Sampling temperature (arcana only, 0.0-1.0).                                                                                     |
-| `top_p`                    | `float`           | `NOT_GIVEN` | Cumulative probability threshold (arcana only, 0.0-1.0).                                                                         |
-| `timeScaleFactor`          | `float`           | `NOT_GIVEN` | Audio playback speed factor (arcana, mistv3, and coda only). Values above 1.0 slow down the audio; values below 1.0 speed it up. |
+| Parameter                  | Type              | Default     | Description                                                                                                  |
+| -------------------------- | ----------------- | ----------- | ------------------------------------------------------------------------------------------------------------ |
+| `model`                    | `str`             | `None`      | Model identifier. _(Inherited.)_                                                                             |
+| `voice`                    | `str`             | `None`      | Voice identifier. _(Inherited.)_                                                                             |
+| `language`                 | `Language \| str` | `None`      | Language for synthesis. _(Inherited.)_                                                                       |
+| `segment`                  | `str`             | `NOT_GIVEN` | Segment type for synthesis.                                                                                  |
+| `speedAlpha`               | `float`           | `NOT_GIVEN` | Speed alpha parameter.                                                                                       |
+| `reduceLatency`            | `bool`            | `NOT_GIVEN` | Whether to reduce latency.                                                                                   |
+| `pauseBetweenBrackets`     | `bool`            | `NOT_GIVEN` | Pause between brackets.                                                                                      |
+| `phonemizeBetweenBrackets` | `bool`            | `NOT_GIVEN` | Phonemize between brackets.                                                                                  |
+| `noTextNormalization`      | `bool`            | `NOT_GIVEN` | Disable text normalization.                                                                                  |
+| `saveOovs`                 | `bool`            | `NOT_GIVEN` | Save out-of-vocabulary words.                                                                                |
+| `inlineSpeedAlpha`         | `str`             | `NOT_GIVEN` | Inline speed alpha.                                                                                          |
+| `repetition_penalty`       | `float`           | `NOT_GIVEN` | Token repetition penalty (coda only, 1.0-2.0).                                                               |
+| `temperature`              | `float`           | `NOT_GIVEN` | Sampling temperature (coda only, 0.0-1.0).                                                                   |
+| `top_p`                    | `float`           | `NOT_GIVEN` | Cumulative probability threshold (coda only, 0.0-1.0).                                                       |
+| `timeScaleFactor`          | `float`           | `NOT_GIVEN` | Audio playback speed factor (coda only). Values above 1.0 slow down the audio; values below 1.0 speed it up. |
 
 #### RimeNonJsonTTSService Settings
 
@@ -248,7 +249,8 @@ from pipecat.services.rime import RimeTTSService
 tts = RimeTTSService(
     api_key=os.getenv("RIME_API_KEY"),
     settings=RimeTTSService.Settings(
-        voice="cove",
+        model="coda",
+        voice="luna",
     ),
 )
 ```
@@ -281,13 +283,14 @@ async with aiohttp.ClientSession() as session:
     tts = RimeHttpTTSService(
         api_key=os.getenv("RIME_API_KEY"),
         settings=RimeHttpTTSService.Settings(
-            voice="cove",
+            model="coda",
+            voice="luna",
         ),
         aiohttp_session=session,
     )
 ```
 
-### Non-JSON WebSocket (Arcana)
+### Non-JSON WebSocket
 
 ```python
 from pipecat.services.rime import RimeNonJsonTTSService
@@ -295,8 +298,8 @@ from pipecat.services.rime import RimeNonJsonTTSService
 tts = RimeNonJsonTTSService(
     api_key=os.getenv("RIME_API_KEY"),
     settings=RimeNonJsonTTSService.Settings(
-        voice="cove",
-        model="arcana",
+        model="coda",
+        voice="luna",
     ),
 )
 ```
@@ -396,7 +399,7 @@ tts = RimeTTSService(
 
 - **Word-level timestamps**: `RimeTTSService` provides word-level timing information, enabling synchronized text highlighting.
 - **WebSocket vs HTTP**: The WebSocket service supports word-level timestamps, interruption handling, and maintains context across messages within a turn. The HTTP service is simpler but lacks these features.
-- **Non-JSON WebSocket**: `RimeNonJsonTTSService` is for models like Arcana that use plain text messages instead of JSON. It does not support word-level timestamps.
+- **Non-JSON WebSocket**: `RimeNonJsonTTSService` is the deprecated plain-text and raw-audio WebSocket implementation. It does not support word-level timestamps.
 
 ## Event Handlers
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -53634,7 +53634,8 @@ Before using Rime TTS services, you need:
 
 ### RimeNonJsonTTSService
 
-A non-JSON WebSocket service for models like Arcana that use plain text messages.
+A deprecated non-JSON WebSocket service that uses plain-text messages and raw
+audio responses. Use `RimeTTSService` for current integrations.
 
 <ParamField path="api_key" type="str" required>
   Rime API key for authentication.
@@ -53649,7 +53650,7 @@ A non-JSON WebSocket service for models like Arcana that use plain text messages
   Rime WebSocket API endpoint.
 </ParamField>
 
-<ParamField path="model" type="str" default="arcana" deprecated>
+<ParamField path="model" type="str" default="coda" deprecated>
   Model ID to use for synthesis. _Deprecated in v0.0.105. Use
   `settings=RimeNonJsonTTSService.Settings(model=...)` instead._
 </ParamField>
@@ -53695,23 +53696,23 @@ A non-JSON WebSocket service for models like Arcana that use plain text messages
 
 Runtime-configurable settings passed via the `settings` constructor argument using `RimeTTSService.Settings(...)`. These can be updated mid-conversation with `TTSUpdateSettingsFrame`. See [Service Settings](/pipecat/fundamentals/service-settings) for details.
 
-| Parameter                  | Type              | Default     | Description                                                                                                                      |
-| -------------------------- | ----------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `model`                    | `str`             | `None`      | Model identifier. _(Inherited.)_                                                                                                 |
-| `voice`                    | `str`             | `None`      | Voice identifier. _(Inherited.)_                                                                                                 |
-| `language`                 | `Language \| str` | `None`      | Language for synthesis. _(Inherited.)_                                                                                           |
-| `segment`                  | `str`             | `NOT_GIVEN` | Segment type for synthesis.                                                                                                      |
-| `speedAlpha`               | `float`           | `NOT_GIVEN` | Speed alpha parameter.                                                                                                           |
-| `reduceLatency`            | `bool`            | `NOT_GIVEN` | Whether to reduce latency.                                                                                                       |
-| `pauseBetweenBrackets`     | `bool`            | `NOT_GIVEN` | Pause between brackets.                                                                                                          |
-| `phonemizeBetweenBrackets` | `bool`            | `NOT_GIVEN` | Phonemize between brackets.                                                                                                      |
-| `noTextNormalization`      | `bool`            | `NOT_GIVEN` | Disable text normalization.                                                                                                      |
-| `saveOovs`                 | `bool`            | `NOT_GIVEN` | Save out-of-vocabulary words.                                                                                                    |
-| `inlineSpeedAlpha`         | `str`             | `NOT_GIVEN` | Inline speed alpha.                                                                                                              |
-| `repetition_penalty`       | `float`           | `NOT_GIVEN` | Token repetition penalty (arcana only, 1.0-2.0).                                                                                 |
-| `temperature`              | `float`           | `NOT_GIVEN` | Sampling temperature (arcana only, 0.0-1.0).                                                                                     |
-| `top_p`                    | `float`           | `NOT_GIVEN` | Cumulative probability threshold (arcana only, 0.0-1.0).                                                                         |
-| `timeScaleFactor`          | `float`           | `NOT_GIVEN` | Audio playback speed factor (arcana, mistv3, and coda only). Values above 1.0 slow down the audio; values below 1.0 speed it up. |
+| Parameter                  | Type              | Default     | Description                                                                                                  |
+| -------------------------- | ----------------- | ----------- | ------------------------------------------------------------------------------------------------------------ |
+| `model`                    | `str`             | `None`      | Model identifier. _(Inherited.)_                                                                             |
+| `voice`                    | `str`             | `None`      | Voice identifier. _(Inherited.)_                                                                             |
+| `language`                 | `Language \| str` | `None`      | Language for synthesis. _(Inherited.)_                                                                       |
+| `segment`                  | `str`             | `NOT_GIVEN` | Segment type for synthesis.                                                                                  |
+| `speedAlpha`               | `float`           | `NOT_GIVEN` | Speed alpha parameter.                                                                                       |
+| `reduceLatency`            | `bool`            | `NOT_GIVEN` | Whether to reduce latency.                                                                                   |
+| `pauseBetweenBrackets`     | `bool`            | `NOT_GIVEN` | Pause between brackets.                                                                                      |
+| `phonemizeBetweenBrackets` | `bool`            | `NOT_GIVEN` | Phonemize between brackets.                                                                                  |
+| `noTextNormalization`      | `bool`            | `NOT_GIVEN` | Disable text normalization.                                                                                  |
+| `saveOovs`                 | `bool`            | `NOT_GIVEN` | Save out-of-vocabulary words.                                                                                |
+| `inlineSpeedAlpha`         | `str`             | `NOT_GIVEN` | Inline speed alpha.                                                                                          |
+| `repetition_penalty`       | `float`           | `NOT_GIVEN` | Token repetition penalty (coda only, 1.0-2.0).                                                               |
+| `temperature`              | `float`           | `NOT_GIVEN` | Sampling temperature (coda only, 0.0-1.0).                                                                   |
+| `top_p`                    | `float`           | `NOT_GIVEN` | Cumulative probability threshold (coda only, 0.0-1.0).                                                       |
+| `timeScaleFactor`          | `float`           | `NOT_GIVEN` | Audio playback speed factor (coda only). Values above 1.0 slow down the audio; values below 1.0 speed it up. |
 
 #### RimeNonJsonTTSService Settings
 
@@ -53737,7 +53738,8 @@ from pipecat.services.rime import RimeTTSService
 tts = RimeTTSService(
     api_key=os.getenv("RIME_API_KEY"),
     settings=RimeTTSService.Settings(
-        voice="cove",
+        model="coda",
+        voice="luna",
     ),
 )
 ```
@@ -53770,13 +53772,14 @@ async with aiohttp.ClientSession() as session:
     tts = RimeHttpTTSService(
         api_key=os.getenv("RIME_API_KEY"),
         settings=RimeHttpTTSService.Settings(
-            voice="cove",
+            model="coda",
+            voice="luna",
         ),
         aiohttp_session=session,
     )
 ```
 
-### Non-JSON WebSocket (Arcana)
+### Non-JSON WebSocket
 
 ```python
 from pipecat.services.rime import RimeNonJsonTTSService
@@ -53784,8 +53787,8 @@ from pipecat.services.rime import RimeNonJsonTTSService
 tts = RimeNonJsonTTSService(
     api_key=os.getenv("RIME_API_KEY"),
     settings=RimeNonJsonTTSService.Settings(
-        voice="cove",
-        model="arcana",
+        model="coda",
+        voice="luna",
     ),
 )
 ```
@@ -53885,7 +53888,7 @@ tts = RimeTTSService(
 
 - **Word-level timestamps**: `RimeTTSService` provides word-level timing information, enabling synchronized text highlighting.
 - **WebSocket vs HTTP**: The WebSocket service supports word-level timestamps, interruption handling, and maintains context across messages within a turn. The HTTP service is simpler but lacks these features.
-- **Non-JSON WebSocket**: `RimeNonJsonTTSService` is for models like Arcana that use plain text messages instead of JSON. It does not support word-level timestamps.
+- **Non-JSON WebSocket**: `RimeNonJsonTTSService` is the deprecated plain-text and raw-audio WebSocket implementation. It does not support word-level timestamps.
 
 ## Event Handlers
 


### PR DESCRIPTION
## Summary
- remove current Arcana guidance from the Rime TTS reference
- document the Coda sampling settings
- use Coda with Luna in the Rime examples because Pipecat already used Luna and Rime supports it on both Arcana and Coda
- update the matching llms-full.txt content