### PR TITLE
Document when a deploy does not replace running agents

### DIFF
--- a/pipecat-cloud/fundamentals/agent-images.mdx
+++ b/pipecat-cloud/fundamentals/agent-images.mdx
@@ -173,7 +173,13 @@ The base image supports multiple Python versions. The default Python version is 
 - `dailyco/pipecat-base:0.1.0-py3.13` (Python 3.13)
 - `dailyco/pipecat-base:0.1.0-py3.14` (Python 3.14)
 
-<Tip>For production use, we recommend pinning to specific versions.</Tip>
+<Tip>
+  For production use, we recommend pinning to specific versions. A `:latest` tag
+  can change underneath you without your project changing, which means a deploy
+  can quietly leave your warm instances on the old image. See [when a deploy does
+  not replace running
+  agents](/pipecat-cloud/fundamentals/deploy#when-a-deploy-does-not-replace-running-agents).
+</Tip>
 
 ## Using a custom image
 

--- a/pipecat-cloud/fundamentals/agent-images.mdx
+++ b/pipecat-cloud/fundamentals/agent-images.mdx
@@ -175,10 +175,9 @@ The base image supports multiple Python versions. The default Python version is 
 
 <Tip>
   For production use, we recommend pinning to specific versions. A `:latest` tag
-  can change underneath you without your project changing, which means a deploy
-  can quietly leave your warm instances on the old image. See [when a deploy does
-  not replace running
-  agents](/pipecat-cloud/fundamentals/deploy#when-a-deploy-does-not-replace-running-agents).
+  can change without your project changing, so a deploy can leave your warm
+  instances on the old image
+  ([why](/pipecat-cloud/fundamentals/deploy#when-a-deploy-does-not-replace-running-agents)).
 </Tip>
 
 ## Using a custom image

--- a/pipecat-cloud/fundamentals/deploy.mdx
+++ b/pipecat-cloud/fundamentals/deploy.mdx
@@ -149,46 +149,23 @@ remains consistent and avoids potential cold starts.
 
 ### When a deploy does not replace running agents
 
-A deploy only replaces your running agent instances when it creates a new version of your agent. If the configuration you send is the same as what the agent already has, Pipecat Cloud keeps the current version and leaves your instances alone. That is on purpose: a routine deploy can't cut off a session that is already in progress.
+A deploy only replaces your running agent instances when it creates a new version of your agent. If the configuration you send matches what the agent already has, Pipecat Cloud keeps the current version and leaves your instances alone, so a routine deploy can't cut off a session that is already in progress.
 
-Watch for this if you keep warm instances (`min-agents` set to 1 or higher). Those instances can keep serving your old code, and the deploy output won't look wrong.
+Watch for this if you keep warm instances (`min-agents` set to 1 or higher): they can keep serving your old code, your deploy will report success, and the output won't look wrong.
 
-You may hit this if:
+These changes do **not** create a new version:
 
-- Your deploy succeeded, but the new image never took effect.
-- Your agent is still running old code.
-- You updated a secret, but the agent still uses the old value.
+- **Scaling only.** `min-agents` and `max-agents` apply to the running pool in place.
+- **An image tag you already deployed.** Pipecat Cloud stores the tag you gave it, not the image behind it, so pushing new content to a tag like `:latest` and deploying that same tag looks like no change. [Cloud builds](/pipecat-cloud/guides/cloud-builds) behave the same way when your project files haven't changed, because the tag comes from your file contents.
+- **A secret's value.** Your deployment records which secret sets it uses, not the values inside them.
 
-**These changes create a new version, so your instances are replaced:**
-
-- A new image tag, or a different image.
-- A new agent profile, region, or any other deployment setting.
-- Any deploy you run with `--force`.
-
-**These changes do not create a new version, so warm instances keep running as they are:**
-
-- Changing only `min-agents` or `max-agents`. Scaling limits are applied to the running pool in place, so no restart is needed.
-- Deploying an image tag you already deployed. Pipecat Cloud stores the tag you gave it, not the exact image sitting behind that tag. Pushing new content to a tag like `:latest` and deploying that same tag looks like no change at all.
-- Changing the value of a secret. Your deployment records which secret sets it uses, not the values inside them.
-- Running `pipecat cloud deploy` with no changes when you use [cloud builds](/pipecat-cloud/guides/cloud-builds). The image tag comes from the contents of your project, so if your files haven't changed, you get the same tag back.
-
-To pick up one of these changes, deploy with `--force`:
+To pick up any of these, force a new version:
 
 ```bash
 pipecat cloud deploy --force
 ```
 
-This creates a new version and replaces your running instances. See the [`--force` flag](/api-reference/cli/cloud/deploy) in the CLI reference.
-
-<Tip>
-  Pin your base image to an exact version, such as
-  `dailyco/pipecat-base:0.1.0-py3.13`, rather than `:latest`. With `:latest`, the
-  image can change underneath you without your project changing, so a deploy can
-  quietly do nothing. Pinning means every upgrade edits your Dockerfile, which
-  gives you a real new version, and you always know which base image your agent
-  is running. See [Agent images](/pipecat-cloud/fundamentals/agent-images) for
-  the available tags.
-</Tip>
+Pinning your base image to an exact version instead of `:latest` avoids the second case entirely. See [Agent images](/pipecat-cloud/fundamentals/agent-images) for the available tags, and the [`--force` flag](/api-reference/cli/cloud/deploy) in the CLI reference.
 
 ### Failed deployments
 

--- a/pipecat-cloud/fundamentals/deploy.mdx
+++ b/pipecat-cloud/fundamentals/deploy.mdx
@@ -147,6 +147,49 @@ Idle agent instances in your agent pool will be replaced with the new configurat
 New agent requests may, therefore, start with prior deployment configuration if updates are not fully propagated. This ensures on-demand availability
 remains consistent and avoids potential cold starts.
 
+### When a deploy does not replace running agents
+
+A deploy only replaces your running agent instances when it creates a new version of your agent. If the configuration you send is the same as what the agent already has, Pipecat Cloud keeps the current version and leaves your instances alone. That is on purpose: a routine deploy can't cut off a session that is already in progress.
+
+Watch for this if you keep warm instances (`min-agents` set to 1 or higher). Those instances can keep serving your old code, and the deploy output won't look wrong.
+
+You may hit this if:
+
+- Your deploy succeeded, but the new image never took effect.
+- Your agent is still running old code.
+- You updated a secret, but the agent still uses the old value.
+
+**These changes create a new version, so your instances are replaced:**
+
+- A new image tag, or a different image.
+- A new agent profile, region, or any other deployment setting.
+- Any deploy you run with `--force`.
+
+**These changes do not create a new version, so warm instances keep running as they are:**
+
+- Changing only `min-agents` or `max-agents`. Scaling limits are applied to the running pool in place, so no restart is needed.
+- Deploying an image tag you already deployed. Pipecat Cloud stores the tag you gave it, not the exact image sitting behind that tag. Pushing new content to a tag like `:latest` and deploying that same tag looks like no change at all.
+- Changing the value of a secret. Your deployment records which secret sets it uses, not the values inside them.
+- Running `pipecat cloud deploy` with no changes when you use [cloud builds](/pipecat-cloud/guides/cloud-builds). The image tag comes from the contents of your project, so if your files haven't changed, you get the same tag back.
+
+To pick up one of these changes, deploy with `--force`:
+
+```bash
+pipecat cloud deploy --force
+```
+
+This creates a new version and replaces your running instances. See the [`--force` flag](/api-reference/cli/cloud/deploy) in the CLI reference.
+
+<Tip>
+  Pin your base image to an exact version, such as
+  `dailyco/pipecat-base:0.1.0-py3.13`, rather than `:latest`. With `:latest`, the
+  image can change underneath you without your project changing, so a deploy can
+  quietly do nothing. Pinning means every upgrade edits your Dockerfile, which
+  gives you a real new version, and you always know which base image your agent
+  is running. See [Agent images](/pipecat-cloud/fundamentals/agent-images) for
+  the available tags.
+</Tip>
+
 ### Failed deployments
 
 If a deployment fails (i.e. fails to enter a `ready` state), requests will be routed to any prior deployments in a ready state.

--- a/pipecat-cloud/fundamentals/deploy.mdx
+++ b/pipecat-cloud/fundamentals/deploy.mdx
@@ -149,23 +149,7 @@ remains consistent and avoids potential cold starts.
 
 ### When a deploy does not replace running agents
 
-A deploy only replaces your running agent instances when it creates a new version of your agent. If the configuration you send matches what the agent already has, Pipecat Cloud keeps the current version and leaves your instances alone, so a routine deploy can't cut off a session that is already in progress.
-
-Watch for this if you keep warm instances (`min-agents` set to 1 or higher): they can keep serving your old code, your deploy will report success, and the output won't look wrong.
-
-These changes do **not** create a new version:
-
-- **Scaling only.** `min-agents` and `max-agents` apply to the running pool in place.
-- **An image tag you already deployed.** Pipecat Cloud stores the tag you gave it, not the image behind it, so pushing new content to a tag like `:latest` and deploying that same tag looks like no change. [Cloud builds](/pipecat-cloud/guides/cloud-builds) behave the same way when your project files haven't changed, because the tag comes from your file contents.
-- **A secret's value.** Your deployment records which secret sets it uses, not the values inside them.
-
-To pick up any of these, force a new version:
-
-```bash
-pipecat cloud deploy --force
-```
-
-Pinning your base image to an exact version instead of `:latest` avoids the second case entirely. See [Agent images](/pipecat-cloud/fundamentals/agent-images) for the available tags, and the [`--force` flag](/api-reference/cli/cloud/deploy) in the CLI reference.
+A deploy only replaces your running agent instances when it creates a new version of your agent, so a routine deploy can't cut off a session that is already in progress. Some changes look like no change and keep the current version: a scaling-only change (`min-agents` or `max-agents`), an image tag you already deployed (Pipecat Cloud stores the tag, not the image behind it, so re-pushing to a tag like `:latest` looks identical), and a new value for a secret in a set you already use. If you keep warm instances (`min-agents` set to 1 or higher), they can keep serving your old code while the deploy reports success. Run [`pipecat cloud deploy --force`](/api-reference/cli/cloud/deploy) to force a new version.
 
 ### Failed deployments
 

--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -241,8 +241,6 @@ pipecat cloud deploy [agent-name] [image] --min-agents 1 --max-agents 5
 Please note that changing your scaling parameters will not disrupt any active sessions.
 If you reduce your max instance count below the number of currently active sessions, you will still be billed for the duration of those sessions.
 
-A scaling-only change also doesn't create a new version or restart your instances, so it won't pick up new code, a new image, or a new secret value ([why](/pipecat-cloud/fundamentals/deploy#when-a-deploy-does-not-replace-running-agents)).
-
 ## Capacity Planning
 
 Effective capacity planning is crucial for production deployments to ensure your agents respond immediately.

--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -241,7 +241,7 @@ pipecat cloud deploy [agent-name] [image] --min-agents 1 --max-agents 5
 Please note that changing your scaling parameters will not disrupt any active sessions.
 If you reduce your max instance count below the number of currently active sessions, you will still be billed for the duration of those sessions.
 
-Because a scaling-only change doesn't disrupt anything, it also doesn't create a new version of your agent or restart your instances. If you meant to pick up new code, a new image, or a new secret value at the same time, see [when a deploy does not replace running agents](/pipecat-cloud/fundamentals/deploy#when-a-deploy-does-not-replace-running-agents).
+A scaling-only change also doesn't create a new version or restart your instances, so it won't pick up new code, a new image, or a new secret value ([why](/pipecat-cloud/fundamentals/deploy#when-a-deploy-does-not-replace-running-agents)).
 
 ## Capacity Planning
 

--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -241,6 +241,8 @@ pipecat cloud deploy [agent-name] [image] --min-agents 1 --max-agents 5
 Please note that changing your scaling parameters will not disrupt any active sessions.
 If you reduce your max instance count below the number of currently active sessions, you will still be billed for the duration of those sessions.
 
+Because a scaling-only change doesn't disrupt anything, it also doesn't create a new version of your agent or restart your instances. If you meant to pick up new code, a new image, or a new secret value at the same time, see [when a deploy does not replace running agents](/pipecat-cloud/fundamentals/deploy#when-a-deploy-does-not-replace-running-agents).
+
 ## Capacity Planning
 
 Effective capacity planning is crucial for production deployments to ensure your agents respond immediately.

--- a/pipecat-cloud/fundamentals/secrets.mdx
+++ b/pipecat-cloud/fundamentals/secrets.mdx
@@ -31,8 +31,13 @@ pipecat cloud secrets set my-secrets SECRET_NAME_3 secret-value-3
 ```
 
 <Info>
-  Whenever a secret is added or updated in an existing set, any deployments
-  using that set will need to be redeployed to access the new values.
+  Whenever a secret is added or updated in an existing set, any deployments using
+  that set will need to be redeployed to access the new values. Your deployment
+  records which secret sets it uses, not the values inside them, so a plain
+  `pipecat cloud deploy` looks like no change and leaves your running instances
+  on the old values. Use `pipecat cloud deploy --force` to pick up the new
+  values. See [when a deploy does not replace running
+  agents](/pipecat-cloud/fundamentals/deploy#when-a-deploy-does-not-replace-running-agents).
 </Info>
 
 #### Provisioning and readiness

--- a/pipecat-cloud/fundamentals/secrets.mdx
+++ b/pipecat-cloud/fundamentals/secrets.mdx
@@ -32,12 +32,10 @@ pipecat cloud secrets set my-secrets SECRET_NAME_3 secret-value-3
 
 <Info>
   Whenever a secret is added or updated in an existing set, any deployments using
-  that set will need to be redeployed to access the new values. Your deployment
-  records which secret sets it uses, not the values inside them, so a plain
-  `pipecat cloud deploy` looks like no change and leaves your running instances
-  on the old values. Use `pipecat cloud deploy --force` to pick up the new
-  values. See [when a deploy does not replace running
-  agents](/pipecat-cloud/fundamentals/deploy#when-a-deploy-does-not-replace-running-agents).
+  that set will need to be redeployed to access the new values. A plain
+  `pipecat cloud deploy` looks like no change here, so use
+  `pipecat cloud deploy --force`
+  ([why](/pipecat-cloud/fundamentals/deploy#when-a-deploy-does-not-replace-running-agents)).
 </Info>
 
 #### Provisioning and readiness


### PR DESCRIPTION
## Why


Nothing customer-facing documented the fact that a Pipecat Cloud deploy does not always replace running pods. A customer with warm instances (`min-agents >= 1`) can keep serving an older version of their agent with no sign that anything is wrong. One customer ran a broken Krisp setup for two months, building from the mutable `dailyco/pipecat-base:latest` tag.

The behavior is intentional (a no-op deploy used to roll pods and drop in-flight sessions), but it was only intuitive if you already knew the internals. This documents the customer-facing shape of it.
