### PR TITLE
docs: fix agent logs and stop session flag

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -24715,7 +24715,7 @@ This command will list all active sessions for the specified agent, alongside a 
 To view individual session logs, use the following command:
 
 ```shell
-pipecat cloud agent logs [my-first-agent] --session [session-id]
+pipecat cloud agent logs [my-first-agent] --session-id [session-id]
 ```
 
 For more information, see [Logging and Observability](./logging).
@@ -24725,7 +24725,7 @@ For more information, see [Logging and Observability](./logging).
 You can issue a termination request to stop an active session. This will immediately stop the instance so be aware of disrupting any ongoing user interactions.
 
 ```shell
-pipecat cloud agent stop my-first-agent --session [session-id]
+pipecat cloud agent stop my-first-agent --session-id [session-id]
 ```
 
 Deleting an agent deployment will block any new sessions from starting, but will not stop any active sessions. You must stop each session individually.

--- a/pipecat-cloud/fundamentals/active-sessions.mdx
+++ b/pipecat-cloud/fundamentals/active-sessions.mdx
@@ -317,7 +317,7 @@ This command will list all active sessions for the specified agent, alongside a 
 To view individual session logs, use the following command:
 
 ```shell
-pipecat cloud agent logs [my-first-agent] --session [session-id]
+pipecat cloud agent logs [my-first-agent] --session-id [session-id]
 ```
 
 For more information, see [Logging and Observability](./logging).
@@ -327,7 +327,7 @@ For more information, see [Logging and Observability](./logging).
 You can issue a termination request to stop an active session. This will immediately stop the instance so be aware of disrupting any ongoing user interactions.
 
 ```shell
-pipecat cloud agent stop my-first-agent --session [session-id]
+pipecat cloud agent stop my-first-agent --session-id [session-id]
 ```
 
 Deleting an agent deployment will block any new sessions from starting, but will not stop any active sessions. You must stop each session individually.


### PR DESCRIPTION
## What this fixes

The Pipecat Cloud "Starting Sessions" page told people to filter agent logs with `--session`. The CLI option is `--session-id` (short form `-s`). The same page also used `--session` for `pipecat cloud agent stop`, which takes `--session-id` too.

Typer does not match partial option names, so anyone who copied these commands straight from the docs got an error.

## Why now

Found while working Daily support ticket where a customer hit exactly this.

## Notes

The CLI reference page (`api-reference/cli/cloud/agent`) already showed the correct `--session-id`, so the docs were disagreeing with themselves. This brings the fundamentals page in line.

I grepped the whole repo for the old `--session` form. There were 2 stale spots, both on that one page, plus their copies in the generated `llms-full.txt`, which I updated to match. I did not run a full `gen-llms-txt` regeneration because the checked-in file is already stale against unrelated pages on main, and that would have buried this small change in hundreds of unrelated lines.
