### PR TITLE
docs: add Pipecat Cloud GitHub integration guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -263,19 +263,24 @@
           {
             "group": "Guides",
             "pages": [
-              "pipecat-cloud/guides/cloud-builds",
-              "pipecat-cloud/guides/deploy-from-github",
-              "pipecat-cloud/guides/capacity-planning",
               {
-                "group": "Container Registries",
+                "group": "Building & Deploying",
                 "pages": [
-                  "pipecat-cloud/guides/container-registries/overview",
-                  "pipecat-cloud/guides/container-registries/docker-hub",
-                  "pipecat-cloud/guides/container-registries/aws-ecr",
-                  "pipecat-cloud/guides/container-registries/gcp-artifact-registry"
+                  "pipecat-cloud/guides/cloud-builds",
+                  "pipecat-cloud/guides/deploy-from-github",
+                  "pipecat-cloud/guides/ci-with-github-actions",
+                  {
+                    "group": "Container Registries",
+                    "pages": [
+                      "pipecat-cloud/guides/container-registries/overview",
+                      "pipecat-cloud/guides/container-registries/docker-hub",
+                      "pipecat-cloud/guides/container-registries/aws-ecr",
+                      "pipecat-cloud/guides/container-registries/gcp-artifact-registry"
+                    ]
+                  }
                 ]
               },
-              "pipecat-cloud/guides/ci-with-github-actions",
+              "pipecat-cloud/guides/capacity-planning",
               "pipecat-cloud/guides/personal-access-tokens",
               "pipecat-cloud/guides/daily-webrtc",
               "pipecat-cloud/guides/krisp-viva",

--- a/docs.json
+++ b/docs.json
@@ -264,6 +264,7 @@
             "group": "Guides",
             "pages": [
               "pipecat-cloud/guides/cloud-builds",
+              "pipecat-cloud/guides/deploy-from-github",
               "pipecat-cloud/guides/capacity-planning",
               {
                 "group": "Container Registries",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25681,7 +25681,7 @@ Pipecat Cloud Build lets you deploy agents directly from your source code. Inste
 <Tip>
   The same build service backs the [GitHub
   integration](/pipecat-cloud/guides/deploy-from-github), which builds and
-  deploys your agent on every push to a connected branch — no CLI required.
+  deploys your agent on every push to a connected branch.
 </Tip>
 
 ## Prerequisites
@@ -25873,9 +25873,9 @@ Connect the Pipecat Cloud GitHub App to deploy agents from a repository branch, 
 Connect a GitHub repository to an agent and Pipecat Cloud builds and deploys it for you. Push to the connected branch and your agent updates — no Docker build, no registry, no CI workflow to maintain.
 
 <Info>
-  The GitHub integration is configured from the [Pipecat Cloud dashboard{" "}
+  This guide sets the integration up in the [Pipecat Cloud dashboard{" "}
   <Icon icon="arrow-up-right-from-square" iconType="solid" />
-  ](https://pipecat.daily.co). Deploys still use [cloud
+  ](https://pipecat.daily.co). Deploys use [cloud
   builds](/pipecat-cloud/guides/cloud-builds) under the hood, so your project
   needs a `Dockerfile`.
 </Info>
@@ -25886,7 +25886,7 @@ Pipecat Cloud gives you three ways to ship an agent. They all end up building th
 
 | Method                                                         | Best for                                                               |
 | -------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| **GitHub integration** (this guide)                            | Push-to-deploy with no CI setup. Configured entirely in the dashboard. |
+| **GitHub integration** (this guide)                            | Push-to-deploy with no CI setup and no API key to manage.              |
 | [CLI cloud builds](/pipecat-cloud/guides/cloud-builds)         | Deploying from your laptop, or from a script that already has the CLI. |
 | [GitHub Actions](/pipecat-cloud/guides/ci-with-github-actions) | Pipelines that need tests, approvals, or custom steps before a deploy. |
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -24258,6 +24258,12 @@ pipecat cloud deploy
 
 The CLI builds your image in the cloud from your project's Dockerfile and deploys it - no container registry setup needed. For more details on how cloud builds work, see the [Cloud Builds guide](/pipecat-cloud/guides/cloud-builds).
 
+<Tip>
+  Prefer not to deploy by hand? Connect a GitHub repository to your agent and
+  every push to the connected branch deploys it. See [Deploy from
+  GitHub](/pipecat-cloud/guides/deploy-from-github).
+</Tip>
+
 ### Deploying to a specific region
 
 Agents deploy to your organization's default region, which is `us-west` by default. You can deploy to a specific region to reduce latency or meet data residency requirements:
@@ -25672,6 +25678,12 @@ Build and deploy agents on Pipecat Cloud without managing your own container reg
 
 Pipecat Cloud Build lets you deploy agents directly from your source code. Instead of building Docker images locally and pushing them to a registry, just run `pipecat cloud deploy` and the CLI handles everything.
 
+<Tip>
+  The same build service backs the [GitHub
+  integration](/pipecat-cloud/guides/deploy-from-github), which builds and
+  deploys your agent on every push to a connected branch — no CLI required.
+</Tip>
+
 ## Prerequisites
 
 - A [Pipecat Cloud account](/pipecat-cloud/fundamentals/accounts-and-organizations) with an active organization
@@ -25852,6 +25864,165 @@ See the [deploy command reference](/api-reference/cli/cloud/deploy#configuration
     Full reference for build management commands.
   </Card>
 </CardGroup>
+
+# Deploy from GitHub
+Source: https://docs.pipecat.ai/pipecat-cloud/guides/deploy-from-github.md
+
+Connect the Pipecat Cloud GitHub App to deploy agents from a repository branch, with deploy on push, manual deploys, and commit tracking.
+
+Connect a GitHub repository to an agent and Pipecat Cloud builds and deploys it for you. Push to the connected branch and your agent updates — no Docker build, no registry, no CI workflow to maintain.
+
+<Info>
+  The GitHub integration is configured from the [Pipecat Cloud dashboard{" "}
+  <Icon icon="arrow-up-right-from-square" iconType="solid" />
+  ](https://pipecat.daily.co). Deploys still use [cloud
+  builds](/pipecat-cloud/guides/cloud-builds) under the hood, so your project
+  needs a `Dockerfile`.
+</Info>
+
+## Choosing a deployment method
+
+Pipecat Cloud gives you three ways to ship an agent. They all end up building the same image:
+
+| Method                                                         | Best for                                                               |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **GitHub integration** (this guide)                            | Push-to-deploy with no CI setup. Configured entirely in the dashboard. |
+| [CLI cloud builds](/pipecat-cloud/guides/cloud-builds)         | Deploying from your laptop, or from a script that already has the CLI. |
+| [GitHub Actions](/pipecat-cloud/guides/ci-with-github-actions) | Pipelines that need tests, approvals, or custom steps before a deploy. |
+
+You can mix them. An agent connected to a repository can still be deployed with the CLI, though the next push to the connected branch will deploy over it.
+
+## Prerequisites
+
+- A [Pipecat Cloud account](/pipecat-cloud/fundamentals/accounts-and-organizations) with an active organization
+- A GitHub repository containing your agent, with a `Dockerfile` at the repository root (or at a path you specify)
+- Permission to install a GitHub App on the account or organization that owns the repository
+
+## Connect your GitHub account
+
+The GitHub App is installed once per Pipecat Cloud organization, and every agent in that organization shares it.
+
+<Steps>
+  <Step title="Open GitHub settings">
+    In the dashboard, go to **Settings → GitHub**.
+  </Step>
+  <Step title="Install the app">
+    Click **Connect GitHub**. A new tab opens GitHub's installation screen,
+    where you choose the account or organization to install into and which
+    repositories to grant access to — all of them, or a hand-picked list.
+  </Step>
+  <Step title="Return to the dashboard">
+    Once you approve the install, the dashboard picks up the connection
+    automatically and shows the connected account.
+  </Step>
+</Steps>
+
+<Tip>
+  Granting access to only the repositories you deploy from is the safer default.
+  You can change the selection later from **Manage on GitHub** without
+  reconnecting.
+</Tip>
+
+## Deploy a new agent from a repository
+
+When you create an agent, choose **GitHub** as the source:
+
+<Steps>
+  <Step title="Pick the repository">
+    Select any repository the installation can see. Private repositories are
+    supported.
+  </Step>
+  <Step title="Pick the branch">
+    The repository's default branch is preselected. Search to find any other
+    branch.
+  </Step>
+  <Step title="Set the Dockerfile path (optional)">
+    Defaults to `Dockerfile` at the repository root. Set a path such as
+    `docker/Dockerfile` if yours lives elsewhere.
+  </Step>
+</Steps>
+
+Creating the agent builds the branch's current commit and deploys it.
+
+## Connect an existing agent
+
+Agents that already run a Docker image can be moved onto GitHub deploys at any time.
+
+Go to your agent's **Settings → GitHub** tab and pick a repository, branch, and Dockerfile path.
+
+<Note>
+  Linking a repository does not deploy anything. The agent keeps serving its
+  current image until the next push to the connected branch, or until you deploy
+  manually. This lets you connect a repository and choose your moment.
+</Note>
+
+## Deploy on push
+
+**Deploy on push** is on by default. With it enabled, every push to the connected branch builds that commit and rolls it out.
+
+Pushes to any other branch are ignored — only the branch you connected triggers a deploy.
+
+Turn it off from the agent's **Settings → GitHub** tab when you want to control the timing yourself, for example while you're stabilizing a branch.
+
+## Deploy manually
+
+The **Deploy** button on the agent's GitHub settings builds and deploys the connected branch's current `HEAD`. It works whether or not deploy on push is enabled, and it's the way to ship a change when it's off.
+
+Deploys are queued: the button returns as soon as the build is accepted, and progress shows up in the agent's deployment history and on the [Builds](/pipecat-cloud/guides/cloud-builds) page.
+
+## See what's running
+
+An agent deployed from GitHub shows its source and the exact commit it is running — on the agent overview and in the agents list — linked back to that commit on GitHub.
+
+The commit that's running and the branch that's connected can legitimately differ: right after you link a repository, after you re-point an agent at a different repository or branch, or when deploy on push is off and there are unshipped commits. The dashboard says so and offers a deploy when that's the case.
+
+## Change or remove a connection
+
+<AccordionGroup>
+  <Accordion title="Switch branch or repository">
+    Edit the repository, branch, or Dockerfile path on the agent's **Settings →
+    GitHub** tab and save. The running deployment is untouched until the next
+    deploy.
+  </Accordion>
+  <Accordion title="Unlink one agent">
+    **Unlink** removes the agent's connection to the repository. Pushes stop
+    deploying it, and its current deployment stays live.
+  </Accordion>
+  <Accordion title="Disconnect the organization">
+    **Disconnect** on **Settings → GitHub** removes the installation and every
+    repository link in the organization. Connected agents stop auto-deploying
+    and keep running what they last deployed. This does not uninstall the app on
+    GitHub — do that from GitHub if you want to revoke access entirely.
+  </Accordion>
+</AccordionGroup>
+
+## Things to know
+
+- **One agent per repository and branch.** A given repository and branch pair can be connected to a single agent. Use a different branch, or a different repository, for a second agent.
+- **Each agent connects to one branch.** To run staging and production from one repository, create two agents and connect each to its own branch.
+- **A `Dockerfile` is required.** The build follows the same path as [cloud builds](/pipecat-cloud/guides/cloud-builds). Run `pipecat init` to scaffold a project that already has one.
+- **Secrets are configured in Pipecat Cloud**, not in your repository. See [Secrets](/pipecat-cloud/fundamentals/secrets).
+- **A suspended installation stops deploys.** If the app is suspended on GitHub, the dashboard flags it; reinstate it from GitHub to resume.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="A repository is missing from the picker">
+    The installation can only see repositories you granted it. Open **Settings →
+    GitHub → Manage on GitHub** and add the repository to the installation's
+    access list.
+  </Accordion>
+  <Accordion title="A push didn't deploy">
+    Check that the push went to the connected branch, that **Deploy on push** is
+    enabled on the agent, and that the installation isn't suspended on GitHub.
+  </Accordion>
+  <Accordion title="The build failed">
+    Build logs are on the agent's deployment history. The most common causes are
+    a `Dockerfile` path that doesn't match the repository and a build that
+    succeeds locally but not from a clean checkout — check that everything the
+    build needs is committed.
+  </Accordion>
+</AccordionGroup>
 
 # Pipecat Cloud Capacity Planning
 Source: https://docs.pipecat.ai/pipecat-cloud/guides/capacity-planning.md
@@ -26411,6 +26582,13 @@ Source: https://docs.pipecat.ai/pipecat-cloud/guides/ci-with-github-actions.md
 Automate Pipecat Cloud builds and deploys from CI using the official pipecat-ai GitHub Action in your workflow.
 
 This guide shows you how to automate Pipecat Cloud deployments from GitHub Actions using the official [Deploy to Pipecat Cloud](https://github.com/daily-co/pipecat-cloud-deploy-action) action.
+
+<Note>
+  If you only need push-to-deploy, the [GitHub
+  integration](/pipecat-cloud/guides/deploy-from-github) does that with no
+  workflow file and no API key to manage. Reach for a GitHub Actions workflow
+  when a deploy has to run tests, wait on an approval, or do custom steps.
+</Note>
 
 ## Prerequisites
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25879,12 +25879,9 @@ Connect the Pipecat Cloud GitHub App to deploy agents from a repository branch, 
 
 Connect a GitHub repository to an agent and Pipecat Cloud builds and deploys it for you. Push to the connected branch and your agent updates — no Docker build, no registry, no CI workflow to maintain.
 
+{/* prettier-ignore */}
 <Info>
-  This guide sets the integration up in the [Pipecat Cloud dashboard{" "}
-  <Icon icon="arrow-up-right-from-square" iconType="solid" />
-  ](https://pipecat.daily.co). Deploys use [cloud
-  builds](/pipecat-cloud/guides/cloud-builds) under the hood, so your project
-  needs a `Dockerfile`.
+  This guide sets the integration up in the [Pipecat Cloud dashboard <Icon icon="arrow-up-right-from-square" iconType="solid" />](https://pipecat.daily.co). Deploys use [cloud builds](/pipecat-cloud/guides/cloud-builds) under the hood, so your project needs a `Dockerfile`.
 </Info>
 
 <Note>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -24248,6 +24248,19 @@ Source: https://docs.pipecat.ai/pipecat-cloud/fundamentals/deploy.md
 
 Deploy agents with the pipecat cloud deploy CLI command: cloud image builds from your Dockerfile and deployment configuration.
 
+## Choosing a deployment method
+
+Pipecat Cloud gives you four ways to ship an agent. The first three build the image for you from a `Dockerfile` in your project; the fourth deploys an image you built and pushed yourself.
+
+| Method                                        | Best for                                                                                                                                           |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **CLI cloud builds** (`pipecat cloud deploy`) | Deploying from your laptop, or from a script that already has the CLI. See [Cloud Builds](/pipecat-cloud/guides/cloud-builds).                     |
+| **GitHub integration**                        | Push-to-deploy with no CI setup and no API key to manage. See [Deploy from GitHub](/pipecat-cloud/guides/deploy-from-github).                      |
+| **GitHub Actions**                            | Pipelines that need tests, approvals, or custom steps before a deploy. See [CI with GitHub Actions](/pipecat-cloud/guides/ci-with-github-actions). |
+| **Your own container registry**               | Reusing an image your existing build pipeline already produces. See [Container Registries](/pipecat-cloud/guides/container-registries/overview).   |
+
+You can mix them. An agent connected to a GitHub repository can still be deployed with the CLI, though the next push to the connected branch will deploy over it.
+
 ## Deploying an agent
 
 Deploy your agent to Pipecat Cloud with a single command:
@@ -24257,12 +24270,6 @@ pipecat cloud deploy
 ```
 
 The CLI builds your image in the cloud from your project's Dockerfile and deploys it - no container registry setup needed. For more details on how cloud builds work, see the [Cloud Builds guide](/pipecat-cloud/guides/cloud-builds).
-
-<Tip>
-  Prefer not to deploy by hand? Connect a GitHub repository to your agent and
-  every push to the connected branch deploys it. See [Deploy from
-  GitHub](/pipecat-cloud/guides/deploy-from-github).
-</Tip>
 
 ### Deploying to a specific region
 
@@ -25880,17 +25887,12 @@ Connect a GitHub repository to an agent and Pipecat Cloud builds and deploys it 
   needs a `Dockerfile`.
 </Info>
 
-## Choosing a deployment method
-
-Pipecat Cloud gives you three ways to ship an agent. They all end up building the same image:
-
-| Method                                                         | Best for                                                               |
-| -------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| **GitHub integration** (this guide)                            | Push-to-deploy with no CI setup and no API key to manage.              |
-| [CLI cloud builds](/pipecat-cloud/guides/cloud-builds)         | Deploying from your laptop, or from a script that already has the CLI. |
-| [GitHub Actions](/pipecat-cloud/guides/ci-with-github-actions) | Pipelines that need tests, approvals, or custom steps before a deploy. |
-
-You can mix them. An agent connected to a repository can still be deployed with the CLI, though the next push to the connected branch will deploy over it.
+<Note>
+  Not sure this is the right method? The [deployment
+  overview](/pipecat-cloud/fundamentals/deploy#choosing-a-deployment-method)
+  compares the GitHub integration with CLI cloud builds, GitHub Actions, and
+  your own container registry.
+</Note>
 
 ## Prerequisites
 
@@ -26024,177 +26026,197 @@ The commit that's running and the branch that's connected can legitimately diffe
   </Accordion>
 </AccordionGroup>
 
-# Pipecat Cloud Capacity Planning
-Source: https://docs.pipecat.ai/pipecat-cloud/guides/capacity-planning.md
+# Pipecat Cloud CI with GitHub Actions
+Source: https://docs.pipecat.ai/pipecat-cloud/guides/ci-with-github-actions.md
 
-Plan Pipecat Cloud capacity to minimize cold starts: auto-scaling behavior, the min-agents parameter, and sizing for call volume.
+Automate Pipecat Cloud builds and deploys from CI using the official pipecat-ai GitHub Action in your workflow.
 
-## Overview
+This guide shows you how to automate Pipecat Cloud deployments from GitHub Actions using the official [Deploy to Pipecat Cloud](https://github.com/daily-co/pipecat-cloud-deploy-action) action.
 
-By default, Pipecat Cloud auto-scales your agent to help minimize the likelihood that your agents experience a cold start. For many applications, you can simply set the `--min-agents` parameter to 1 in order to avoid scaling from zero and let Pipecat Cloud handle the rest.
+<Note>
+  If you only need push-to-deploy, the [GitHub
+  integration](/pipecat-cloud/guides/deploy-from-github) does that with no
+  workflow file and no API key to manage. Reach for a GitHub Actions workflow
+  when a deploy has to run tests, wait on an approval, or do custom steps.
+</Note>
 
-However, for applications where traffic can fluctuate, you may need to plan for additional warm capacity to ensure your agents are always ready to respond immediately. For those cases, this guide will help you understand how warm capacity works in Pipecat Cloud, when you need to plan to use reserves, and how you can optimize your plan for both performance and cost.
+## Prerequisites
 
-## Agent Types
+Before setting up your workflow, ensure you have:
 
-Before discussing capacity planning, it's important to understand the different types of agent instances in Pipecat Cloud:
+- A Pipecat Cloud account with a **Private** API key
+- A secret set configured for your agent
 
-- **Active Agents**: Agent instances currently running and handling user sessions.
-- **Idle Agents**: When you start an active agent, Pipecat Cloud automatically provisions an additional idle agent to help with scaling. These take approximately 30 seconds to become available, though this time may vary based on system load and image size. You are not charged for these idle agents.
-- **Reserved Agents**: Agent instances maintained according to your `--min-agents` deployment setting, ensuring immediate availability regardless of current traffic.
+## Configure GitHub Secrets
 
-## Understanding Warm Capacity
+Add the following secret to your repository (Settings → Secrets and variables → Actions):
 
-Your "warm capacity" represents agent instances that are immediately available to handle new sessions without a cold start. Pipecat Cloud automatically manages this based on:
+- `PCC_API_KEY`: Your Pipecat Cloud **Private** API key
 
-1. Your configured **reserved agents** (`min-agents`)
-2. Your current **active sessions**
-3. Automatically provisioned **idle agents**
+## Basic Workflow — Cloud Build
 
-The system ensures you always have the following warm capacity available:
+The simplest setup uses [cloud builds](./cloud-builds) to build your image server-side. No Docker, no container registry, no extra infrastructure.
 
-- When **Reserved > Active**: Your warm capacity equals the number of **Reserved Agents**
-- When **Active ≥ Reserved**: Your warm capacity equals the number of **Active Agents** (through automatically provisioned idle agents)
+Create `.github/workflows/deploy.yml` in your repository:
 
-To illustrate the point, here are a few scenarios showing how warm capacity works:
+```yml
+name: Deploy to Pipecat Cloud
 
-| Reserved | Active | Warm Capacity |
-| -------- | ------ | ------------- |
-| 10       | 1      | 10            |
-| 10       | 10     | 10            |
-| 1        | 10     | 10            |
+on:
+  push:
+    branches: ["main"]
 
-This shows how:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-- Reserved agents provide a guaranteed minimum warm capacity
-- As active sessions increase beyond your reserved count, your warm capacity grows to match through automatically provisioned idle agents
+      - name: Build and Deploy to Pipecat Cloud
+        uses: daily-co/pipecat-cloud-deploy-action@v2
+        with:
+          api-key: ${{ secrets.PCC_API_KEY }}
+          agent-name: ${{ github.event.repository.name }}
+          cloud-build: true
+          secret-set: my-secret-set
+          region: us-east
+```
 
-## Agent Cooldown
+This workflow will:
 
-When an active session ends, the agent instance behavior is governed by a cooldown period:
-
-- The agent instance remains available in your warm capacity pool for a 5-minute cooldown period
-- During this time, it can immediately serve another request without any cold start
-- After the 5-minute cooldown expires, if the agent instance hasn't been used, it will be terminated
-- This cooldown provides a buffer in your warm capacity pool, helping to smooth transitions between traffic peaks
-
-## Planning for Traffic Patterns
-
-To determine the optimal reserved instance count for your deployment, consider:
-
-1. **Peak Concurrent Sessions**: How many simultaneous sessions do you expect during peak periods?
-
-2. **Growth Rate**: How quickly do new sessions start during peak periods?
-   - If new sessions start faster than the ~30 second warm-up time for auto-scaled agent instances, you'll need more reserved capacity
-
-3. **Cold Start Tolerance**: How important is immediate response for your use case?
+1. Trigger on every push to the `main` branch
+2. Create a build context from your repository
+3. Upload it to Pipecat Cloud and build the image server-side
+4. Deploy the new image and wait for readiness
 
 <Tip>
-  Completely avoiding cold starts may not be practical for all applications. We
-  strongly recommend considering longer or variable start up times when building
-  your application. For phone use cases, consider a hold message or for web
-  apps, consider a waiting UX or message.
+  Cloud builds automatically detect and reuse identical build contexts, so
+  re-deploying unchanged code is nearly instant.
 </Tip>
 
-## Cost-Efficient Scaling Strategies
+## Build Caching
 
-- **Development/Testing**: Use `min-agents: 0` to minimize costs during development
-- **Production Voice AI**: Set `min-agents` to cover your baseline traffic to avoid cold starts
-- **Time-Based Scaling**: Consider modifying your reserved count for known high-traffic periods
-- **Cap session duration**: Use [`--max-session-duration`](/api-reference/cli/cloud/deploy#param-max-session-duration) as a safety net against runaway sessions. If your application's calls are meant to be short, setting a tight cap (e.g. 120s for a 60s use case) prevents a buggy bot from racking up hours of charges.
-- **Monitoring**: Regularly review your warm capacity utilization to optimize your configuration
-  <Info>
-    Cold start times vary widely. See
-    [Cold-starts](../fundamentals/scaling#cold-starts) for best-case timing and
-    what can push it to a minute or more.
-  </Info>
+Cloud builds use a content hash of your build context to detect cache hits. If the files haven't changed since the last successful build, the action skips the upload and build entirely and reuses the previous image.
 
-## Calculating Optimal Reserved Agents
+You can also reuse a specific build across workflows with the `build-id` input:
 
-For production deployments where immediate response is essential, you can calculate your optimal reserved agent count using a growth rate approach:
-
-```
-Optimal Reserved = MAX(Baseline Sessions, CPS × Idle Creation Delay)
+```yml
+- name: Deploy to Pipecat Cloud
+  uses: daily-co/pipecat-cloud-deploy-action@v2
+  with:
+    api-key: ${{ secrets.PCC_API_KEY }}
+    agent-name: ${{ github.event.repository.name }}
+    build-id: 14f5a062-7ecd-407a-b5f0-3ebba82e790b
+    secret-set: my-secret-set
 ```
 
-Where:
+## Monorepo Configuration
 
-- **Baseline Sessions**: Minimum concurrent sessions you typically maintain
-- **CPS (Calls Per Second)**: Your expected session growth rate during peak periods
-- **Idle Creation Delay**: Time for new idle agents to become available (~30 seconds)
+If your agent lives in a subdirectory (e.g. `server/`), set the build context and optionally restrict the workflow to that path:
 
-This formula addresses the fundamental challenge: "Can our warm capacity creation keep pace with our call growth rate?" By reserving capacity based on your growth rate and the idle creation delay, you ensure sufficient capacity is available during the critical period before auto-scaling can catch up.
+```yml
+name: Deploy to Pipecat Cloud
 
-### Growth Rate Examples
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "server/**"
 
-Here's how the formula works with different growth rates:
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-| Scenario      | Baseline | CPS                | Idle Creation Delay | Calculation       | Optimal Reserved |
-| ------------- | -------- | ------------------ | ------------------- | ----------------- | ---------------- |
-| High volume   | 10       | 1.0 (1 call/sec)   | 30s                 | MAX(10, 1.0 × 30) | 30               |
-| Medium volume | 10       | 0.5 (1 call/2sec)  | 30s                 | MAX(10, 0.5 × 30) | 15               |
-| Low volume    | 10       | 0.1 (1 call/10sec) | 30s                 | MAX(10, 0.1 × 30) | 10               |
-
-### Call Center Example
-
-Consider a voice AI call center that:
-
-- Normally handles 10 concurrent calls (baseline)
-- During promotions, receives new calls at a rate of 1 call per second
-- Has a 30-second idle creation delay
-
-Applying our formula:
-
-```
-Optimal Reserved = MAX(10, 1 × 30)
-                 = MAX(10, 30)
-                 = 30
+      - name: Build and Deploy to Pipecat Cloud
+        uses: daily-co/pipecat-cloud-deploy-action@v2
+        with:
+          api-key: ${{ secrets.PCC_API_KEY }}
+          agent-name: ${{ github.event.repository.name }}
+          cloud-build: true
+          build-context: ./server
+          dockerfile: Dockerfile
+          secret-set: my-secret-set
 ```
 
-With 30 reserved agents:
+The `paths` filter ensures the workflow runs only when files under `server/` change.
 
-- You can handle the growth rate of 1 call per second for the full 30 seconds until new idle agents start becoming available
-- This prevents any cold starts during the critical catch-up period
-- Auto-scaling will create additional idle agents to handle continued growth
+## Customizing Deployment
 
-### Understanding the Growth Rate Approach
+Configure the deployment via action inputs:
 
-This approach works because:
-
-1. When your call volume starts increasing, you immediately begin consuming your warm capacity
-2. At the same time, each new active call triggers the creation of a new idle agent
-3. However, these new idle agents take ~30 seconds to become available
-4. Your reserved capacity must be sufficient to handle all calls during this 30-second "catch-up period"
-
-### Trading Cost for Performance
-
-The formula provides a starting point, which you can adjust based on your specific needs:
-
-- **Cost-sensitive**: Use a lower reserved count and accept some cold starts during traffic spikes
-- **Performance-sensitive**: Use the calculated reserved count to ensure zero cold starts
-- **Hybrid approach**: Monitor your actual traffic patterns and adjust based on real-world performance
+- **secret-set**: Name of the secret set used for runtime environment variables
+- **region**: Deployment region (uses your organization default if omitted)
+- **min-agents**: Minimum agents to keep warm (0–50)
+- **max-agents**: Maximum concurrent agents (1–50)
+- **agent-profile**: Agent profile name, if used
+- **wait-for-ready**: Whether to poll until the deployment is ready (default: true)
+- **wait-timeout**: Max seconds to wait for readiness (default: 90)
 
 <Tip>
-  For most production voice AI applications, we recommend using at least the
-  calculated optimal reserved agent count during business hours or peak usage
-  periods, and then scaling down during off-hours to optimize costs.
+  Tune `min-agents` and `max-agents` based on your traffic. See the [Capacity
+  Planning guide](./capacity-planning) for guidance.
 </Tip>
 
-## Summary and Next Steps
+## Deploying from Your Own Container Registry
 
-Proper capacity planning ensures your agents are always ready to respond immediately, providing the best possible user experience while optimizing costs:
+If you host images in your own container registry (e.g. Docker Hub, AWS ECR, GHCR), you can skip the cloud build and deploy a fully tagged image directly:
 
-1. **Understand your traffic patterns**: Baseline sessions, peak sessions, and growth rate
-2. **Calculate your optimal reserved agents**: Use the formula to determine the right level of warm capacity
-3. **Monitor and adjust**: Refine your capacity planning based on real-world performance and costs
+```yml
+- name: Deploy to Pipecat Cloud
+  uses: daily-co/pipecat-cloud-deploy-action@v2
+  with:
+    api-key: ${{ secrets.PCC_API_KEY }}
+    agent-name: ${{ github.event.repository.name }}
+    image: my-registry.example.com/my-agent:v1.2.3
+    image-credentials: my-image-pull-secret
+    secret-set: my-secret-set
+```
+
+<Note>
+  When deploying a pre-built image, you must provide an `image-credentials`
+  reference if the image is in a private registry. Pipecat Cloud requires images
+  built for `linux/arm64`.
+</Note>
+
+## Using v1 with Docker Build
+
+<Note>
+  **v1 is still available** for users who need the action to run `docker build`
+  and push to their own container registry. However, we recommend upgrading to
+  v2 with cloud builds for a simpler setup.
+</Note>
+
+The v1 action can build, tag, and push Docker images as part of the workflow. This requires registry credentials and the `packages: write` permission (for GHCR):
+
+```yml
+- name: Build and Deploy to Pipecat Cloud
+  uses: daily-co/pipecat-cloud-deploy-action@v1
+  with:
+    api-key: ${{ secrets.PCC_API_KEY }}
+    agent-name: ${{ github.event.repository.name }}
+    build: true
+    image: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
+    registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+    registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
+    secret-set: my-secret-set
+    image-credentials: my-image-pull-secret
+```
+
+See the [v1 README](https://github.com/daily-co/pipecat-cloud-deploy-action/tree/v1#readme) for full documentation of v1 inputs.
+
+## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Explore Scaling Options" icon="server" href="../fundamentals/scaling">
-    Learn more about scaling configuration options and deployment strategies.
+  <Card title="Secrets Management" icon="key" href="../fundamentals/secrets">
+    Learn how to securely manage image pull secrets and environment variables.
   </Card>
 
-  <Card title="Deploy Your Agent" icon="rocket" href="../fundamentals/deploy">
-    Apply your capacity planning knowledge to your agent deployment.
+  <Card title="Scaling Configuration" icon="chart-line" href="../fundamentals/scaling">
+    Configure auto-scaling to handle varying traffic loads.
   </Card>
 </CardGroup>
 
@@ -26576,197 +26598,177 @@ Replace the following placeholders with your actual values:
   private repository.
 </Note>
 
-# Pipecat Cloud CI with GitHub Actions
-Source: https://docs.pipecat.ai/pipecat-cloud/guides/ci-with-github-actions.md
+# Pipecat Cloud Capacity Planning
+Source: https://docs.pipecat.ai/pipecat-cloud/guides/capacity-planning.md
 
-Automate Pipecat Cloud builds and deploys from CI using the official pipecat-ai GitHub Action in your workflow.
+Plan Pipecat Cloud capacity to minimize cold starts: auto-scaling behavior, the min-agents parameter, and sizing for call volume.
 
-This guide shows you how to automate Pipecat Cloud deployments from GitHub Actions using the official [Deploy to Pipecat Cloud](https://github.com/daily-co/pipecat-cloud-deploy-action) action.
+## Overview
 
-<Note>
-  If you only need push-to-deploy, the [GitHub
-  integration](/pipecat-cloud/guides/deploy-from-github) does that with no
-  workflow file and no API key to manage. Reach for a GitHub Actions workflow
-  when a deploy has to run tests, wait on an approval, or do custom steps.
-</Note>
+By default, Pipecat Cloud auto-scales your agent to help minimize the likelihood that your agents experience a cold start. For many applications, you can simply set the `--min-agents` parameter to 1 in order to avoid scaling from zero and let Pipecat Cloud handle the rest.
 
-## Prerequisites
+However, for applications where traffic can fluctuate, you may need to plan for additional warm capacity to ensure your agents are always ready to respond immediately. For those cases, this guide will help you understand how warm capacity works in Pipecat Cloud, when you need to plan to use reserves, and how you can optimize your plan for both performance and cost.
 
-Before setting up your workflow, ensure you have:
+## Agent Types
 
-- A Pipecat Cloud account with a **Private** API key
-- A secret set configured for your agent
+Before discussing capacity planning, it's important to understand the different types of agent instances in Pipecat Cloud:
 
-## Configure GitHub Secrets
+- **Active Agents**: Agent instances currently running and handling user sessions.
+- **Idle Agents**: When you start an active agent, Pipecat Cloud automatically provisions an additional idle agent to help with scaling. These take approximately 30 seconds to become available, though this time may vary based on system load and image size. You are not charged for these idle agents.
+- **Reserved Agents**: Agent instances maintained according to your `--min-agents` deployment setting, ensuring immediate availability regardless of current traffic.
 
-Add the following secret to your repository (Settings → Secrets and variables → Actions):
+## Understanding Warm Capacity
 
-- `PCC_API_KEY`: Your Pipecat Cloud **Private** API key
+Your "warm capacity" represents agent instances that are immediately available to handle new sessions without a cold start. Pipecat Cloud automatically manages this based on:
 
-## Basic Workflow — Cloud Build
+1. Your configured **reserved agents** (`min-agents`)
+2. Your current **active sessions**
+3. Automatically provisioned **idle agents**
 
-The simplest setup uses [cloud builds](./cloud-builds) to build your image server-side. No Docker, no container registry, no extra infrastructure.
+The system ensures you always have the following warm capacity available:
 
-Create `.github/workflows/deploy.yml` in your repository:
+- When **Reserved > Active**: Your warm capacity equals the number of **Reserved Agents**
+- When **Active ≥ Reserved**: Your warm capacity equals the number of **Active Agents** (through automatically provisioned idle agents)
 
-```yml
-name: Deploy to Pipecat Cloud
+To illustrate the point, here are a few scenarios showing how warm capacity works:
 
-on:
-  push:
-    branches: ["main"]
+| Reserved | Active | Warm Capacity |
+| -------- | ------ | ------------- |
+| 10       | 1      | 10            |
+| 10       | 10     | 10            |
+| 1        | 10     | 10            |
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+This shows how:
 
-      - name: Build and Deploy to Pipecat Cloud
-        uses: daily-co/pipecat-cloud-deploy-action@v2
-        with:
-          api-key: ${{ secrets.PCC_API_KEY }}
-          agent-name: ${{ github.event.repository.name }}
-          cloud-build: true
-          secret-set: my-secret-set
-          region: us-east
-```
+- Reserved agents provide a guaranteed minimum warm capacity
+- As active sessions increase beyond your reserved count, your warm capacity grows to match through automatically provisioned idle agents
 
-This workflow will:
+## Agent Cooldown
 
-1. Trigger on every push to the `main` branch
-2. Create a build context from your repository
-3. Upload it to Pipecat Cloud and build the image server-side
-4. Deploy the new image and wait for readiness
+When an active session ends, the agent instance behavior is governed by a cooldown period:
 
-<Tip>
-  Cloud builds automatically detect and reuse identical build contexts, so
-  re-deploying unchanged code is nearly instant.
-</Tip>
+- The agent instance remains available in your warm capacity pool for a 5-minute cooldown period
+- During this time, it can immediately serve another request without any cold start
+- After the 5-minute cooldown expires, if the agent instance hasn't been used, it will be terminated
+- This cooldown provides a buffer in your warm capacity pool, helping to smooth transitions between traffic peaks
 
-## Build Caching
+## Planning for Traffic Patterns
 
-Cloud builds use a content hash of your build context to detect cache hits. If the files haven't changed since the last successful build, the action skips the upload and build entirely and reuses the previous image.
+To determine the optimal reserved instance count for your deployment, consider:
 
-You can also reuse a specific build across workflows with the `build-id` input:
+1. **Peak Concurrent Sessions**: How many simultaneous sessions do you expect during peak periods?
 
-```yml
-- name: Deploy to Pipecat Cloud
-  uses: daily-co/pipecat-cloud-deploy-action@v2
-  with:
-    api-key: ${{ secrets.PCC_API_KEY }}
-    agent-name: ${{ github.event.repository.name }}
-    build-id: 14f5a062-7ecd-407a-b5f0-3ebba82e790b
-    secret-set: my-secret-set
-```
+2. **Growth Rate**: How quickly do new sessions start during peak periods?
+   - If new sessions start faster than the ~30 second warm-up time for auto-scaled agent instances, you'll need more reserved capacity
 
-## Monorepo Configuration
-
-If your agent lives in a subdirectory (e.g. `server/`), set the build context and optionally restrict the workflow to that path:
-
-```yml
-name: Deploy to Pipecat Cloud
-
-on:
-  push:
-    branches: ["main"]
-    paths:
-      - "server/**"
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Build and Deploy to Pipecat Cloud
-        uses: daily-co/pipecat-cloud-deploy-action@v2
-        with:
-          api-key: ${{ secrets.PCC_API_KEY }}
-          agent-name: ${{ github.event.repository.name }}
-          cloud-build: true
-          build-context: ./server
-          dockerfile: Dockerfile
-          secret-set: my-secret-set
-```
-
-The `paths` filter ensures the workflow runs only when files under `server/` change.
-
-## Customizing Deployment
-
-Configure the deployment via action inputs:
-
-- **secret-set**: Name of the secret set used for runtime environment variables
-- **region**: Deployment region (uses your organization default if omitted)
-- **min-agents**: Minimum agents to keep warm (0–50)
-- **max-agents**: Maximum concurrent agents (1–50)
-- **agent-profile**: Agent profile name, if used
-- **wait-for-ready**: Whether to poll until the deployment is ready (default: true)
-- **wait-timeout**: Max seconds to wait for readiness (default: 90)
+3. **Cold Start Tolerance**: How important is immediate response for your use case?
 
 <Tip>
-  Tune `min-agents` and `max-agents` based on your traffic. See the [Capacity
-  Planning guide](./capacity-planning) for guidance.
+  Completely avoiding cold starts may not be practical for all applications. We
+  strongly recommend considering longer or variable start up times when building
+  your application. For phone use cases, consider a hold message or for web
+  apps, consider a waiting UX or message.
 </Tip>
 
-## Deploying from Your Own Container Registry
+## Cost-Efficient Scaling Strategies
 
-If you host images in your own container registry (e.g. Docker Hub, AWS ECR, GHCR), you can skip the cloud build and deploy a fully tagged image directly:
+- **Development/Testing**: Use `min-agents: 0` to minimize costs during development
+- **Production Voice AI**: Set `min-agents` to cover your baseline traffic to avoid cold starts
+- **Time-Based Scaling**: Consider modifying your reserved count for known high-traffic periods
+- **Cap session duration**: Use [`--max-session-duration`](/api-reference/cli/cloud/deploy#param-max-session-duration) as a safety net against runaway sessions. If your application's calls are meant to be short, setting a tight cap (e.g. 120s for a 60s use case) prevents a buggy bot from racking up hours of charges.
+- **Monitoring**: Regularly review your warm capacity utilization to optimize your configuration
+  <Info>
+    Cold start times vary widely. See
+    [Cold-starts](../fundamentals/scaling#cold-starts) for best-case timing and
+    what can push it to a minute or more.
+  </Info>
 
-```yml
-- name: Deploy to Pipecat Cloud
-  uses: daily-co/pipecat-cloud-deploy-action@v2
-  with:
-    api-key: ${{ secrets.PCC_API_KEY }}
-    agent-name: ${{ github.event.repository.name }}
-    image: my-registry.example.com/my-agent:v1.2.3
-    image-credentials: my-image-pull-secret
-    secret-set: my-secret-set
+## Calculating Optimal Reserved Agents
+
+For production deployments where immediate response is essential, you can calculate your optimal reserved agent count using a growth rate approach:
+
+```
+Optimal Reserved = MAX(Baseline Sessions, CPS × Idle Creation Delay)
 ```
 
-<Note>
-  When deploying a pre-built image, you must provide an `image-credentials`
-  reference if the image is in a private registry. Pipecat Cloud requires images
-  built for `linux/arm64`.
-</Note>
+Where:
 
-## Using v1 with Docker Build
+- **Baseline Sessions**: Minimum concurrent sessions you typically maintain
+- **CPS (Calls Per Second)**: Your expected session growth rate during peak periods
+- **Idle Creation Delay**: Time for new idle agents to become available (~30 seconds)
 
-<Note>
-  **v1 is still available** for users who need the action to run `docker build`
-  and push to their own container registry. However, we recommend upgrading to
-  v2 with cloud builds for a simpler setup.
-</Note>
+This formula addresses the fundamental challenge: "Can our warm capacity creation keep pace with our call growth rate?" By reserving capacity based on your growth rate and the idle creation delay, you ensure sufficient capacity is available during the critical period before auto-scaling can catch up.
 
-The v1 action can build, tag, and push Docker images as part of the workflow. This requires registry credentials and the `packages: write` permission (for GHCR):
+### Growth Rate Examples
 
-```yml
-- name: Build and Deploy to Pipecat Cloud
-  uses: daily-co/pipecat-cloud-deploy-action@v1
-  with:
-    api-key: ${{ secrets.PCC_API_KEY }}
-    agent-name: ${{ github.event.repository.name }}
-    build: true
-    image: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
-    registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
-    registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
-    secret-set: my-secret-set
-    image-credentials: my-image-pull-secret
+Here's how the formula works with different growth rates:
+
+| Scenario      | Baseline | CPS                | Idle Creation Delay | Calculation       | Optimal Reserved |
+| ------------- | -------- | ------------------ | ------------------- | ----------------- | ---------------- |
+| High volume   | 10       | 1.0 (1 call/sec)   | 30s                 | MAX(10, 1.0 × 30) | 30               |
+| Medium volume | 10       | 0.5 (1 call/2sec)  | 30s                 | MAX(10, 0.5 × 30) | 15               |
+| Low volume    | 10       | 0.1 (1 call/10sec) | 30s                 | MAX(10, 0.1 × 30) | 10               |
+
+### Call Center Example
+
+Consider a voice AI call center that:
+
+- Normally handles 10 concurrent calls (baseline)
+- During promotions, receives new calls at a rate of 1 call per second
+- Has a 30-second idle creation delay
+
+Applying our formula:
+
+```
+Optimal Reserved = MAX(10, 1 × 30)
+                 = MAX(10, 30)
+                 = 30
 ```
 
-See the [v1 README](https://github.com/daily-co/pipecat-cloud-deploy-action/tree/v1#readme) for full documentation of v1 inputs.
+With 30 reserved agents:
 
-## Next Steps
+- You can handle the growth rate of 1 call per second for the full 30 seconds until new idle agents start becoming available
+- This prevents any cold starts during the critical catch-up period
+- Auto-scaling will create additional idle agents to handle continued growth
+
+### Understanding the Growth Rate Approach
+
+This approach works because:
+
+1. When your call volume starts increasing, you immediately begin consuming your warm capacity
+2. At the same time, each new active call triggers the creation of a new idle agent
+3. However, these new idle agents take ~30 seconds to become available
+4. Your reserved capacity must be sufficient to handle all calls during this 30-second "catch-up period"
+
+### Trading Cost for Performance
+
+The formula provides a starting point, which you can adjust based on your specific needs:
+
+- **Cost-sensitive**: Use a lower reserved count and accept some cold starts during traffic spikes
+- **Performance-sensitive**: Use the calculated reserved count to ensure zero cold starts
+- **Hybrid approach**: Monitor your actual traffic patterns and adjust based on real-world performance
+
+<Tip>
+  For most production voice AI applications, we recommend using at least the
+  calculated optimal reserved agent count during business hours or peak usage
+  periods, and then scaling down during off-hours to optimize costs.
+</Tip>
+
+## Summary and Next Steps
+
+Proper capacity planning ensures your agents are always ready to respond immediately, providing the best possible user experience while optimizing costs:
+
+1. **Understand your traffic patterns**: Baseline sessions, peak sessions, and growth rate
+2. **Calculate your optimal reserved agents**: Use the formula to determine the right level of warm capacity
+3. **Monitor and adjust**: Refine your capacity planning based on real-world performance and costs
 
 <CardGroup cols={2}>
-  <Card title="Secrets Management" icon="key" href="../fundamentals/secrets">
-    Learn how to securely manage image pull secrets and environment variables.
+  <Card title="Explore Scaling Options" icon="server" href="../fundamentals/scaling">
+    Learn more about scaling configuration options and deployment strategies.
   </Card>
 
-  <Card title="Scaling Configuration" icon="chart-line" href="../fundamentals/scaling">
-    Configure auto-scaling to handle varying traffic loads.
+  <Card title="Deploy Your Agent" icon="rocket" href="../fundamentals/deploy">
+    Apply your capacity planning knowledge to your agent deployment.
   </Card>
 </CardGroup>
 

--- a/llms.txt
+++ b/llms.txt
@@ -223,17 +223,19 @@ LLM, transports, serializers), pipelines, frames, workers, and utilities.
 
 ### Guides
 
+#### Building & Deploying
+
 - [Pipecat Cloud Builds](https://docs.pipecat.ai/pipecat-cloud/guides/cloud-builds.md): Build and deploy agents on Pipecat Cloud without managing your own container registry, using the hosted build service.
 - [Deploy from GitHub](https://docs.pipecat.ai/pipecat-cloud/guides/deploy-from-github.md): Connect the Pipecat Cloud GitHub App to deploy agents from a repository branch, with deploy on push, manual deploys, and commit tracking.
-- [Pipecat Cloud Capacity Planning](https://docs.pipecat.ai/pipecat-cloud/guides/capacity-planning.md): Plan Pipecat Cloud capacity to minimize cold starts: auto-scaling behavior, the min-agents parameter, and sizing for call volume.
+- [Pipecat Cloud CI with GitHub Actions](https://docs.pipecat.ai/pipecat-cloud/guides/ci-with-github-actions.md): Automate Pipecat Cloud builds and deploys from CI using the official pipecat-ai GitHub Action in your workflow.
 
-#### Container Registries
+##### Container Registries
 
 - [Pipecat Cloud Container Registries](https://docs.pipecat.ai/pipecat-cloud/guides/container-registries/overview.md): Deploy Pipecat Cloud agents from private container registries: supported registries, image pull credentials, and setup guides.
 - [Deploy from Docker Hub](https://docs.pipecat.ai/pipecat-cloud/guides/container-registries/docker-hub.md): Deploy Pipecat Cloud agents from Docker Hub: pushing your agent image, access tokens, and private repository configuration.
 - [Deploy from AWS ECR](https://docs.pipecat.ai/pipecat-cloud/guides/container-registries/aws-ecr.md): Deploy Pipecat Cloud agents from Amazon Elastic Container Registry: ECR authentication, image pull secrets, and configuration.
 - [Deploy from GCP Artifact Registry](https://docs.pipecat.ai/pipecat-cloud/guides/container-registries/gcp-artifact-registry.md): Deploy Pipecat Cloud agents from Google Cloud Artifact Registry: service account keys, image paths, and pull configuration.
-- [Pipecat Cloud CI with GitHub Actions](https://docs.pipecat.ai/pipecat-cloud/guides/ci-with-github-actions.md): Automate Pipecat Cloud builds and deploys from CI using the official pipecat-ai GitHub Action in your workflow.
+- [Pipecat Cloud Capacity Planning](https://docs.pipecat.ai/pipecat-cloud/guides/capacity-planning.md): Plan Pipecat Cloud capacity to minimize cold starts: auto-scaling behavior, the min-agents parameter, and sizing for call volume.
 - [Pipecat Cloud Personal Access Tokens](https://docs.pipecat.ai/pipecat-cloud/guides/personal-access-tokens.md): Authenticate CI/CD pipelines and automation against Pipecat Cloud with non-interactive personal access tokens (PATs).
 - [Pipecat Cloud Daily WebRTC](https://docs.pipecat.ai/pipecat-cloud/guides/daily-webrtc.md): Use Daily as the WebRTC transport for Pipecat Cloud agents: room creation, tokens, and connecting clients to agent sessions.
 - [Krisp VIVA on Pipecat Cloud](https://docs.pipecat.ai/pipecat-cloud/guides/krisp-viva.md): Enable Krisp VIVA voice isolation on Pipecat Cloud to remove background noise and voices for more reliable agent conversations.

--- a/llms.txt
+++ b/llms.txt
@@ -224,6 +224,7 @@ LLM, transports, serializers), pipelines, frames, workers, and utilities.
 ### Guides
 
 - [Pipecat Cloud Builds](https://docs.pipecat.ai/pipecat-cloud/guides/cloud-builds.md): Build and deploy agents on Pipecat Cloud without managing your own container registry, using the hosted build service.
+- [Deploy from GitHub](https://docs.pipecat.ai/pipecat-cloud/guides/deploy-from-github.md): Connect the Pipecat Cloud GitHub App to deploy agents from a repository branch, with deploy on push, manual deploys, and commit tracking.
 - [Pipecat Cloud Capacity Planning](https://docs.pipecat.ai/pipecat-cloud/guides/capacity-planning.md): Plan Pipecat Cloud capacity to minimize cold starts: auto-scaling behavior, the min-agents parameter, and sizing for call volume.
 
 #### Container Registries

--- a/pipecat-cloud/fundamentals/deploy.mdx
+++ b/pipecat-cloud/fundamentals/deploy.mdx
@@ -4,6 +4,19 @@ sidebarTitle: "Deployments"
 description: "Deploy agents with the pipecat cloud deploy CLI command: cloud image builds from your Dockerfile and deployment configuration."
 ---
 
+## Choosing a deployment method
+
+Pipecat Cloud gives you four ways to ship an agent. The first three build the image for you from a `Dockerfile` in your project; the fourth deploys an image you built and pushed yourself.
+
+| Method                                        | Best for                                                                                                                                           |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **CLI cloud builds** (`pipecat cloud deploy`) | Deploying from your laptop, or from a script that already has the CLI. See [Cloud Builds](/pipecat-cloud/guides/cloud-builds).                     |
+| **GitHub integration**                        | Push-to-deploy with no CI setup and no API key to manage. See [Deploy from GitHub](/pipecat-cloud/guides/deploy-from-github).                      |
+| **GitHub Actions**                            | Pipelines that need tests, approvals, or custom steps before a deploy. See [CI with GitHub Actions](/pipecat-cloud/guides/ci-with-github-actions). |
+| **Your own container registry**               | Reusing an image your existing build pipeline already produces. See [Container Registries](/pipecat-cloud/guides/container-registries/overview).   |
+
+You can mix them. An agent connected to a GitHub repository can still be deployed with the CLI, though the next push to the connected branch will deploy over it.
+
 ## Deploying an agent
 
 Deploy your agent to Pipecat Cloud with a single command:
@@ -13,12 +26,6 @@ pipecat cloud deploy
 ```
 
 The CLI builds your image in the cloud from your project's Dockerfile and deploys it - no container registry setup needed. For more details on how cloud builds work, see the [Cloud Builds guide](/pipecat-cloud/guides/cloud-builds).
-
-<Tip>
-  Prefer not to deploy by hand? Connect a GitHub repository to your agent and
-  every push to the connected branch deploys it. See [Deploy from
-  GitHub](/pipecat-cloud/guides/deploy-from-github).
-</Tip>
 
 ### Deploying to a specific region
 

--- a/pipecat-cloud/fundamentals/deploy.mdx
+++ b/pipecat-cloud/fundamentals/deploy.mdx
@@ -14,6 +14,12 @@ pipecat cloud deploy
 
 The CLI builds your image in the cloud from your project's Dockerfile and deploys it - no container registry setup needed. For more details on how cloud builds work, see the [Cloud Builds guide](/pipecat-cloud/guides/cloud-builds).
 
+<Tip>
+  Prefer not to deploy by hand? Connect a GitHub repository to your agent and
+  every push to the connected branch deploys it. See [Deploy from
+  GitHub](/pipecat-cloud/guides/deploy-from-github).
+</Tip>
+
 ### Deploying to a specific region
 
 Agents deploy to your organization's default region, which is `us-west` by default. You can deploy to a specific region to reduce latency or meet data residency requirements:

--- a/pipecat-cloud/guides/ci-with-github-actions.mdx
+++ b/pipecat-cloud/guides/ci-with-github-actions.mdx
@@ -6,6 +6,13 @@ description: "Automate Pipecat Cloud builds and deploys from CI using the offici
 
 This guide shows you how to automate Pipecat Cloud deployments from GitHub Actions using the official [Deploy to Pipecat Cloud](https://github.com/daily-co/pipecat-cloud-deploy-action) action.
 
+<Note>
+  If you only need push-to-deploy, the [GitHub
+  integration](/pipecat-cloud/guides/deploy-from-github) does that with no
+  workflow file and no API key to manage. Reach for a GitHub Actions workflow
+  when a deploy has to run tests, wait on an approval, or do custom steps.
+</Note>
+
 ## Prerequisites
 
 Before setting up your workflow, ensure you have:

--- a/pipecat-cloud/guides/cloud-builds.mdx
+++ b/pipecat-cloud/guides/cloud-builds.mdx
@@ -9,7 +9,7 @@ Pipecat Cloud Build lets you deploy agents directly from your source code. Inste
 <Tip>
   The same build service backs the [GitHub
   integration](/pipecat-cloud/guides/deploy-from-github), which builds and
-  deploys your agent on every push to a connected branch — no CLI required.
+  deploys your agent on every push to a connected branch.
 </Tip>
 
 ## Prerequisites

--- a/pipecat-cloud/guides/cloud-builds.mdx
+++ b/pipecat-cloud/guides/cloud-builds.mdx
@@ -6,6 +6,12 @@ description: "Build and deploy agents on Pipecat Cloud without managing your own
 
 Pipecat Cloud Build lets you deploy agents directly from your source code. Instead of building Docker images locally and pushing them to a registry, just run `pipecat cloud deploy` and the CLI handles everything.
 
+<Tip>
+  The same build service backs the [GitHub
+  integration](/pipecat-cloud/guides/deploy-from-github), which builds and
+  deploys your agent on every push to a connected branch — no CLI required.
+</Tip>
+
 ## Prerequisites
 
 - A [Pipecat Cloud account](/pipecat-cloud/fundamentals/accounts-and-organizations) with an active organization

--- a/pipecat-cloud/guides/cloud-builds.mdx
+++ b/pipecat-cloud/guides/cloud-builds.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Pipecat Cloud Builds"
-sidebarTitle: "Cloud Builds"
+sidebarTitle: "Deploy with the CLI"
 description: "Build and deploy agents on Pipecat Cloud without managing your own container registry, using the hosted build service."
 ---
 

--- a/pipecat-cloud/guides/deploy-from-github.mdx
+++ b/pipecat-cloud/guides/deploy-from-github.mdx
@@ -1,17 +1,13 @@
 ---
 title: "Deploy from GitHub"
-sidebarTitle: "GitHub"
 description: "Connect the Pipecat Cloud GitHub App to deploy agents from a repository branch, with deploy on push, manual deploys, and commit tracking."
 ---
 
 Connect a GitHub repository to an agent and Pipecat Cloud builds and deploys it for you. Push to the connected branch and your agent updates — no Docker build, no registry, no CI workflow to maintain.
 
+{/* prettier-ignore */}
 <Info>
-  This guide sets the integration up in the [Pipecat Cloud dashboard
-  <Icon icon="arrow-up-right-from-square" iconType="solid" />
-  ](https://pipecat.daily.co). Deploys use [cloud
-  builds](/pipecat-cloud/guides/cloud-builds) under the hood, so your project
-  needs a `Dockerfile`.
+  This guide sets the integration up in the [Pipecat Cloud dashboard <Icon icon="arrow-up-right-from-square" iconType="solid" />](https://pipecat.daily.co). Deploys use [cloud builds](/pipecat-cloud/guides/cloud-builds) under the hood, so your project needs a `Dockerfile`.
 </Info>
 
 <Note>

--- a/pipecat-cloud/guides/deploy-from-github.mdx
+++ b/pipecat-cloud/guides/deploy-from-github.mdx
@@ -1,0 +1,159 @@
+---
+title: "Deploy from GitHub"
+sidebarTitle: "GitHub"
+description: "Connect the Pipecat Cloud GitHub App to deploy agents from a repository branch, with deploy on push, manual deploys, and commit tracking."
+---
+
+Connect a GitHub repository to an agent and Pipecat Cloud builds and deploys it for you. Push to the connected branch and your agent updates — no Docker build, no registry, no CI workflow to maintain.
+
+<Info>
+  The GitHub integration is configured from the [Pipecat Cloud dashboard{" "}
+  <Icon icon="arrow-up-right-from-square" iconType="solid" />
+  ](https://pipecat.daily.co). Deploys still use [cloud
+  builds](/pipecat-cloud/guides/cloud-builds) under the hood, so your project
+  needs a `Dockerfile`.
+</Info>
+
+## Choosing a deployment method
+
+Pipecat Cloud gives you three ways to ship an agent. They all end up building the same image:
+
+| Method                                                         | Best for                                                               |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **GitHub integration** (this guide)                            | Push-to-deploy with no CI setup. Configured entirely in the dashboard. |
+| [CLI cloud builds](/pipecat-cloud/guides/cloud-builds)         | Deploying from your laptop, or from a script that already has the CLI. |
+| [GitHub Actions](/pipecat-cloud/guides/ci-with-github-actions) | Pipelines that need tests, approvals, or custom steps before a deploy. |
+
+You can mix them. An agent connected to a repository can still be deployed with the CLI, though the next push to the connected branch will deploy over it.
+
+## Prerequisites
+
+- A [Pipecat Cloud account](/pipecat-cloud/fundamentals/accounts-and-organizations) with an active organization
+- A GitHub repository containing your agent, with a `Dockerfile` at the repository root (or at a path you specify)
+- Permission to install a GitHub App on the account or organization that owns the repository
+
+## Connect your GitHub account
+
+The GitHub App is installed once per Pipecat Cloud organization, and every agent in that organization shares it.
+
+<Steps>
+  <Step title="Open GitHub settings">
+    In the dashboard, go to **Settings → GitHub**.
+  </Step>
+  <Step title="Install the app">
+    Click **Connect GitHub**. A new tab opens GitHub's installation screen,
+    where you choose the account or organization to install into and which
+    repositories to grant access to — all of them, or a hand-picked list.
+  </Step>
+  <Step title="Return to the dashboard">
+    Once you approve the install, the dashboard picks up the connection
+    automatically and shows the connected account.
+  </Step>
+</Steps>
+
+<Tip>
+  Granting access to only the repositories you deploy from is the safer default.
+  You can change the selection later from **Manage on GitHub** without
+  reconnecting.
+</Tip>
+
+## Deploy a new agent from a repository
+
+When you create an agent, choose **GitHub** as the source:
+
+<Steps>
+  <Step title="Pick the repository">
+    Select any repository the installation can see. Private repositories are
+    supported.
+  </Step>
+  <Step title="Pick the branch">
+    The repository's default branch is preselected. Search to find any other
+    branch.
+  </Step>
+  <Step title="Set the Dockerfile path (optional)">
+    Defaults to `Dockerfile` at the repository root. Set a path such as
+    `docker/Dockerfile` if yours lives elsewhere.
+  </Step>
+</Steps>
+
+Creating the agent builds the branch's current commit and deploys it.
+
+## Connect an existing agent
+
+Agents that already run a Docker image can be moved onto GitHub deploys at any time.
+
+Go to your agent's **Settings → GitHub** tab and pick a repository, branch, and Dockerfile path.
+
+<Note>
+  Linking a repository does not deploy anything. The agent keeps serving its
+  current image until the next push to the connected branch, or until you deploy
+  manually. This lets you connect a repository and choose your moment.
+</Note>
+
+## Deploy on push
+
+**Deploy on push** is on by default. With it enabled, every push to the connected branch builds that commit and rolls it out.
+
+Pushes to any other branch are ignored — only the branch you connected triggers a deploy.
+
+Turn it off from the agent's **Settings → GitHub** tab when you want to control the timing yourself, for example while you're stabilizing a branch.
+
+## Deploy manually
+
+The **Deploy** button on the agent's GitHub settings builds and deploys the connected branch's current `HEAD`. It works whether or not deploy on push is enabled, and it's the way to ship a change when it's off.
+
+Deploys are queued: the button returns as soon as the build is accepted, and progress shows up in the agent's deployment history and on the [Builds](/pipecat-cloud/guides/cloud-builds) page.
+
+## See what's running
+
+An agent deployed from GitHub shows its source and the exact commit it is running — on the agent overview and in the agents list — linked back to that commit on GitHub.
+
+The commit that's running and the branch that's connected can legitimately differ: right after you link a repository, after you re-point an agent at a different repository or branch, or when deploy on push is off and there are unshipped commits. The dashboard says so and offers a deploy when that's the case.
+
+## Change or remove a connection
+
+<AccordionGroup>
+  <Accordion title="Switch branch or repository">
+    Edit the repository, branch, or Dockerfile path on the agent's **Settings →
+    GitHub** tab and save. The running deployment is untouched until the next
+    deploy.
+  </Accordion>
+  <Accordion title="Unlink one agent">
+    **Unlink** removes the agent's connection to the repository. Pushes stop
+    deploying it, and its current deployment stays live.
+  </Accordion>
+  <Accordion title="Disconnect the organization">
+    **Disconnect** on **Settings → GitHub** removes the installation and every
+    repository link in the organization. Connected agents stop auto-deploying
+    and keep running what they last deployed. This does not uninstall the app on
+    GitHub — do that from GitHub if you want to revoke access entirely.
+  </Accordion>
+</AccordionGroup>
+
+## Things to know
+
+- **One agent per repository and branch.** A given repository and branch pair can be connected to a single agent. Use a different branch, or a different repository, for a second agent.
+- **Each agent connects to one branch.** To run staging and production from one repository, create two agents and connect each to its own branch.
+- **A `Dockerfile` is required.** The build follows the same path as [cloud builds](/pipecat-cloud/guides/cloud-builds). Run `pipecat init` to scaffold a project that already has one.
+- **Secrets are configured in Pipecat Cloud**, not in your repository. See [Secrets](/pipecat-cloud/fundamentals/secrets).
+- **A suspended installation stops deploys.** If the app is suspended on GitHub, the dashboard flags it; reinstate it from GitHub to resume.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="A repository is missing from the picker">
+    The installation can only see repositories you granted it. Open **Settings →
+    GitHub → Manage on GitHub** and add the repository to the installation's
+    access list.
+  </Accordion>
+  <Accordion title="A push didn't deploy">
+    Check that the push went to the connected branch, that **Deploy on push** is
+    enabled on the agent, and that the installation isn't suspended on GitHub.
+  </Accordion>
+  <Accordion title="The build failed">
+    Build logs are on the agent's deployment history. The most common causes are
+    a `Dockerfile` path that doesn't match the repository and a build that
+    succeeds locally but not from a clean checkout — check that everything the
+    build needs is committed.
+  </Accordion>
+</AccordionGroup>

--- a/pipecat-cloud/guides/deploy-from-github.mdx
+++ b/pipecat-cloud/guides/deploy-from-github.mdx
@@ -7,9 +7,9 @@ description: "Connect the Pipecat Cloud GitHub App to deploy agents from a repos
 Connect a GitHub repository to an agent and Pipecat Cloud builds and deploys it for you. Push to the connected branch and your agent updates — no Docker build, no registry, no CI workflow to maintain.
 
 <Info>
-  The GitHub integration is configured from the [Pipecat Cloud dashboard{" "}
+  This guide sets the integration up in the [Pipecat Cloud dashboard{" "}
   <Icon icon="arrow-up-right-from-square" iconType="solid" />
-  ](https://pipecat.daily.co). Deploys still use [cloud
+  ](https://pipecat.daily.co). Deploys use [cloud
   builds](/pipecat-cloud/guides/cloud-builds) under the hood, so your project
   needs a `Dockerfile`.
 </Info>
@@ -20,7 +20,7 @@ Pipecat Cloud gives you three ways to ship an agent. They all end up building th
 
 | Method                                                         | Best for                                                               |
 | -------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| **GitHub integration** (this guide)                            | Push-to-deploy with no CI setup. Configured entirely in the dashboard. |
+| **GitHub integration** (this guide)                            | Push-to-deploy with no CI setup and no API key to manage.              |
 | [CLI cloud builds](/pipecat-cloud/guides/cloud-builds)         | Deploying from your laptop, or from a script that already has the CLI. |
 | [GitHub Actions](/pipecat-cloud/guides/ci-with-github-actions) | Pipelines that need tests, approvals, or custom steps before a deploy. |
 

--- a/pipecat-cloud/guides/deploy-from-github.mdx
+++ b/pipecat-cloud/guides/deploy-from-github.mdx
@@ -7,24 +7,19 @@ description: "Connect the Pipecat Cloud GitHub App to deploy agents from a repos
 Connect a GitHub repository to an agent and Pipecat Cloud builds and deploys it for you. Push to the connected branch and your agent updates — no Docker build, no registry, no CI workflow to maintain.
 
 <Info>
-  This guide sets the integration up in the [Pipecat Cloud dashboard{" "}
+  This guide sets the integration up in the [Pipecat Cloud dashboard
   <Icon icon="arrow-up-right-from-square" iconType="solid" />
   ](https://pipecat.daily.co). Deploys use [cloud
   builds](/pipecat-cloud/guides/cloud-builds) under the hood, so your project
   needs a `Dockerfile`.
 </Info>
 
-## Choosing a deployment method
-
-Pipecat Cloud gives you three ways to ship an agent. They all end up building the same image:
-
-| Method                                                         | Best for                                                               |
-| -------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| **GitHub integration** (this guide)                            | Push-to-deploy with no CI setup and no API key to manage.              |
-| [CLI cloud builds](/pipecat-cloud/guides/cloud-builds)         | Deploying from your laptop, or from a script that already has the CLI. |
-| [GitHub Actions](/pipecat-cloud/guides/ci-with-github-actions) | Pipelines that need tests, approvals, or custom steps before a deploy. |
-
-You can mix them. An agent connected to a repository can still be deployed with the CLI, though the next push to the connected branch will deploy over it.
+<Note>
+  Not sure this is the right method? The [deployment
+  overview](/pipecat-cloud/fundamentals/deploy#choosing-a-deployment-method)
+  compares the GitHub integration with CLI cloud builds, GitHub Actions, and
+  your own container registry.
+</Note>
 
 ## Prerequisites
 


### PR DESCRIPTION
Documents the new Pipecat Cloud GitHub integration ahead of its production release.

## What's here

**New guide — `pipecat-cloud/guides/deploy-from-github.mdx`** ("Deploy from GitHub"):

- Choosing between the GitHub integration, CLI cloud builds, and GitHub Actions
- Connecting the GitHub App (once per organization, from Settings → GitHub)
- Creating an agent from a repository, and linking a repository to an existing agent
- Deploy on push, and manual deploys of the connected branch's `HEAD`
- Deployed-commit tracking, including why the running commit and connected branch can legitimately differ
- Changing a connection, unlinking an agent, and disconnecting the organization
- Limits (one agent per repo+branch, one branch per agent, `Dockerfile` required) and troubleshooting

**Cross-links from three neighbouring pages** so readers land on the right deployment method rather than the first one they find:

- `fundamentals/deploy.mdx` — points at push-to-deploy as an alternative to deploying by hand
- `guides/cloud-builds.mdx` — notes the same build service backs the GitHub integration
- `guides/ci-with-github-actions.mdx` — explains when to prefer a workflow (tests, approvals, custom steps) over the integration

## Checks

- `npx mint broken-links` — clean
- `node scripts/docs-meta-lint.mjs` — 0 errors (title 18 chars, description 137 chars, both in band)
- Prettier — clean

## Note on the llms.txt diff

`llms.txt` and `llms-full.txt` were **already stale on `main`** before this branch — `docs-meta-lint` failed check 13 on a clean checkout. Regenerating them here picks up that pre-existing drift alongside the new page, which is why those two files show a larger diff than one page would explain. Net effect is that CI goes green again.

Projected `llms.txt` budget after this change: 97,625 / 100,000.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQci1e5Fo9oMmHomtpJd97)_