### PR TITLE
docs: fix service import paths that raise AttributeError (T-2331)

### DIFF
--- a/api-reference/server/services/image-generation/fal.mdx
+++ b/api-reference/server/services/image-generation/fal.mdx
@@ -107,7 +107,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import aiohttp
-from pipecat.services.fal import FalImageGenService
+from pipecat.services.fal.image import FalImageGenService
 
 async with aiohttp.ClientSession() as session:
     image_gen = FalImageGenService(

--- a/api-reference/server/services/image-generation/google.mdx
+++ b/api-reference/server/services/image-generation/google.mdx
@@ -106,7 +106,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.google import GoogleImageGenService
+from pipecat.services.google.image import GoogleImageGenService
 
 image_gen = GoogleImageGenService(
     api_key=os.getenv("GOOGLE_API_KEY"),

--- a/api-reference/server/services/image-generation/openai.mdx
+++ b/api-reference/server/services/image-generation/openai.mdx
@@ -113,7 +113,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import aiohttp
-from pipecat.services.openai import OpenAIImageGenService
+from pipecat.services.openai.image import OpenAIImageGenService
 
 async with aiohttp.ClientSession() as session:
     image_gen = OpenAIImageGenService(

--- a/api-reference/server/services/llm/anthropic.mdx
+++ b/api-reference/server/services/llm/anthropic.mdx
@@ -134,7 +134,7 @@ When extended thinking is enabled, the service emits `LLMThoughtStartFrame`, `LL
 ### Basic Setup
 
 ```python
-from pipecat.services.anthropic import AnthropicLLMService
+from pipecat.services.anthropic.llm import AnthropicLLMService
 
 llm = AnthropicLLMService(
     api_key=os.getenv("ANTHROPIC_API_KEY"),
@@ -145,7 +145,7 @@ llm = AnthropicLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.anthropic import AnthropicLLMService
+from pipecat.services.anthropic.llm import AnthropicLLMService
 
 llm = AnthropicLLMService(
     api_key=os.getenv("ANTHROPIC_API_KEY"),

--- a/api-reference/server/services/llm/aws.mdx
+++ b/api-reference/server/services/llm/aws.mdx
@@ -154,7 +154,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.aws import AWSBedrockLLMService
+from pipecat.services.aws.llm import AWSBedrockLLMService
 
 llm = AWSBedrockLLMService(
     model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -167,7 +167,7 @@ llm = AWSBedrockLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.aws import AWSBedrockLLMService
+from pipecat.services.aws.llm import AWSBedrockLLMService
 
 llm = AWSBedrockLLMService(
     model="us.amazon.nova-pro-v1:0",

--- a/api-reference/server/services/llm/azure.mdx
+++ b/api-reference/server/services/llm/azure.mdx
@@ -111,7 +111,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.azure import AzureLLMService
+from pipecat.services.azure.llm import AzureLLMService
 
 llm = AzureLLMService(
     api_key=os.getenv("AZURE_CHATGPT_API_KEY"),
@@ -123,7 +123,7 @@ llm = AzureLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.azure import AzureLLMService
+from pipecat.services.azure.llm import AzureLLMService
 
 llm = AzureLLMService(
     api_key=os.getenv("AZURE_CHATGPT_API_KEY"),

--- a/api-reference/server/services/llm/baseten.mdx
+++ b/api-reference/server/services/llm/baseten.mdx
@@ -97,7 +97,7 @@ The default model is `moonshotai/Kimi-K2.6`, which streams visible content immed
 
 ```python
 import os
-from pipecat.services.baseten import BasetenLLMService
+from pipecat.services.baseten.llm import BasetenLLMService
 
 llm = BasetenLLMService(
     api_key=os.getenv("BASETEN_API_KEY"),
@@ -110,7 +110,7 @@ llm = BasetenLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.baseten import BasetenLLMService
+from pipecat.services.baseten.llm import BasetenLLMService
 
 llm = BasetenLLMService(
     api_key=os.getenv("BASETEN_API_KEY"),

--- a/api-reference/server/services/llm/cerebras.mdx
+++ b/api-reference/server/services/llm/cerebras.mdx
@@ -94,7 +94,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.cerebras import CerebrasLLMService
+from pipecat.services.cerebras.llm import CerebrasLLMService
 
 llm = CerebrasLLMService(
     api_key=os.getenv("CEREBRAS_API_KEY"),
@@ -105,7 +105,7 @@ llm = CerebrasLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.cerebras import CerebrasLLMService
+from pipecat.services.cerebras.llm import CerebrasLLMService
 
 llm = CerebrasLLMService(
     api_key=os.getenv("CEREBRAS_API_KEY"),

--- a/api-reference/server/services/llm/crusoe.mdx
+++ b/api-reference/server/services/llm/crusoe.mdx
@@ -96,7 +96,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import os
-from pipecat.services.crusoe import CrusoeLLMService
+from pipecat.services.crusoe.llm import CrusoeLLMService
 
 llm = CrusoeLLMService(
     api_key=os.getenv("CRUSOE_API_KEY"),
@@ -107,7 +107,7 @@ llm = CrusoeLLMService(
 
 ```python
 import os
-from pipecat.services.crusoe import CrusoeLLMService
+from pipecat.services.crusoe.llm import CrusoeLLMService
 
 llm = CrusoeLLMService(
     api_key=os.getenv("CRUSOE_API_KEY"),

--- a/api-reference/server/services/llm/deepseek.mdx
+++ b/api-reference/server/services/llm/deepseek.mdx
@@ -94,7 +94,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.deepseek import DeepSeekLLMService
+from pipecat.services.deepseek.llm import DeepSeekLLMService
 
 llm = DeepSeekLLMService(
     api_key=os.getenv("DEEPSEEK_API_KEY"),
@@ -107,7 +107,7 @@ llm = DeepSeekLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.deepseek import DeepSeekLLMService
+from pipecat.services.deepseek.llm import DeepSeekLLMService
 
 llm = DeepSeekLLMService(
     api_key=os.getenv("DEEPSEEK_API_KEY"),

--- a/api-reference/server/services/llm/fireworks.mdx
+++ b/api-reference/server/services/llm/fireworks.mdx
@@ -103,7 +103,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.fireworks import FireworksLLMService
+from pipecat.services.fireworks.llm import FireworksLLMService
 
 llm = FireworksLLMService(
     api_key=os.getenv("FIREWORKS_API_KEY"),
@@ -114,7 +114,7 @@ llm = FireworksLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.fireworks import FireworksLLMService
+from pipecat.services.fireworks.llm import FireworksLLMService
 
 llm = FireworksLLMService(
     api_key=os.getenv("FIREWORKS_API_KEY"),

--- a/api-reference/server/services/llm/google.mdx
+++ b/api-reference/server/services/llm/google.mdx
@@ -166,7 +166,7 @@ Configuration for controlling the model's internal thinking process. Gemini 2.5 
 ### Basic Setup
 
 ```python
-from pipecat.services.google import GoogleLLMService
+from pipecat.services.google.llm import GoogleLLMService
 
 llm = GoogleLLMService(
     api_key=os.getenv("GOOGLE_API_KEY"),
@@ -177,7 +177,7 @@ llm = GoogleLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.google import GoogleLLMService
+from pipecat.services.google.llm import GoogleLLMService
 
 llm = GoogleLLMService(
     api_key=os.getenv("GOOGLE_API_KEY"),

--- a/api-reference/server/services/llm/groq.mdx
+++ b/api-reference/server/services/llm/groq.mdx
@@ -90,7 +90,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.groq import GroqLLMService
+from pipecat.services.groq.llm import GroqLLMService
 
 llm = GroqLLMService(
     api_key=os.getenv("GROQ_API_KEY"),
@@ -101,7 +101,7 @@ llm = GroqLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.groq import GroqLLMService
+from pipecat.services.groq.llm import GroqLLMService
 
 llm = GroqLLMService(
     api_key=os.getenv("GROQ_API_KEY"),

--- a/api-reference/server/services/llm/inception.mdx
+++ b/api-reference/server/services/llm/inception.mdx
@@ -106,7 +106,7 @@ For additional settings inherited from OpenAI, see [OpenAI LLM Settings](/api-re
 
 ```python
 import os
-from pipecat.services.inception import InceptionLLMService
+from pipecat.services.inception.llm import InceptionLLMService
 
 llm = InceptionLLMService(
     api_key=os.getenv("INCEPTION_API_KEY"),
@@ -116,7 +116,7 @@ llm = InceptionLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.inception import InceptionLLMService
+from pipecat.services.inception.llm import InceptionLLMService
 
 llm = InceptionLLMService(
     api_key=os.getenv("INCEPTION_API_KEY"),
@@ -134,7 +134,7 @@ llm = InceptionLLMService(
 
 ```python
 from pipecat.processors.aggregators.llm_context import LLMContext
-from pipecat.services.inception import InceptionLLMService
+from pipecat.services.inception.llm import InceptionLLMService
 from pipecat.services.llm_service import FunctionCallParams
 
 # A direct function: schema is auto-derived from the signature and docstring

--- a/api-reference/server/services/llm/mistral.mdx
+++ b/api-reference/server/services/llm/mistral.mdx
@@ -87,7 +87,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.mistral import MistralLLMService
+from pipecat.services.mistral.llm import MistralLLMService
 
 llm = MistralLLMService(
     api_key=os.getenv("MISTRAL_API_KEY"),
@@ -98,7 +98,7 @@ llm = MistralLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.mistral import MistralLLMService
+from pipecat.services.mistral.llm import MistralLLMService
 
 llm = MistralLLMService(
     api_key=os.getenv("MISTRAL_API_KEY"),

--- a/api-reference/server/services/llm/nebius.mdx
+++ b/api-reference/server/services/llm/nebius.mdx
@@ -100,7 +100,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import os
-from pipecat.services.nebius import NebiusLLMService
+from pipecat.services.nebius.llm import NebiusLLMService
 
 llm = NebiusLLMService(
     api_key=os.getenv("NEBIUS_API_KEY"),
@@ -111,7 +111,7 @@ llm = NebiusLLMService(
 
 ```python
 import os
-from pipecat.services.nebius import NebiusLLMService
+from pipecat.services.nebius.llm import NebiusLLMService
 
 llm = NebiusLLMService(
     api_key=os.getenv("NEBIUS_API_KEY"),

--- a/api-reference/server/services/llm/novita.mdx
+++ b/api-reference/server/services/llm/novita.mdx
@@ -85,7 +85,7 @@ The default model is `"moonshotai/kimi-k2.5"`.
 
 ```python
 import os
-from pipecat.services.novita import NovitaLLMService
+from pipecat.services.novita.llm import NovitaLLMService
 
 llm = NovitaLLMService(
     api_key=os.getenv("NOVITA_API_KEY"),

--- a/api-reference/server/services/llm/nvidia.mdx
+++ b/api-reference/server/services/llm/nvidia.mdx
@@ -106,7 +106,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.nvidia import NvidiaLLMService
+from pipecat.services.nvidia.llm import NvidiaLLMService
 
 llm = NvidiaLLMService(
     api_key=os.getenv("NVIDIA_API_KEY"),
@@ -119,7 +119,7 @@ llm = NvidiaLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.nvidia import NvidiaLLMService
+from pipecat.services.nvidia.llm import NvidiaLLMService
 
 llm = NvidiaLLMService(
     api_key=os.getenv("NVIDIA_API_KEY"),

--- a/api-reference/server/services/llm/ollama.mdx
+++ b/api-reference/server/services/llm/ollama.mdx
@@ -106,7 +106,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 ### Basic Setup
 
 ```python
-from pipecat.services.ollama import OLLamaLLMService
+from pipecat.services.ollama.llm import OLLamaLLMService
 
 llm = OLLamaLLMService(
     model="llama2",
@@ -116,7 +116,7 @@ llm = OLLamaLLMService(
 ### With Custom Model and URL
 
 ```python
-from pipecat.services.ollama import OLLamaLLMService
+from pipecat.services.ollama.llm import OLLamaLLMService
 
 llm = OLLamaLLMService(
     model="mistral",
@@ -127,7 +127,7 @@ llm = OLLamaLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.ollama import OLLamaLLMService
+from pipecat.services.ollama.llm import OLLamaLLMService
 
 llm = OLLamaLLMService(
     base_url="http://localhost:11434/v1",

--- a/api-reference/server/services/llm/openai.mdx
+++ b/api-reference/server/services/llm/openai.mdx
@@ -139,7 +139,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.openai import OpenAILLMService
+from pipecat.services.openai.llm import OpenAILLMService
 
 llm = OpenAILLMService(
     api_key=os.getenv("OPENAI_API_KEY"),
@@ -150,7 +150,7 @@ llm = OpenAILLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.openai import OpenAILLMService
+from pipecat.services.openai.llm import OpenAILLMService
 
 llm = OpenAILLMService(
     api_key=os.getenv("OPENAI_API_KEY"),

--- a/api-reference/server/services/llm/openrouter.mdx
+++ b/api-reference/server/services/llm/openrouter.mdx
@@ -94,7 +94,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.openrouter import OpenRouterLLMService
+from pipecat.services.openrouter.llm import OpenRouterLLMService
 
 llm = OpenRouterLLMService(
     api_key=os.getenv("OPENROUTER_API_KEY"),
@@ -107,7 +107,7 @@ llm = OpenRouterLLMService(
 ### With a Different Provider Model
 
 ```python
-from pipecat.services.openrouter import OpenRouterLLMService
+from pipecat.services.openrouter.llm import OpenRouterLLMService
 
 llm = OpenRouterLLMService(
     api_key=os.getenv("OPENROUTER_API_KEY"),

--- a/api-reference/server/services/llm/perplexity.mdx
+++ b/api-reference/server/services/llm/perplexity.mdx
@@ -98,7 +98,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.perplexity import PerplexityLLMService
+from pipecat.services.perplexity.llm import PerplexityLLMService
 
 llm = PerplexityLLMService(
     api_key=os.getenv("PERPLEXITY_API_KEY"),
@@ -109,7 +109,7 @@ llm = PerplexityLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.perplexity import PerplexityLLMService
+from pipecat.services.perplexity.llm import PerplexityLLMService
 
 llm = PerplexityLLMService(
     api_key=os.getenv("PERPLEXITY_API_KEY"),

--- a/api-reference/server/services/llm/qwen.mdx
+++ b/api-reference/server/services/llm/qwen.mdx
@@ -96,7 +96,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.qwen import QwenLLMService
+from pipecat.services.qwen.llm import QwenLLMService
 
 llm = QwenLLMService(
     api_key=os.getenv("QWEN_API_KEY"),
@@ -107,7 +107,7 @@ llm = QwenLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.qwen import QwenLLMService
+from pipecat.services.qwen.llm import QwenLLMService
 
 llm = QwenLLMService(
     api_key=os.getenv("QWEN_API_KEY"),

--- a/api-reference/server/services/llm/sambanova.mdx
+++ b/api-reference/server/services/llm/sambanova.mdx
@@ -92,7 +92,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.sambanova import SambaNovaLLMService
+from pipecat.services.sambanova.llm import SambaNovaLLMService
 
 llm = SambaNovaLLMService(
     api_key=os.getenv("SAMBANOVA_API_KEY"),
@@ -103,7 +103,7 @@ llm = SambaNovaLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.sambanova import SambaNovaLLMService
+from pipecat.services.sambanova.llm import SambaNovaLLMService
 
 llm = SambaNovaLLMService(
     api_key=os.getenv("SAMBANOVA_API_KEY"),

--- a/api-reference/server/services/llm/sarvam.mdx
+++ b/api-reference/server/services/llm/sarvam.mdx
@@ -102,7 +102,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import os
-from pipecat.services.sarvam import SarvamLLMService
+from pipecat.services.sarvam.llm import SarvamLLMService
 
 llm = SarvamLLMService(
     api_key=os.getenv("SARVAM_API_KEY"),
@@ -113,7 +113,7 @@ llm = SarvamLLMService(
 
 ```python
 import os
-from pipecat.services.sarvam import SarvamLLMService
+from pipecat.services.sarvam.llm import SarvamLLMService
 
 llm = SarvamLLMService(
     api_key=os.getenv("SARVAM_API_KEY"),

--- a/api-reference/server/services/llm/together.mdx
+++ b/api-reference/server/services/llm/together.mdx
@@ -92,7 +92,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.together import TogetherLLMService
+from pipecat.services.together.llm import TogetherLLMService
 
 llm = TogetherLLMService(
     api_key=os.getenv("TOGETHER_API_KEY"),
@@ -103,7 +103,7 @@ llm = TogetherLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.together import TogetherLLMService
+from pipecat.services.together.llm import TogetherLLMService
 
 llm = TogetherLLMService(
     api_key=os.getenv("TOGETHER_API_KEY"),

--- a/api-reference/server/services/memory/mem0.mdx
+++ b/api-reference/server/services/memory/mem0.mdx
@@ -116,7 +116,7 @@ Before using Mem0 memory services, you need:
 ### Cloud API Setup
 
 ```python
-from pipecat.services.mem0 import Mem0MemoryService
+from pipecat.services.mem0.memory import Mem0MemoryService
 
 memory = Mem0MemoryService(
     api_key=os.getenv("MEM0_API_KEY"),

--- a/api-reference/server/services/s2s/ultravox.mdx
+++ b/api-reference/server/services/s2s/ultravox.mdx
@@ -178,7 +178,7 @@ Join an existing Ultravox call using a join URL.
 ```python
 import os
 import uuid
-from pipecat.services.ultravox import UltravoxRealtimeLLMService, AgentInputParams
+from pipecat.services.ultravox.llm import UltravoxRealtimeLLMService, AgentInputParams
 
 llm = UltravoxRealtimeLLMService(
     params=AgentInputParams(
@@ -191,7 +191,7 @@ llm = UltravoxRealtimeLLMService(
 ### One-Shot Call
 
 ```python
-from pipecat.services.ultravox import UltravoxRealtimeLLMService, OneShotInputParams
+from pipecat.services.ultravox.llm import UltravoxRealtimeLLMService, OneShotInputParams
 
 llm = UltravoxRealtimeLLMService(
     params=OneShotInputParams(
@@ -206,7 +206,7 @@ llm = UltravoxRealtimeLLMService(
 ### One-Shot with Tools
 
 ```python
-from pipecat.services.ultravox import UltravoxRealtimeLLMService, OneShotInputParams
+from pipecat.services.ultravox.llm import UltravoxRealtimeLLMService, OneShotInputParams
 
 llm = UltravoxRealtimeLLMService(
     params=OneShotInputParams(
@@ -225,7 +225,7 @@ async def get_weather(function_name, tool_call_id, args, llm, context, result_ca
 ### Join Existing Call
 
 ```python
-from pipecat.services.ultravox import UltravoxRealtimeLLMService, JoinUrlInputParams
+from pipecat.services.ultravox.llm import UltravoxRealtimeLLMService, JoinUrlInputParams
 
 llm = UltravoxRealtimeLLMService(
     params=JoinUrlInputParams(

--- a/api-reference/server/services/stt/mistral.mdx
+++ b/api-reference/server/services/stt/mistral.mdx
@@ -111,7 +111,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import os
-from pipecat.services.mistral import MistralSTTService
+from pipecat.services.mistral.stt import MistralSTTService
 
 stt = MistralSTTService(
     api_key=os.getenv("MISTRAL_API_KEY"),
@@ -122,7 +122,7 @@ stt = MistralSTTService(
 
 ```python
 import os
-from pipecat.services.mistral import MistralSTTService
+from pipecat.services.mistral.stt import MistralSTTService
 
 stt = MistralSTTService(
     api_key=os.getenv("MISTRAL_API_KEY"),

--- a/api-reference/server/services/stt/together.mdx
+++ b/api-reference/server/services/stt/together.mdx
@@ -101,7 +101,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import os
-from pipecat.services.together import TogetherSTTService
+from pipecat.services.together.stt import TogetherSTTService
 
 stt = TogetherSTTService(
     api_key=os.getenv("TOGETHER_API_KEY"),
@@ -111,7 +111,7 @@ stt = TogetherSTTService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.together import TogetherSTTService
+from pipecat.services.together.stt import TogetherSTTService
 from pipecat.transcriptions.language import Language
 
 stt = TogetherSTTService(
@@ -129,7 +129,7 @@ stt = TogetherSTTService(
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.processors.audio.vad_processor import VADProcessor
-from pipecat.services.together import TogetherSTTService
+from pipecat.services.together.stt import TogetherSTTService
 
 stt = TogetherSTTService(api_key=os.getenv("TOGETHER_API_KEY"))
 vad_processor = VADProcessor(vad_analyzer=SileroVADAnalyzer())

--- a/api-reference/server/services/tts/asyncai.mdx
+++ b/api-reference/server/services/tts/asyncai.mdx
@@ -148,7 +148,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.asyncai import AsyncAITTSService
+from pipecat.services.asyncai.tts import AsyncAITTSService
 
 tts = AsyncAITTSService(
     api_key=os.getenv("ASYNCAI_API_KEY"),
@@ -177,7 +177,7 @@ tts = AsyncAITTSService(
 
 ```python
 import aiohttp
-from pipecat.services.asyncai import AsyncAIHttpTTSService
+from pipecat.services.asyncai.tts import AsyncAIHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = AsyncAIHttpTTSService(

--- a/api-reference/server/services/tts/aws.mdx
+++ b/api-reference/server/services/tts/aws.mdx
@@ -128,7 +128,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.aws import AWSPollyTTSService
+from pipecat.services.aws.tts import AWSPollyTTSService
 
 tts = AWSPollyTTSService(
     settings=AWSPollyTTSService.Settings(

--- a/api-reference/server/services/tts/azure.mdx
+++ b/api-reference/server/services/tts/azure.mdx
@@ -176,7 +176,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.azure import AzureTTSService
+from pipecat.services.azure.tts import AzureTTSService
 
 tts = AzureTTSService(
     api_key=os.getenv("AZURE_SPEECH_API_KEY"),
@@ -208,7 +208,7 @@ tts = AzureTTSService(
 ### HTTP Service
 
 ```python
-from pipecat.services.azure import AzureHttpTTSService
+from pipecat.services.azure.tts import AzureHttpTTSService
 
 tts = AzureHttpTTSService(
     api_key=os.getenv("AZURE_SPEECH_API_KEY"),
@@ -220,7 +220,7 @@ tts = AzureHttpTTSService(
 ### With Private Endpoint
 
 ```python
-from pipecat.services.azure import AzureTTSService
+from pipecat.services.azure.tts import AzureTTSService
 
 tts = AzureTTSService(
     api_key=os.getenv("AZURE_SPEECH_API_KEY"),

--- a/api-reference/server/services/tts/camb.mdx
+++ b/api-reference/server/services/tts/camb.mdx
@@ -116,7 +116,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.camb import CambTTSService
+from pipecat.services.camb.tts import CambTTSService
 
 tts = CambTTSService(
     api_key=os.getenv("CAMB_API_KEY"),

--- a/api-reference/server/services/tts/cartesia.mdx
+++ b/api-reference/server/services/tts/cartesia.mdx
@@ -181,7 +181,7 @@ Configuration for Cartesia generation parameters. Applicable to sonic-3 and soni
 ### Basic Setup
 
 ```python
-from pipecat.services.cartesia import CartesiaTTSService
+from pipecat.services.cartesia.tts import CartesiaTTSService
 
 tts = CartesiaTTSService(
     api_key=os.getenv("CARTESIA_API_KEY"),
@@ -212,7 +212,7 @@ tts = CartesiaTTSService(
 ### HTTP Service
 
 ```python
-from pipecat.services.cartesia import CartesiaHttpTTSService
+from pipecat.services.cartesia.tts import CartesiaHttpTTSService
 
 tts = CartesiaHttpTTSService(
     api_key=os.getenv("CARTESIA_API_KEY"),

--- a/api-reference/server/services/tts/deepgram.mdx
+++ b/api-reference/server/services/tts/deepgram.mdx
@@ -313,7 +313,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.deepgram import DeepgramTTSService
+from pipecat.services.deepgram.tts import DeepgramTTSService
 
 tts = DeepgramTTSService(
     api_key=os.getenv("DEEPGRAM_API_KEY"),
@@ -356,7 +356,7 @@ tts = DeepgramFluxTTSService(
 
 ```python
 import aiohttp
-from pipecat.services.deepgram import DeepgramHttpTTSService
+from pipecat.services.deepgram.tts import DeepgramHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = DeepgramHttpTTSService(

--- a/api-reference/server/services/tts/elevenlabs.mdx
+++ b/api-reference/server/services/tts/elevenlabs.mdx
@@ -203,7 +203,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.elevenlabs import ElevenLabsTTSService
+from pipecat.services.elevenlabs.tts import ElevenLabsTTSService
 
 tts = ElevenLabsTTSService(
     api_key=os.getenv("ELEVENLABS_API_KEY"),
@@ -251,7 +251,7 @@ await worker.queue_frame(
 
 ```python
 import aiohttp
-from pipecat.services.elevenlabs import ElevenLabsHttpTTSService
+from pipecat.services.elevenlabs.tts import ElevenLabsHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = ElevenLabsHttpTTSService(

--- a/api-reference/server/services/tts/fish.mdx
+++ b/api-reference/server/services/tts/fish.mdx
@@ -122,7 +122,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.fish import FishAudioTTSService
+from pipecat.services.fish.tts import FishAudioTTSService
 
 tts = FishAudioTTSService(
     api_key=os.getenv("FISH_API_KEY"),

--- a/api-reference/server/services/tts/google.mdx
+++ b/api-reference/server/services/tts/google.mdx
@@ -262,7 +262,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup (Streaming)
 
 ```python
-from pipecat.services.google import GoogleTTSService
+from pipecat.services.google.tts import GoogleTTSService
 
 tts = GoogleTTSService(
     credentials_path="/path/to/service-account.json",
@@ -276,7 +276,7 @@ tts = GoogleTTSService(
 ### HTTP Service with SSML
 
 ```python
-from pipecat.services.google import GoogleHttpTTSService
+from pipecat.services.google.tts import GoogleHttpTTSService
 from pipecat.transcriptions.language import Language
 
 tts = GoogleHttpTTSService(
@@ -293,7 +293,7 @@ tts = GoogleHttpTTSService(
 ### Gemini TTS with GenAI Backend (API Key)
 
 ```python
-from pipecat.services.google import GeminiTTSService
+from pipecat.services.google.tts import GeminiTTSService
 
 tts = GeminiTTSService(
     api_key=os.environ["GOOGLE_API_KEY"],
@@ -307,7 +307,7 @@ tts = GeminiTTSService(
 ### Gemini TTS with Google Cloud Backend (Style Prompt)
 
 ```python
-from pipecat.services.google import GeminiTTSService
+from pipecat.services.google.tts import GeminiTTSService
 from pipecat.transcriptions.language import Language
 
 tts = GeminiTTSService(

--- a/api-reference/server/services/tts/gradium.mdx
+++ b/api-reference/server/services/tts/gradium.mdx
@@ -113,7 +113,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.gradium import GradiumTTSService
+from pipecat.services.gradium.tts import GradiumTTSService
 
 tts = GradiumTTSService(
     api_key=os.getenv("GRADIUM_API_KEY"),

--- a/api-reference/server/services/tts/groq.mdx
+++ b/api-reference/server/services/tts/groq.mdx
@@ -116,7 +116,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.groq import GroqTTSService
+from pipecat.services.groq.tts import GroqTTSService
 
 tts = GroqTTSService(
     api_key=os.getenv("GROQ_API_KEY"),

--- a/api-reference/server/services/tts/hume.mdx
+++ b/api-reference/server/services/tts/hume.mdx
@@ -110,7 +110,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.hume import HumeTTSService
+from pipecat.services.hume.tts import HumeTTSService
 
 tts = HumeTTSService(
     api_key=os.getenv("HUME_API_KEY"),

--- a/api-reference/server/services/tts/inworld.mdx
+++ b/api-reference/server/services/tts/inworld.mdx
@@ -203,7 +203,7 @@ HTTP-based service supporting both streaming and non-streaming modes.
 ### Basic Setup (WebSocket)
 
 ```python
-from pipecat.services.inworld import InworldTTSService
+from pipecat.services.inworld.tts import InworldTTSService
 
 tts = InworldTTSService(
     api_key=os.getenv("INWORLD_API_KEY"),
@@ -231,7 +231,7 @@ tts = InworldTTSService(
 
 ```python
 import aiohttp
-from pipecat.services.inworld import InworldHttpTTSService
+from pipecat.services.inworld.tts import InworldHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = InworldHttpTTSService(

--- a/api-reference/server/services/tts/kokoro.mdx
+++ b/api-reference/server/services/tts/kokoro.mdx
@@ -134,7 +134,7 @@ Kokoro supports the following languages. Language codes are mapped to espeak-ng 
 ### Basic Setup
 
 ```python
-from pipecat.services.kokoro import KokoroTTSService
+from pipecat.services.kokoro.tts import KokoroTTSService
 
 tts = KokoroTTSService(
     settings=KokoroTTSService.Settings(
@@ -146,7 +146,7 @@ tts = KokoroTTSService(
 ### With Language Configuration
 
 ```python
-from pipecat.services.kokoro import KokoroTTSService
+from pipecat.services.kokoro.tts import KokoroTTSService
 from pipecat.transcriptions.language import Language
 
 tts = KokoroTTSService(
@@ -160,7 +160,7 @@ tts = KokoroTTSService(
 ### With Custom Model Paths
 
 ```python
-from pipecat.services.kokoro import KokoroTTSService
+from pipecat.services.kokoro.tts import KokoroTTSService
 
 tts = KokoroTTSService(
     model_path="/path/to/kokoro-v1.0.onnx",

--- a/api-reference/server/services/tts/lmnt.mdx
+++ b/api-reference/server/services/tts/lmnt.mdx
@@ -105,7 +105,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.lmnt import LmntTTSService
+from pipecat.services.lmnt.tts import LmntTTSService
 
 tts = LmntTTSService(
     api_key=os.getenv("LMNT_API_KEY"),
@@ -118,7 +118,7 @@ tts = LmntTTSService(
 ### With Language Configuration
 
 ```python
-from pipecat.services.lmnt import LmntTTSService
+from pipecat.services.lmnt.tts import LmntTTSService
 from pipecat.transcriptions.language import Language
 
 tts = LmntTTSService(

--- a/api-reference/server/services/tts/minimax.mdx
+++ b/api-reference/server/services/tts/minimax.mdx
@@ -147,7 +147,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import aiohttp
-from pipecat.services.minimax import MiniMaxHttpTTSService
+from pipecat.services.minimax.tts import MiniMaxHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = MiniMaxHttpTTSService(
@@ -161,7 +161,7 @@ async with aiohttp.ClientSession() as session:
 
 ```python
 import aiohttp
-from pipecat.services.minimax import MiniMaxHttpTTSService
+from pipecat.services.minimax.tts import MiniMaxHttpTTSService
 from pipecat.transcriptions.language import Language
 
 async with aiohttp.ClientSession() as session:

--- a/api-reference/server/services/tts/mistral.mdx
+++ b/api-reference/server/services/tts/mistral.mdx
@@ -127,7 +127,7 @@ Slug example: `fr_marie_neutral` and UUID example: `5a271406-039d-46fe-835b-fbbb
 
 ```python
 import os
-from pipecat.services.mistral import MistralTTSService
+from pipecat.services.mistral.tts import MistralTTSService
 
 tts = MistralTTSService(
     api_key=os.getenv("MISTRAL_API_KEY"),
@@ -153,7 +153,7 @@ If you have created a custom voice in your Mistral account, use its UUID as the 
 
 ```python
 import os
-from pipecat.services.mistral import MistralTTSService
+from pipecat.services.mistral.tts import MistralTTSService
 
 tts = MistralTTSService(
     api_key=os.getenv("MISTRAL_API_KEY"),
@@ -167,7 +167,7 @@ tts = MistralTTSService(
 
 ```python
 import os
-from pipecat.services.mistral import MistralTTSService
+from pipecat.services.mistral.tts import MistralTTSService
 
 tts = MistralTTSService(
     api_key=os.getenv("MISTRAL_API_KEY"),

--- a/api-reference/server/services/tts/neuphonic.mdx
+++ b/api-reference/server/services/tts/neuphonic.mdx
@@ -178,7 +178,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup (WebSocket)
 
 ```python
-from pipecat.services.neuphonic import NeuphonicTTSService
+from pipecat.services.neuphonic.tts import NeuphonicTTSService
 
 tts = NeuphonicTTSService(
     api_key=os.getenv("NEUPHONIC_API_KEY"),
@@ -191,7 +191,7 @@ tts = NeuphonicTTSService(
 ### With Customization (WebSocket)
 
 ```python
-from pipecat.services.neuphonic import NeuphonicTTSService
+from pipecat.services.neuphonic.tts import NeuphonicTTSService
 from pipecat.transcriptions.language import Language
 
 tts = NeuphonicTTSService(
@@ -209,7 +209,7 @@ tts = NeuphonicTTSService(
 
 ```python
 import aiohttp
-from pipecat.services.neuphonic import NeuphonicHttpTTSService
+from pipecat.services.neuphonic.tts import NeuphonicHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = NeuphonicHttpTTSService(

--- a/api-reference/server/services/tts/nvidia.mdx
+++ b/api-reference/server/services/tts/nvidia.mdx
@@ -172,7 +172,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.nvidia import NvidiaTTSService
+from pipecat.services.nvidia.tts import NvidiaTTSService
 
 tts = NvidiaTTSService(
     api_key=os.getenv("NVIDIA_API_KEY"),
@@ -182,7 +182,7 @@ tts = NvidiaTTSService(
 ### With Custom Voice and Quality
 
 ```python
-from pipecat.services.nvidia import NvidiaTTSService
+from pipecat.services.nvidia.tts import NvidiaTTSService
 from pipecat.transcriptions.language import Language
 
 tts = NvidiaTTSService(

--- a/api-reference/server/services/tts/openai.mdx
+++ b/api-reference/server/services/tts/openai.mdx
@@ -131,7 +131,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.openai import OpenAITTSService
+from pipecat.services.openai.tts import OpenAITTSService
 
 tts = OpenAITTSService(
     api_key=os.getenv("OPENAI_API_KEY"),
@@ -144,7 +144,7 @@ tts = OpenAITTSService(
 ### With Voice Customization
 
 ```python
-from pipecat.services.openai import OpenAITTSService
+from pipecat.services.openai.tts import OpenAITTSService
 
 tts = OpenAITTSService(
     api_key=os.getenv("OPENAI_API_KEY"),

--- a/api-reference/server/services/tts/piper.mdx
+++ b/api-reference/server/services/tts/piper.mdx
@@ -145,7 +145,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Local Inference
 
 ```python
-from pipecat.services.piper import PiperTTSService
+from pipecat.services.piper.tts import PiperTTSService
 
 tts = PiperTTSService(
     settings=PiperTTSService.Settings(
@@ -167,7 +167,7 @@ Then connect to it:
 
 ```python
 import aiohttp
-from pipecat.services.piper import PiperHttpTTSService
+from pipecat.services.piper.tts import PiperHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = PiperHttpTTSService(

--- a/api-reference/server/services/tts/resembleai.mdx
+++ b/api-reference/server/services/tts/resembleai.mdx
@@ -109,7 +109,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.resembleai import ResembleAITTSService
+from pipecat.services.resembleai.tts import ResembleAITTSService
 
 tts = ResembleAITTSService(
     api_key=os.getenv("RESEMBLE_API_KEY"),
@@ -122,7 +122,7 @@ tts = ResembleAITTSService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.resembleai import ResembleAITTSService
+from pipecat.services.resembleai.tts import ResembleAITTSService
 
 tts = ResembleAITTSService(
     api_key=os.getenv("RESEMBLE_API_KEY"),

--- a/api-reference/server/services/tts/rime.mdx
+++ b/api-reference/server/services/tts/rime.mdx
@@ -244,7 +244,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup (WebSocket)
 
 ```python
-from pipecat.services.rime import RimeTTSService
+from pipecat.services.rime.tts import RimeTTSService
 
 tts = RimeTTSService(
     api_key=os.getenv("RIME_API_KEY"),
@@ -258,7 +258,7 @@ tts = RimeTTSService(
 ### With Customization (WebSocket)
 
 ```python
-from pipecat.services.rime import RimeTTSService
+from pipecat.services.rime.tts import RimeTTSService
 from pipecat.transcriptions.language import Language
 
 tts = RimeTTSService(
@@ -277,7 +277,7 @@ tts = RimeTTSService(
 
 ```python
 import aiohttp
-from pipecat.services.rime import RimeHttpTTSService
+from pipecat.services.rime.tts import RimeHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = RimeHttpTTSService(
@@ -293,7 +293,7 @@ async with aiohttp.ClientSession() as session:
 ### Non-JSON WebSocket
 
 ```python
-from pipecat.services.rime import RimeNonJsonTTSService
+from pipecat.services.rime.tts import RimeNonJsonTTSService
 
 tts = RimeNonJsonTTSService(
     api_key=os.getenv("RIME_API_KEY"),

--- a/api-reference/server/services/tts/sarvam.mdx
+++ b/api-reference/server/services/tts/sarvam.mdx
@@ -194,7 +194,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup (WebSocket)
 
 ```python
-from pipecat.services.sarvam import SarvamTTSService
+from pipecat.services.sarvam.tts import SarvamTTSService
 from pipecat.transcriptions.language import Language
 
 tts = SarvamTTSService(
@@ -210,7 +210,7 @@ tts = SarvamTTSService(
 ### With v3 Model and Temperature Control
 
 ```python
-from pipecat.services.sarvam import SarvamTTSService
+from pipecat.services.sarvam.tts import SarvamTTSService
 from pipecat.transcriptions.language import Language
 
 tts = SarvamTTSService(
@@ -229,7 +229,7 @@ tts = SarvamTTSService(
 
 ```python
 import aiohttp
-from pipecat.services.sarvam import SarvamHttpTTSService
+from pipecat.services.sarvam.tts import SarvamHttpTTSService
 from pipecat.transcriptions.language import Language
 
 async with aiohttp.ClientSession() as session:

--- a/api-reference/server/services/tts/smallest.mdx
+++ b/api-reference/server/services/tts/smallest.mdx
@@ -93,7 +93,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.smallest import SmallestTTSService
+from pipecat.services.smallest.tts import SmallestTTSService
 
 tts = SmallestTTSService(
     api_key=os.getenv("SMALLEST_API_KEY"),

--- a/api-reference/server/services/tts/speechmatics.mdx
+++ b/api-reference/server/services/tts/speechmatics.mdx
@@ -124,7 +124,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import aiohttp
-from pipecat.services.speechmatics import SpeechmaticsTTSService
+from pipecat.services.speechmatics.tts import SpeechmaticsTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = SpeechmaticsTTSService(
@@ -140,7 +140,7 @@ async with aiohttp.ClientSession() as session:
 
 ```python
 import aiohttp
-from pipecat.services.speechmatics import SpeechmaticsTTSService
+from pipecat.services.speechmatics.tts import SpeechmaticsTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = SpeechmaticsTTSService(

--- a/api-reference/server/services/tts/together.mdx
+++ b/api-reference/server/services/tts/together.mdx
@@ -101,7 +101,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import os
-from pipecat.services.together import TogetherTTSService
+from pipecat.services.together.tts import TogetherTTSService
 
 tts = TogetherTTSService(
     api_key=os.getenv("TOGETHER_API_KEY"),
@@ -111,7 +111,7 @@ tts = TogetherTTSService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.together import TogetherTTSService
+from pipecat.services.together.tts import TogetherTTSService
 from pipecat.transcriptions.language import Language
 
 tts = TogetherTTSService(
@@ -128,7 +128,7 @@ tts = TogetherTTSService(
 
 ```python
 from pipecat.pipeline.pipeline import Pipeline
-from pipecat.services.together import TogetherTTSService
+from pipecat.services.together.tts import TogetherTTSService
 
 tts = TogetherTTSService(
     api_key=os.getenv("TOGETHER_API_KEY"),

--- a/api-reference/server/services/tts/xtts.mdx
+++ b/api-reference/server/services/tts/xtts.mdx
@@ -128,7 +128,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import aiohttp
-from pipecat.services.xtts import XTTSService
+from pipecat.services.xtts.tts import XTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = XTTSService(
@@ -144,7 +144,7 @@ async with aiohttp.ClientSession() as session:
 
 ```python
 import aiohttp
-from pipecat.services.xtts import XTTSService
+from pipecat.services.xtts.tts import XTTSService
 from pipecat.transcriptions.language import Language
 
 async with aiohttp.ClientSession() as session:

--- a/api-reference/server/services/video/heygen.mdx
+++ b/api-reference/server/services/video/heygen.mdx
@@ -97,7 +97,7 @@ Before using HeyGen video services, you need:
 
 ```python
 import aiohttp
-from pipecat.services.heygen import HeyGenVideoService
+from pipecat.services.heygen.video import HeyGenVideoService
 
 async with aiohttp.ClientSession() as session:
     heygen = HeyGenVideoService(

--- a/api-reference/server/services/video/simli.mdx
+++ b/api-reference/server/services/video/simli.mdx
@@ -126,7 +126,7 @@ Before using Simli video services, you need:
 ### Basic Setup
 
 ```python
-from pipecat.services.simli import SimliVideoService
+from pipecat.services.simli.video import SimliVideoService
 
 simli = SimliVideoService(
     api_key=os.getenv("SIMLI_API_KEY"),

--- a/api-reference/server/services/video/tavus.mdx
+++ b/api-reference/server/services/video/tavus.mdx
@@ -95,7 +95,7 @@ Before using Tavus video services, you need:
 
 ```python
 import aiohttp
-from pipecat.services.tavus import TavusVideoService
+from pipecat.services.tavus.video import TavusVideoService
 
 async with aiohttp.ClientSession() as session:
     tavus = TavusVideoService(

--- a/api-reference/server/services/vision/moondream.mdx
+++ b/api-reference/server/services/vision/moondream.mdx
@@ -118,7 +118,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.moondream import MoondreamService
+from pipecat.services.moondream.vision import MoondreamService
 
 vision = MoondreamService()
 ```

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7882,7 +7882,7 @@ When no custom prompt is provided, Pipecat uses a built-in prompt that instructs
 By default, summarization uses the same LLM service that handles conversation. You can route summarization to a separate, cheaper model by setting the `llm` field:
 
 ```python
-from pipecat.services.google import GoogleLLMService
+from pipecat.services.google.llm import GoogleLLMService
 
 # Use a fast/cheap model for summarization
 summarization_llm = GoogleLLMService(
@@ -39286,7 +39286,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import os
-from pipecat.services.mistral import MistralSTTService
+from pipecat.services.mistral.stt import MistralSTTService
 
 stt = MistralSTTService(
     api_key=os.getenv("MISTRAL_API_KEY"),
@@ -39297,7 +39297,7 @@ stt = MistralSTTService(
 
 ```python
 import os
-from pipecat.services.mistral import MistralSTTService
+from pipecat.services.mistral.stt import MistralSTTService
 
 stt = MistralSTTService(
     api_key=os.getenv("MISTRAL_API_KEY"),
@@ -41879,7 +41879,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import os
-from pipecat.services.together import TogetherSTTService
+from pipecat.services.together.stt import TogetherSTTService
 
 stt = TogetherSTTService(
     api_key=os.getenv("TOGETHER_API_KEY"),
@@ -41889,7 +41889,7 @@ stt = TogetherSTTService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.together import TogetherSTTService
+from pipecat.services.together.stt import TogetherSTTService
 from pipecat.transcriptions.language import Language
 
 stt = TogetherSTTService(
@@ -41907,7 +41907,7 @@ stt = TogetherSTTService(
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.processors.audio.vad_processor import VADProcessor
-from pipecat.services.together import TogetherSTTService
+from pipecat.services.together.stt import TogetherSTTService
 
 stt = TogetherSTTService(api_key=os.getenv("TOGETHER_API_KEY"))
 vad_processor = VADProcessor(vad_analyzer=SileroVADAnalyzer())
@@ -42757,7 +42757,7 @@ When extended thinking is enabled, the service emits `LLMThoughtStartFrame`, `LL
 ### Basic Setup
 
 ```python
-from pipecat.services.anthropic import AnthropicLLMService
+from pipecat.services.anthropic.llm import AnthropicLLMService
 
 llm = AnthropicLLMService(
     api_key=os.getenv("ANTHROPIC_API_KEY"),
@@ -42768,7 +42768,7 @@ llm = AnthropicLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.anthropic import AnthropicLLMService
+from pipecat.services.anthropic.llm import AnthropicLLMService
 
 llm = AnthropicLLMService(
     api_key=os.getenv("ANTHROPIC_API_KEY"),
@@ -43000,7 +43000,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.aws import AWSBedrockLLMService
+from pipecat.services.aws.llm import AWSBedrockLLMService
 
 llm = AWSBedrockLLMService(
     model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
@@ -43013,7 +43013,7 @@ llm = AWSBedrockLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.aws import AWSBedrockLLMService
+from pipecat.services.aws.llm import AWSBedrockLLMService
 
 llm = AWSBedrockLLMService(
     model="us.amazon.nova-pro-v1:0",
@@ -43187,7 +43187,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.azure import AzureLLMService
+from pipecat.services.azure.llm import AzureLLMService
 
 llm = AzureLLMService(
     api_key=os.getenv("AZURE_CHATGPT_API_KEY"),
@@ -43199,7 +43199,7 @@ llm = AzureLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.azure import AzureLLMService
+from pipecat.services.azure.llm import AzureLLMService
 
 llm = AzureLLMService(
     api_key=os.getenv("AZURE_CHATGPT_API_KEY"),
@@ -43357,7 +43357,7 @@ The default model is `moonshotai/Kimi-K2.6`, which streams visible content immed
 
 ```python
 import os
-from pipecat.services.baseten import BasetenLLMService
+from pipecat.services.baseten.llm import BasetenLLMService
 
 llm = BasetenLLMService(
     api_key=os.getenv("BASETEN_API_KEY"),
@@ -43370,7 +43370,7 @@ llm = BasetenLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.baseten import BasetenLLMService
+from pipecat.services.baseten.llm import BasetenLLMService
 
 llm = BasetenLLMService(
     api_key=os.getenv("BASETEN_API_KEY"),
@@ -43505,7 +43505,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.cerebras import CerebrasLLMService
+from pipecat.services.cerebras.llm import CerebrasLLMService
 
 llm = CerebrasLLMService(
     api_key=os.getenv("CEREBRAS_API_KEY"),
@@ -43516,7 +43516,7 @@ llm = CerebrasLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.cerebras import CerebrasLLMService
+from pipecat.services.cerebras.llm import CerebrasLLMService
 
 llm = CerebrasLLMService(
     api_key=os.getenv("CEREBRAS_API_KEY"),
@@ -43637,7 +43637,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import os
-from pipecat.services.crusoe import CrusoeLLMService
+from pipecat.services.crusoe.llm import CrusoeLLMService
 
 llm = CrusoeLLMService(
     api_key=os.getenv("CRUSOE_API_KEY"),
@@ -43648,7 +43648,7 @@ llm = CrusoeLLMService(
 
 ```python
 import os
-from pipecat.services.crusoe import CrusoeLLMService
+from pipecat.services.crusoe.llm import CrusoeLLMService
 
 llm = CrusoeLLMService(
     api_key=os.getenv("CRUSOE_API_KEY"),
@@ -43794,7 +43794,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.deepseek import DeepSeekLLMService
+from pipecat.services.deepseek.llm import DeepSeekLLMService
 
 llm = DeepSeekLLMService(
     api_key=os.getenv("DEEPSEEK_API_KEY"),
@@ -43805,7 +43805,7 @@ llm = DeepSeekLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.deepseek import DeepSeekLLMService
+from pipecat.services.deepseek.llm import DeepSeekLLMService
 
 llm = DeepSeekLLMService(
     api_key=os.getenv("DEEPSEEK_API_KEY"),
@@ -43933,7 +43933,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.fireworks import FireworksLLMService
+from pipecat.services.fireworks.llm import FireworksLLMService
 
 llm = FireworksLLMService(
     api_key=os.getenv("FIREWORKS_API_KEY"),
@@ -43944,7 +43944,7 @@ llm = FireworksLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.fireworks import FireworksLLMService
+from pipecat.services.fireworks.llm import FireworksLLMService
 
 llm = FireworksLLMService(
     api_key=os.getenv("FIREWORKS_API_KEY"),
@@ -44227,7 +44227,7 @@ Configuration for controlling the model's internal thinking process. Gemini 2.5 
 ### Basic Setup
 
 ```python
-from pipecat.services.google import GoogleLLMService
+from pipecat.services.google.llm import GoogleLLMService
 
 llm = GoogleLLMService(
     api_key=os.getenv("GOOGLE_API_KEY"),
@@ -44238,7 +44238,7 @@ llm = GoogleLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.google import GoogleLLMService
+from pipecat.services.google.llm import GoogleLLMService
 
 llm = GoogleLLMService(
     api_key=os.getenv("GOOGLE_API_KEY"),
@@ -44789,7 +44789,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.groq import GroqLLMService
+from pipecat.services.groq.llm import GroqLLMService
 
 llm = GroqLLMService(
     api_key=os.getenv("GROQ_API_KEY"),
@@ -44800,7 +44800,7 @@ llm = GroqLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.groq import GroqLLMService
+from pipecat.services.groq.llm import GroqLLMService
 
 llm = GroqLLMService(
     api_key=os.getenv("GROQ_API_KEY"),
@@ -44931,7 +44931,7 @@ For additional settings inherited from OpenAI, see [OpenAI LLM Settings](/api-re
 
 ```python
 import os
-from pipecat.services.inception import InceptionLLMService
+from pipecat.services.inception.llm import InceptionLLMService
 
 llm = InceptionLLMService(
     api_key=os.getenv("INCEPTION_API_KEY"),
@@ -44941,7 +44941,7 @@ llm = InceptionLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.inception import InceptionLLMService
+from pipecat.services.inception.llm import InceptionLLMService
 
 llm = InceptionLLMService(
     api_key=os.getenv("INCEPTION_API_KEY"),
@@ -44959,7 +44959,7 @@ llm = InceptionLLMService(
 
 ```python
 from pipecat.processors.aggregators.llm_context import LLMContext
-from pipecat.services.inception import InceptionLLMService
+from pipecat.services.inception.llm import InceptionLLMService
 from pipecat.services.llm_service import FunctionCallParams
 
 # A direct function: schema is auto-derived from the signature and docstring
@@ -45081,7 +45081,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.mistral import MistralLLMService
+from pipecat.services.mistral.llm import MistralLLMService
 
 llm = MistralLLMService(
     api_key=os.getenv("MISTRAL_API_KEY"),
@@ -45092,7 +45092,7 @@ llm = MistralLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.mistral import MistralLLMService
+from pipecat.services.mistral.llm import MistralLLMService
 
 llm = MistralLLMService(
     api_key=os.getenv("MISTRAL_API_KEY"),
@@ -45235,7 +45235,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import os
-from pipecat.services.nebius import NebiusLLMService
+from pipecat.services.nebius.llm import NebiusLLMService
 
 llm = NebiusLLMService(
     api_key=os.getenv("NEBIUS_API_KEY"),
@@ -45246,7 +45246,7 @@ llm = NebiusLLMService(
 
 ```python
 import os
-from pipecat.services.nebius import NebiusLLMService
+from pipecat.services.nebius.llm import NebiusLLMService
 
 llm = NebiusLLMService(
     api_key=os.getenv("NEBIUS_API_KEY"),
@@ -45382,7 +45382,7 @@ The default model is `"moonshotai/kimi-k2.5"`.
 
 ```python
 import os
-from pipecat.services.novita import NovitaLLMService
+from pipecat.services.novita.llm import NovitaLLMService
 
 llm = NovitaLLMService(
     api_key=os.getenv("NOVITA_API_KEY"),
@@ -45543,7 +45543,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.nvidia import NvidiaLLMService
+from pipecat.services.nvidia.llm import NvidiaLLMService
 
 llm = NvidiaLLMService(
     api_key=os.getenv("NVIDIA_API_KEY"),
@@ -45556,7 +45556,7 @@ llm = NvidiaLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.nvidia import NvidiaLLMService
+from pipecat.services.nvidia.llm import NvidiaLLMService
 
 llm = NvidiaLLMService(
     api_key=os.getenv("NVIDIA_API_KEY"),
@@ -45692,7 +45692,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 ### Basic Setup
 
 ```python
-from pipecat.services.ollama import OLLamaLLMService
+from pipecat.services.ollama.llm import OLLamaLLMService
 
 llm = OLLamaLLMService(
     model="llama2",
@@ -45702,7 +45702,7 @@ llm = OLLamaLLMService(
 ### With Custom Model and URL
 
 ```python
-from pipecat.services.ollama import OLLamaLLMService
+from pipecat.services.ollama.llm import OLLamaLLMService
 
 llm = OLLamaLLMService(
     model="mistral",
@@ -45713,7 +45713,7 @@ llm = OLLamaLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.ollama import OLLamaLLMService
+from pipecat.services.ollama.llm import OLLamaLLMService
 
 llm = OLLamaLLMService(
     base_url="http://localhost:11434/v1",
@@ -45876,7 +45876,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.openai import OpenAILLMService
+from pipecat.services.openai.llm import OpenAILLMService
 
 llm = OpenAILLMService(
     api_key=os.getenv("OPENAI_API_KEY"),
@@ -45887,7 +45887,7 @@ llm = OpenAILLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.openai import OpenAILLMService
+from pipecat.services.openai.llm import OpenAILLMService
 
 llm = OpenAILLMService(
     api_key=os.getenv("OPENAI_API_KEY"),
@@ -46322,7 +46322,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.openrouter import OpenRouterLLMService
+from pipecat.services.openrouter.llm import OpenRouterLLMService
 
 llm = OpenRouterLLMService(
     api_key=os.getenv("OPENROUTER_API_KEY"),
@@ -46335,7 +46335,7 @@ llm = OpenRouterLLMService(
 ### With a Different Provider Model
 
 ```python
-from pipecat.services.openrouter import OpenRouterLLMService
+from pipecat.services.openrouter.llm import OpenRouterLLMService
 
 llm = OpenRouterLLMService(
     api_key=os.getenv("OPENROUTER_API_KEY"),
@@ -46459,7 +46459,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.perplexity import PerplexityLLMService
+from pipecat.services.perplexity.llm import PerplexityLLMService
 
 llm = PerplexityLLMService(
     api_key=os.getenv("PERPLEXITY_API_KEY"),
@@ -46470,7 +46470,7 @@ llm = PerplexityLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.perplexity import PerplexityLLMService
+from pipecat.services.perplexity.llm import PerplexityLLMService
 
 llm = PerplexityLLMService(
     api_key=os.getenv("PERPLEXITY_API_KEY"),
@@ -46593,7 +46593,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.qwen import QwenLLMService
+from pipecat.services.qwen.llm import QwenLLMService
 
 llm = QwenLLMService(
     api_key=os.getenv("QWEN_API_KEY"),
@@ -46604,7 +46604,7 @@ llm = QwenLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.qwen import QwenLLMService
+from pipecat.services.qwen.llm import QwenLLMService
 
 llm = QwenLLMService(
     api_key=os.getenv("QWEN_API_KEY"),
@@ -46722,7 +46722,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.sambanova import SambaNovaLLMService
+from pipecat.services.sambanova.llm import SambaNovaLLMService
 
 llm = SambaNovaLLMService(
     api_key=os.getenv("SAMBANOVA_API_KEY"),
@@ -46733,7 +46733,7 @@ llm = SambaNovaLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.sambanova import SambaNovaLLMService
+from pipecat.services.sambanova.llm import SambaNovaLLMService
 
 llm = SambaNovaLLMService(
     api_key=os.getenv("SAMBANOVA_API_KEY"),
@@ -46861,7 +46861,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import os
-from pipecat.services.sarvam import SarvamLLMService
+from pipecat.services.sarvam.llm import SarvamLLMService
 
 llm = SarvamLLMService(
     api_key=os.getenv("SARVAM_API_KEY"),
@@ -46872,7 +46872,7 @@ llm = SarvamLLMService(
 
 ```python
 import os
-from pipecat.services.sarvam import SarvamLLMService
+from pipecat.services.sarvam.llm import SarvamLLMService
 
 llm = SarvamLLMService(
     api_key=os.getenv("SARVAM_API_KEY"),
@@ -47117,7 +47117,7 @@ This service uses the same settings as `OpenAILLMService`. See [OpenAI LLM Setti
 
 ```python
 import os
-from pipecat.services.together import TogetherLLMService
+from pipecat.services.together.llm import TogetherLLMService
 
 llm = TogetherLLMService(
     api_key=os.getenv("TOGETHER_API_KEY"),
@@ -47128,7 +47128,7 @@ llm = TogetherLLMService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.together import TogetherLLMService
+from pipecat.services.together.llm import TogetherLLMService
 
 llm = TogetherLLMService(
     api_key=os.getenv("TOGETHER_API_KEY"),
@@ -47301,7 +47301,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.asyncai import AsyncAITTSService
+from pipecat.services.asyncai.tts import AsyncAITTSService
 
 tts = AsyncAITTSService(
     api_key=os.getenv("ASYNCAI_API_KEY"),
@@ -47330,7 +47330,7 @@ tts = AsyncAITTSService(
 
 ```python
 import aiohttp
-from pipecat.services.asyncai import AsyncAIHttpTTSService
+from pipecat.services.asyncai.tts import AsyncAIHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = AsyncAIHttpTTSService(
@@ -47493,7 +47493,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.aws import AWSPollyTTSService
+from pipecat.services.aws.tts import AWSPollyTTSService
 
 tts = AWSPollyTTSService(
     settings=AWSPollyTTSService.Settings(
@@ -47710,7 +47710,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.azure import AzureTTSService
+from pipecat.services.azure.tts import AzureTTSService
 
 tts = AzureTTSService(
     api_key=os.getenv("AZURE_SPEECH_API_KEY"),
@@ -47742,7 +47742,7 @@ tts = AzureTTSService(
 ### HTTP Service
 
 ```python
-from pipecat.services.azure import AzureHttpTTSService
+from pipecat.services.azure.tts import AzureHttpTTSService
 
 tts = AzureHttpTTSService(
     api_key=os.getenv("AZURE_SPEECH_API_KEY"),
@@ -47754,7 +47754,7 @@ tts = AzureHttpTTSService(
 ### With Private Endpoint
 
 ```python
-from pipecat.services.azure import AzureTTSService
+from pipecat.services.azure.tts import AzureTTSService
 
 tts = AzureTTSService(
     api_key=os.getenv("AZURE_SPEECH_API_KEY"),
@@ -47895,7 +47895,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.camb import CambTTSService
+from pipecat.services.camb.tts import CambTTSService
 
 tts = CambTTSService(
     api_key=os.getenv("CAMB_API_KEY"),
@@ -48119,7 +48119,7 @@ Configuration for Cartesia generation parameters. Applicable to sonic-3 and soni
 ### Basic Setup
 
 ```python
-from pipecat.services.cartesia import CartesiaTTSService
+from pipecat.services.cartesia.tts import CartesiaTTSService
 
 tts = CartesiaTTSService(
     api_key=os.getenv("CARTESIA_API_KEY"),
@@ -48150,7 +48150,7 @@ tts = CartesiaTTSService(
 ### HTTP Service
 
 ```python
-from pipecat.services.cartesia import CartesiaHttpTTSService
+from pipecat.services.cartesia.tts import CartesiaHttpTTSService
 
 tts = CartesiaHttpTTSService(
     api_key=os.getenv("CARTESIA_API_KEY"),
@@ -48741,7 +48741,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.deepgram import DeepgramTTSService
+from pipecat.services.deepgram.tts import DeepgramTTSService
 
 tts = DeepgramTTSService(
     api_key=os.getenv("DEEPGRAM_API_KEY"),
@@ -48782,7 +48782,7 @@ tts = DeepgramFluxTTSService(
 
 ```python
 import aiohttp
-from pipecat.services.deepgram import DeepgramHttpTTSService
+from pipecat.services.deepgram.tts import DeepgramHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = DeepgramHttpTTSService(
@@ -49048,7 +49048,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.elevenlabs import ElevenLabsTTSService
+from pipecat.services.elevenlabs.tts import ElevenLabsTTSService
 
 tts = ElevenLabsTTSService(
     api_key=os.getenv("ELEVENLABS_API_KEY"),
@@ -49096,7 +49096,7 @@ await worker.queue_frame(
 
 ```python
 import aiohttp
-from pipecat.services.elevenlabs import ElevenLabsHttpTTSService
+from pipecat.services.elevenlabs.tts import ElevenLabsHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = ElevenLabsHttpTTSService(
@@ -49261,7 +49261,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.fish import FishAudioTTSService
+from pipecat.services.fish.tts import FishAudioTTSService
 
 tts = FishAudioTTSService(
     api_key=os.getenv("FISH_API_KEY"),
@@ -49982,7 +49982,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup (Streaming)
 
 ```python
-from pipecat.services.google import GoogleTTSService
+from pipecat.services.google.tts import GoogleTTSService
 
 tts = GoogleTTSService(
     credentials_path="/path/to/service-account.json",
@@ -49996,7 +49996,7 @@ tts = GoogleTTSService(
 ### HTTP Service with SSML
 
 ```python
-from pipecat.services.google import GoogleHttpTTSService
+from pipecat.services.google.tts import GoogleHttpTTSService
 from pipecat.transcriptions.language import Language
 
 tts = GoogleHttpTTSService(
@@ -50013,7 +50013,7 @@ tts = GoogleHttpTTSService(
 ### Gemini TTS with GenAI Backend (API Key)
 
 ```python
-from pipecat.services.google import GeminiTTSService
+from pipecat.services.google.tts import GeminiTTSService
 
 tts = GeminiTTSService(
     api_key=os.environ["GOOGLE_API_KEY"],
@@ -50027,7 +50027,7 @@ tts = GeminiTTSService(
 ### Gemini TTS with Google Cloud Backend (Style Prompt)
 
 ```python
-from pipecat.services.google import GeminiTTSService
+from pipecat.services.google.tts import GeminiTTSService
 from pipecat.transcriptions.language import Language
 
 tts = GeminiTTSService(
@@ -50173,7 +50173,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.gradium import GradiumTTSService
+from pipecat.services.gradium.tts import GradiumTTSService
 
 tts = GradiumTTSService(
     api_key=os.getenv("GRADIUM_API_KEY"),
@@ -50340,7 +50340,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.groq import GroqTTSService
+from pipecat.services.groq.tts import GroqTTSService
 
 tts = GroqTTSService(
     api_key=os.getenv("GROQ_API_KEY"),
@@ -50632,7 +50632,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.hume import HumeTTSService
+from pipecat.services.hume.tts import HumeTTSService
 
 tts = HumeTTSService(
     api_key=os.getenv("HUME_API_KEY"),
@@ -50891,7 +50891,7 @@ HTTP-based service supporting both streaming and non-streaming modes.
 ### Basic Setup (WebSocket)
 
 ```python
-from pipecat.services.inworld import InworldTTSService
+from pipecat.services.inworld.tts import InworldTTSService
 
 tts = InworldTTSService(
     api_key=os.getenv("INWORLD_API_KEY"),
@@ -50919,7 +50919,7 @@ tts = InworldTTSService(
 
 ```python
 import aiohttp
-from pipecat.services.inworld import InworldHttpTTSService
+from pipecat.services.inworld.tts import InworldHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = InworldHttpTTSService(
@@ -51094,7 +51094,7 @@ Kokoro supports the following languages. Language codes are mapped to espeak-ng 
 ### Basic Setup
 
 ```python
-from pipecat.services.kokoro import KokoroTTSService
+from pipecat.services.kokoro.tts import KokoroTTSService
 
 tts = KokoroTTSService(
     settings=KokoroTTSService.Settings(
@@ -51106,7 +51106,7 @@ tts = KokoroTTSService(
 ### With Language Configuration
 
 ```python
-from pipecat.services.kokoro import KokoroTTSService
+from pipecat.services.kokoro.tts import KokoroTTSService
 from pipecat.transcriptions.language import Language
 
 tts = KokoroTTSService(
@@ -51120,7 +51120,7 @@ tts = KokoroTTSService(
 ### With Custom Model Paths
 
 ```python
-from pipecat.services.kokoro import KokoroTTSService
+from pipecat.services.kokoro.tts import KokoroTTSService
 
 tts = KokoroTTSService(
     model_path="/path/to/kokoro-v1.0.onnx",
@@ -51252,7 +51252,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.lmnt import LmntTTSService
+from pipecat.services.lmnt.tts import LmntTTSService
 
 tts = LmntTTSService(
     api_key=os.getenv("LMNT_API_KEY"),
@@ -51265,7 +51265,7 @@ tts = LmntTTSService(
 ### With Language Configuration
 
 ```python
-from pipecat.services.lmnt import LmntTTSService
+from pipecat.services.lmnt.tts import LmntTTSService
 from pipecat.transcriptions.language import Language
 
 tts = LmntTTSService(
@@ -51588,7 +51588,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import aiohttp
-from pipecat.services.minimax import MiniMaxHttpTTSService
+from pipecat.services.minimax.tts import MiniMaxHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = MiniMaxHttpTTSService(
@@ -51602,7 +51602,7 @@ async with aiohttp.ClientSession() as session:
 
 ```python
 import aiohttp
-from pipecat.services.minimax import MiniMaxHttpTTSService
+from pipecat.services.minimax.tts import MiniMaxHttpTTSService
 from pipecat.transcriptions.language import Language
 
 async with aiohttp.ClientSession() as session:
@@ -51761,7 +51761,7 @@ Slug example: `fr_marie_neutral` and UUID example: `5a271406-039d-46fe-835b-fbbb
 
 ```python
 import os
-from pipecat.services.mistral import MistralTTSService
+from pipecat.services.mistral.tts import MistralTTSService
 
 tts = MistralTTSService(
     api_key=os.getenv("MISTRAL_API_KEY"),
@@ -51787,7 +51787,7 @@ If you have created a custom voice in your Mistral account, use its UUID as the 
 
 ```python
 import os
-from pipecat.services.mistral import MistralTTSService
+from pipecat.services.mistral.tts import MistralTTSService
 
 tts = MistralTTSService(
     api_key=os.getenv("MISTRAL_API_KEY"),
@@ -51801,7 +51801,7 @@ tts = MistralTTSService(
 
 ```python
 import os
-from pipecat.services.mistral import MistralTTSService
+from pipecat.services.mistral.tts import MistralTTSService
 
 tts = MistralTTSService(
     api_key=os.getenv("MISTRAL_API_KEY"),
@@ -52141,7 +52141,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup (WebSocket)
 
 ```python
-from pipecat.services.neuphonic import NeuphonicTTSService
+from pipecat.services.neuphonic.tts import NeuphonicTTSService
 
 tts = NeuphonicTTSService(
     api_key=os.getenv("NEUPHONIC_API_KEY"),
@@ -52154,7 +52154,7 @@ tts = NeuphonicTTSService(
 ### With Customization (WebSocket)
 
 ```python
-from pipecat.services.neuphonic import NeuphonicTTSService
+from pipecat.services.neuphonic.tts import NeuphonicTTSService
 from pipecat.transcriptions.language import Language
 
 tts = NeuphonicTTSService(
@@ -52172,7 +52172,7 @@ tts = NeuphonicTTSService(
 
 ```python
 import aiohttp
-from pipecat.services.neuphonic import NeuphonicHttpTTSService
+from pipecat.services.neuphonic.tts import NeuphonicHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = NeuphonicHttpTTSService(
@@ -52385,7 +52385,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.nvidia import NvidiaTTSService
+from pipecat.services.nvidia.tts import NvidiaTTSService
 
 tts = NvidiaTTSService(
     api_key=os.getenv("NVIDIA_API_KEY"),
@@ -52395,7 +52395,7 @@ tts = NvidiaTTSService(
 ### With Custom Voice and Quality
 
 ```python
-from pipecat.services.nvidia import NvidiaTTSService
+from pipecat.services.nvidia.tts import NvidiaTTSService
 from pipecat.transcriptions.language import Language
 
 tts = NvidiaTTSService(
@@ -52683,7 +52683,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.openai import OpenAITTSService
+from pipecat.services.openai.tts import OpenAITTSService
 
 tts = OpenAITTSService(
     api_key=os.getenv("OPENAI_API_KEY"),
@@ -52696,7 +52696,7 @@ tts = OpenAITTSService(
 ### With Voice Customization
 
 ```python
-from pipecat.services.openai import OpenAITTSService
+from pipecat.services.openai.tts import OpenAITTSService
 
 tts = OpenAITTSService(
     api_key=os.getenv("OPENAI_API_KEY"),
@@ -52885,7 +52885,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Local Inference
 
 ```python
-from pipecat.services.piper import PiperTTSService
+from pipecat.services.piper.tts import PiperTTSService
 
 tts = PiperTTSService(
     settings=PiperTTSService.Settings(
@@ -52907,7 +52907,7 @@ Then connect to it:
 
 ```python
 import aiohttp
-from pipecat.services.piper import PiperHttpTTSService
+from pipecat.services.piper.tts import PiperHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = PiperHttpTTSService(
@@ -53211,7 +53211,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.resembleai import ResembleAITTSService
+from pipecat.services.resembleai.tts import ResembleAITTSService
 
 tts = ResembleAITTSService(
     api_key=os.getenv("RESEMBLE_API_KEY"),
@@ -53224,7 +53224,7 @@ tts = ResembleAITTSService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.resembleai import ResembleAITTSService
+from pipecat.services.resembleai.tts import ResembleAITTSService
 
 tts = ResembleAITTSService(
     api_key=os.getenv("RESEMBLE_API_KEY"),
@@ -53733,7 +53733,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup (WebSocket)
 
 ```python
-from pipecat.services.rime import RimeTTSService
+from pipecat.services.rime.tts import RimeTTSService
 
 tts = RimeTTSService(
     api_key=os.getenv("RIME_API_KEY"),
@@ -53747,7 +53747,7 @@ tts = RimeTTSService(
 ### With Customization (WebSocket)
 
 ```python
-from pipecat.services.rime import RimeTTSService
+from pipecat.services.rime.tts import RimeTTSService
 from pipecat.transcriptions.language import Language
 
 tts = RimeTTSService(
@@ -53766,7 +53766,7 @@ tts = RimeTTSService(
 
 ```python
 import aiohttp
-from pipecat.services.rime import RimeHttpTTSService
+from pipecat.services.rime.tts import RimeHttpTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = RimeHttpTTSService(
@@ -53782,7 +53782,7 @@ async with aiohttp.ClientSession() as session:
 ### Non-JSON WebSocket
 
 ```python
-from pipecat.services.rime import RimeNonJsonTTSService
+from pipecat.services.rime.tts import RimeNonJsonTTSService
 
 tts = RimeNonJsonTTSService(
     api_key=os.getenv("RIME_API_KEY"),
@@ -54300,7 +54300,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup (WebSocket)
 
 ```python
-from pipecat.services.sarvam import SarvamTTSService
+from pipecat.services.sarvam.tts import SarvamTTSService
 from pipecat.transcriptions.language import Language
 
 tts = SarvamTTSService(
@@ -54316,7 +54316,7 @@ tts = SarvamTTSService(
 ### With v3 Model and Temperature Control
 
 ```python
-from pipecat.services.sarvam import SarvamTTSService
+from pipecat.services.sarvam.tts import SarvamTTSService
 from pipecat.transcriptions.language import Language
 
 tts = SarvamTTSService(
@@ -54335,7 +54335,7 @@ tts = SarvamTTSService(
 
 ```python
 import aiohttp
-from pipecat.services.sarvam import SarvamHttpTTSService
+from pipecat.services.sarvam.tts import SarvamHttpTTSService
 from pipecat.transcriptions.language import Language
 
 async with aiohttp.ClientSession() as session:
@@ -54801,7 +54801,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.smallest import SmallestTTSService
+from pipecat.services.smallest.tts import SmallestTTSService
 
 tts = SmallestTTSService(
     api_key=os.getenv("SMALLEST_API_KEY"),
@@ -55197,7 +55197,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import aiohttp
-from pipecat.services.speechmatics import SpeechmaticsTTSService
+from pipecat.services.speechmatics.tts import SpeechmaticsTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = SpeechmaticsTTSService(
@@ -55213,7 +55213,7 @@ async with aiohttp.ClientSession() as session:
 
 ```python
 import aiohttp
-from pipecat.services.speechmatics import SpeechmaticsTTSService
+from pipecat.services.speechmatics.tts import SpeechmaticsTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = SpeechmaticsTTSService(
@@ -55502,7 +55502,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import os
-from pipecat.services.together import TogetherTTSService
+from pipecat.services.together.tts import TogetherTTSService
 
 tts = TogetherTTSService(
     api_key=os.getenv("TOGETHER_API_KEY"),
@@ -55512,7 +55512,7 @@ tts = TogetherTTSService(
 ### With Custom Settings
 
 ```python
-from pipecat.services.together import TogetherTTSService
+from pipecat.services.together.tts import TogetherTTSService
 from pipecat.transcriptions.language import Language
 
 tts = TogetherTTSService(
@@ -55529,7 +55529,7 @@ tts = TogetherTTSService(
 
 ```python
 from pipecat.pipeline.pipeline import Pipeline
-from pipecat.services.together import TogetherTTSService
+from pipecat.services.together.tts import TogetherTTSService
 
 tts = TogetherTTSService(
     api_key=os.getenv("TOGETHER_API_KEY"),
@@ -56656,7 +56656,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import aiohttp
-from pipecat.services.xtts import XTTSService
+from pipecat.services.xtts.tts import XTTSService
 
 async with aiohttp.ClientSession() as session:
     tts = XTTSService(
@@ -56672,7 +56672,7 @@ async with aiohttp.ClientSession() as session:
 
 ```python
 import aiohttp
-from pipecat.services.xtts import XTTSService
+from pipecat.services.xtts.tts import XTTSService
 from pipecat.transcriptions.language import Language
 
 async with aiohttp.ClientSession() as session:
@@ -59189,7 +59189,7 @@ Join an existing Ultravox call using a join URL.
 ```python
 import os
 import uuid
-from pipecat.services.ultravox import UltravoxRealtimeLLMService, AgentInputParams
+from pipecat.services.ultravox.llm import UltravoxRealtimeLLMService, AgentInputParams
 
 llm = UltravoxRealtimeLLMService(
     params=AgentInputParams(
@@ -59202,7 +59202,7 @@ llm = UltravoxRealtimeLLMService(
 ### One-Shot Call
 
 ```python
-from pipecat.services.ultravox import UltravoxRealtimeLLMService, OneShotInputParams
+from pipecat.services.ultravox.llm import UltravoxRealtimeLLMService, OneShotInputParams
 
 llm = UltravoxRealtimeLLMService(
     params=OneShotInputParams(
@@ -59217,7 +59217,7 @@ llm = UltravoxRealtimeLLMService(
 ### One-Shot with Tools
 
 ```python
-from pipecat.services.ultravox import UltravoxRealtimeLLMService, OneShotInputParams
+from pipecat.services.ultravox.llm import UltravoxRealtimeLLMService, OneShotInputParams
 
 llm = UltravoxRealtimeLLMService(
     params=OneShotInputParams(
@@ -59236,7 +59236,7 @@ async def get_weather(function_name, tool_call_id, args, llm, context, result_ca
 ### Join Existing Call
 
 ```python
-from pipecat.services.ultravox import UltravoxRealtimeLLMService, JoinUrlInputParams
+from pipecat.services.ultravox.llm import UltravoxRealtimeLLMService, JoinUrlInputParams
 
 llm = UltravoxRealtimeLLMService(
     params=JoinUrlInputParams(
@@ -59523,7 +59523,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import aiohttp
-from pipecat.services.fal import FalImageGenService
+from pipecat.services.fal.image import FalImageGenService
 
 async with aiohttp.ClientSession() as session:
     image_gen = FalImageGenService(
@@ -59670,7 +59670,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.google import GoogleImageGenService
+from pipecat.services.google.image import GoogleImageGenService
 
 image_gen = GoogleImageGenService(
     api_key=os.getenv("GOOGLE_API_KEY"),
@@ -59816,7 +59816,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 
 ```python
 import aiohttp
-from pipecat.services.openai import OpenAIImageGenService
+from pipecat.services.openai.image import OpenAIImageGenService
 
 async with aiohttp.ClientSession() as session:
     image_gen = OpenAIImageGenService(
@@ -60250,7 +60250,7 @@ Before using HeyGen video services, you need:
 
 ```python
 import aiohttp
-from pipecat.services.heygen import HeyGenVideoService
+from pipecat.services.heygen.video import HeyGenVideoService
 
 async with aiohttp.ClientSession() as session:
     heygen = HeyGenVideoService(
@@ -60562,7 +60562,7 @@ Before using Simli video services, you need:
 ### Basic Setup
 
 ```python
-from pipecat.services.simli import SimliVideoService
+from pipecat.services.simli.video import SimliVideoService
 
 simli = SimliVideoService(
     api_key=os.getenv("SIMLI_API_KEY"),
@@ -60698,7 +60698,7 @@ Before using Tavus video services, you need:
 
 ```python
 import aiohttp
-from pipecat.services.tavus import TavusVideoService
+from pipecat.services.tavus.video import TavusVideoService
 
 async with aiohttp.ClientSession() as session:
     tavus = TavusVideoService(
@@ -60842,7 +60842,7 @@ Before using Mem0 memory services, you need:
 ### Cloud API Setup
 
 ```python
-from pipecat.services.mem0 import Mem0MemoryService
+from pipecat.services.mem0.memory import Mem0MemoryService
 
 memory = Mem0MemoryService(
     api_key=os.getenv("MEM0_API_KEY"),
@@ -61193,7 +61193,7 @@ Runtime-configurable settings passed via the `settings` constructor argument usi
 ### Basic Setup
 
 ```python
-from pipecat.services.moondream import MoondreamService
+from pipecat.services.moondream.vision import MoondreamService
 
 vision = MoondreamService()
 ```

--- a/pipecat/fundamentals/context-summarization.mdx
+++ b/pipecat/fundamentals/context-summarization.mdx
@@ -110,7 +110,7 @@ When no custom prompt is provided, Pipecat uses a built-in prompt that instructs
 By default, summarization uses the same LLM service that handles conversation. You can route summarization to a separate, cheaper model by setting the `llm` field:
 
 ```python
-from pipecat.services.google import GoogleLLMService
+from pipecat.services.google.llm import GoogleLLMService
 
 # Use a fast/cheap model for summarization
 summarization_llm = GoogleLLMService(


### PR DESCRIPTION
## The symptom a customer hits

Copy the import off a service page and run it:

```python
from pipecat.services.nvidia import NvidiaLLMService
```

```
AttributeError: module 'pipecat.services.nvidia' has no attribute 'NvidiaLLMService'
```

## Why

Flat service imports were removed in Pipecat 1.0 (documented in the 1.0 migration guide). None of the vendor packages under `pipecat.services` re-export their classes, so the short form always fails. The working form is the submodule path, which is also what the CLI registry (`src/pipecat/cli/registry/_imports.py`) uses as canonical:

```python
from pipecat.services.nvidia.llm import NvidiaLLMService
```

## What changed

124 import lines across 62 service reference pages and 1 fundamentals page, plus the matching 124 lines in `llms-full.txt`.

Left alone on purpose:

- The `# Before (1.0)` example in `pipecat/migration/migration-1.0.mdx`. It is supposed to show the old form.
- Module level imports that already work and were verified: `pipecat.services.llm_service`, `pipecat.services.stt_service`, `pipecat.services.tts_service`, `pipecat.services.mcp_service`.

## Verification

Pipecat repo on `main` at `1.7.1.dev562`, Python 3.12.9, using that repo's `.venv`. Every short form raised `AttributeError`. Every long form passed.
