### PR TITLE
Use canonical Arize evaluation links

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11034,7 +11034,7 @@ Beyond tracing, Arize runs evaluations on the traces it collects, the "evals" pa
 
 This complements Pipecat Evals: use Pipecat Evals for fast, scripted, pre-merge behavioral checks, and Arize for production-scale observability and online scoring of real conversations.
 
-For a broader production workflow, see Arize's [agent evaluation guide](https://arize.com/ai-agents/agent-evaluation) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) for examples of turning traces into regression checks and continuous quality signals.
+For a broader production workflow, see Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) for examples of turning traces into regression checks and continuous quality signals.
 
 ## Next steps
 

--- a/pipecat/evals/platforms/arize.mdx
+++ b/pipecat/evals/platforms/arize.mdx
@@ -121,7 +121,7 @@ Beyond tracing, Arize runs evaluations on the traces it collects, the "evals" pa
 
 This complements Pipecat Evals: use Pipecat Evals for fast, scripted, pre-merge behavioral checks, and Arize for production-scale observability and online scoring of real conversations.
 
-For a broader production workflow, see Arize's [agent evaluation guide](https://arize.com/ai-agents/agent-evaluation) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) for examples of turning traces into regression checks and continuous quality signals.
+For a broader production workflow, see Arize's [agent evaluation guide](https://arize.com/guides/ai-agent-handbook/agent-evaluation/) and [LLM evaluation guide](https://arize.com/resources/llm-evaluation/) for examples of turning traces into regression checks and continuous quality signals.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary
- Updates the Arize agent evaluation guide links to the current canonical URL
- Leaves the existing LLM evaluation links unchanged

## Why
The previous agent evaluation URL redirects to the current page. Linking directly to the current URL avoids unnecessary redirects in the docs.

## Testing
- Docs-only change; not run.
