### PR TITLE
Clarify Arize observability options for Pipecat

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10918,9 +10918,9 @@ Observability and online evaluation for Pipecat voice agents, powered by OpenInf
 
 ## Overview
 
-[Arize](https://arize.com) provides AI observability and evaluation for agents in development and production. It comes in two products that share the same OpenTelemetry and OpenInference foundation: [Arize AX](https://arize.com/docs/ax), the hosted platform that gives AI engineers and product managers the tools to observe, improve, and evaluate their AI agents and applications, and [Phoenix](https://arize.com/docs/phoenix), the open-source AI observability platform for experimentation, evaluation, and troubleshooting.
+[Arize AI](https://arize.com/?utm_source=pipecat-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=evals-arize) provides AI observability and evaluation for agents in development and production. Use [Arize AX](https://arize.com/products/ax/) for the full-featured platform built for production teams, AI-native companies, and enterprises, available as managed cloud or enterprise self-hosted deployment. Use [Arize Phoenix](https://arize.com/phoenix/) when you need an open-source path for local development, experimentation, or single-container self-hosting.
 
-Arize maintains a Pipecat instrumentor, [`openinference-instrumentation-pipecat`](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-pipecat), that auto-traces a running pipeline. It's built on [OpenInference](https://github.com/Arize-ai/openinference), a set of OpenTelemetry-compatible semantic conventions for AI, so spans land in Arize AX, Phoenix, or any OpenTelemetry backend, complementing Pipecat's built-in [OpenTelemetry tracing](/api-reference/server/utilities/opentelemetry). See the [Pipecat tracing guide](https://arize.com/docs/ax/integrations/python-agent-frameworks/pipecat/pipecat-tracing) for the full integration.
+Arize maintains a Pipecat instrumentor, [`openinference-instrumentation-pipecat`](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-pipecat), that auto-traces a running pipeline. It's built on [OpenInference](https://github.com/Arize-ai/openinference), a set of OpenTelemetry-compatible semantic conventions for AI, so spans land in Arize AX, Arize Phoenix, or any OpenTelemetry backend, complementing Pipecat's built-in [OpenTelemetry tracing](/api-reference/server/utilities/opentelemetry). See the [Pipecat tracing guide](https://arize.com/docs/ax/integrations/python-agent-frameworks/pipecat/pipecat-tracing) for the full integration.
 
 <Frame>
   <img
@@ -11034,6 +11034,8 @@ Beyond tracing, Arize runs evaluations on the traces it collects, the "evals" pa
 
 This complements Pipecat Evals: use Pipecat Evals for fast, scripted, pre-merge behavioral checks, and Arize for production-scale observability and online scoring of real conversations.
 
+For a broader production workflow, see Arize's [agent evaluation guide](https://arize.com/ai-agents/agent-evaluation) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) for examples of turning traces into regression checks and continuous quality signals.
+
 ## Next steps
 
 <CardGroup cols={2}>
@@ -11051,17 +11053,17 @@ This complements Pipecat Evals: use Pipecat Evals for fast, scripted, pre-merge 
   title="Arize AX Docs"
   icon="book"
   iconType="duotone"
-  href="https://arize.com/docs/ax"
+  href="https://arize.com/products/ax/"
 >
-  Set up the hosted platform: projects, tracing, online evals, dashboards, and
-  monitors.
+  Set up AX projects, tracing, online evals, dashboards, and monitors for
+  production deployments.
 </Card>
 
 <Card
   title="Phoenix (Open Source)"
   icon="fire"
   iconType="duotone"
-  href="https://arize.com/docs/phoenix"
+  href="https://arize.com/phoenix/"
 >
   Self-host the open-source version for local tracing and evaluation of your
   Pipecat agent.

--- a/pipecat/evals/platforms/arize.mdx
+++ b/pipecat/evals/platforms/arize.mdx
@@ -5,9 +5,9 @@ description: "Observability and online evaluation for Pipecat voice agents, powe
 
 ## Overview
 
-[Arize](https://arize.com) provides AI observability and evaluation for agents in development and production. It comes in two products that share the same OpenTelemetry and OpenInference foundation: [Arize AX](https://arize.com/docs/ax), the hosted platform that gives AI engineers and product managers the tools to observe, improve, and evaluate their AI agents and applications, and [Phoenix](https://arize.com/docs/phoenix), the open-source AI observability platform for experimentation, evaluation, and troubleshooting.
+[Arize AI](https://arize.com/?utm_source=pipecat-docs&utm_medium=partner&utm_campaign=partner-docs&utm_content=evals-arize) provides AI observability and evaluation for agents in development and production. Use [Arize AX](https://arize.com/products/ax/) for the full-featured platform built for production teams, AI-native companies, and enterprises, available as managed cloud or enterprise self-hosted deployment. Use [Arize Phoenix](https://arize.com/phoenix/) when you need an open-source path for local development, experimentation, or single-container self-hosting.
 
-Arize maintains a Pipecat instrumentor, [`openinference-instrumentation-pipecat`](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-pipecat), that auto-traces a running pipeline. It's built on [OpenInference](https://github.com/Arize-ai/openinference), a set of OpenTelemetry-compatible semantic conventions for AI, so spans land in Arize AX, Phoenix, or any OpenTelemetry backend, complementing Pipecat's built-in [OpenTelemetry tracing](/api-reference/server/utilities/opentelemetry). See the [Pipecat tracing guide](https://arize.com/docs/ax/integrations/python-agent-frameworks/pipecat/pipecat-tracing) for the full integration.
+Arize maintains a Pipecat instrumentor, [`openinference-instrumentation-pipecat`](https://github.com/Arize-ai/openinference/tree/main/python/instrumentation/openinference-instrumentation-pipecat), that auto-traces a running pipeline. It's built on [OpenInference](https://github.com/Arize-ai/openinference), a set of OpenTelemetry-compatible semantic conventions for AI, so spans land in Arize AX, Arize Phoenix, or any OpenTelemetry backend, complementing Pipecat's built-in [OpenTelemetry tracing](/api-reference/server/utilities/opentelemetry). See the [Pipecat tracing guide](https://arize.com/docs/ax/integrations/python-agent-frameworks/pipecat/pipecat-tracing) for the full integration.
 
 <Frame>
   <img
@@ -121,6 +121,8 @@ Beyond tracing, Arize runs evaluations on the traces it collects, the "evals" pa
 
 This complements Pipecat Evals: use Pipecat Evals for fast, scripted, pre-merge behavioral checks, and Arize for production-scale observability and online scoring of real conversations.
 
+For a broader production workflow, see Arize's [agent evaluation guide](https://arize.com/ai-agents/agent-evaluation) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) for examples of turning traces into regression checks and continuous quality signals.
+
 ## Next steps
 
 <CardGroup cols={2}>
@@ -138,17 +140,17 @@ This complements Pipecat Evals: use Pipecat Evals for fast, scripted, pre-merge 
   title="Arize AX Docs"
   icon="book"
   iconType="duotone"
-  href="https://arize.com/docs/ax"
+  href="https://arize.com/products/ax/"
 >
-  Set up the hosted platform: projects, tracing, online evals, dashboards, and
-  monitors.
+  Set up AX projects, tracing, online evals, dashboards, and monitors for
+  production deployments.
 </Card>
 
 <Card
   title="Phoenix (Open Source)"
   icon="fire"
   iconType="duotone"
-  href="https://arize.com/docs/phoenix"
+  href="https://arize.com/phoenix/"
 >
   Self-host the open-source version for local tracing and evaluation of your
   Pipecat agent.


### PR DESCRIPTION
## Summary
- Clarifies the Arize AX and Arize Phoenix options for Pipecat users
- Keeps the Pipecat tracing setup focused on the correct OpenInference packages and backends
- Adds concise evaluation workflow context for teams using Pipecat traces beyond initial debugging

## Why
The integration already explains how to collect Pipecat traces. This refresh makes the product choice clearer for readers deciding between AX for production, managed cloud, or enterprise self-hosted deployments and Phoenix for open-source local or single-container workflows.

## Testing
- Docs-only change; not run.
