### PR TITLE
docs(smart-turn): fix pre_speech_ms default

### DIFF
--- a/api-reference/server/utilities/turn-detection/smart-turn-overview.mdx
+++ b/api-reference/server/utilities/turn-detection/smart-turn-overview.mdx
@@ -107,7 +107,7 @@ wait before classifying the turn as complete.
 
 </ParamField>
 
-<ParamField path="pre_speech_ms" type="float" default="0.0">
+<ParamField path="pre_speech_ms" type="float" default="500.0">
   Amount of audio (in milliseconds) to include before speech is detected
 </ParamField>
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -69115,7 +69115,7 @@ wait before classifying the turn as complete.
 
 </ParamField>
 
-<ParamField path="pre_speech_ms" type="float" default="0.0">
+<ParamField path="pre_speech_ms" type="float" default="500.0">
   Amount of audio (in milliseconds) to include before speech is detected
 </ParamField>
 


### PR DESCRIPTION
## What

The smart turn overview page listed `SmartTurnParams.pre_speech_ms` with a default of `0.0`. The real default is `500.0` milliseconds.

## Why

In the Pipecat source, `SmartTurnParams.pre_speech_ms` is set from the `PRE_SPEECH_MS` constant, which is 500. A user reading the page would think no pre-speech audio is buffered by default, when half a second is.

I checked the other two fields on the same page while I was in there:

- `stop_secs` default `3.0`: correct, no change.
- `max_duration_secs` default `8.0`: correct, no change.
