### PR TITLE
docs: add Hopper community LLM integration

### DIFF
--- a/api-reference/server/services/llm/hopper.mdx
+++ b/api-reference/server/services/llm/hopper.mdx
@@ -1,0 +1,121 @@
+---
+title: "Hopper LLM"
+sidebarTitle: "Hopper"
+description: "HopperLLMService generates streaming chat completions through Hopper's OpenAI-compatible API for low-latency voice-agent pipelines."
+---
+
+import { CommunityMaintained } from "/snippets/community-maintained.mdx";
+
+<CommunityMaintained
+  maintainer="Hopper"
+  maintainerUrl="https://github.com/hopper-inc"
+  repo="https://github.com/hopper-inc/pipecat-hopper"
+/>
+
+## Overview
+
+`HopperLLMService` generates streaming chat completions with
+[Hopper](https://withhopper.com), an inference platform for open models used in
+voice-agent pipelines. It extends Pipecat's `OpenAILLMService`, preserving the
+standard context, function-calling, runtime-settings, tracing, and metrics
+interfaces.
+
+<CardGroup cols={2}>
+  <Card
+    title="Source Repository"
+    icon="github"
+    href="https://github.com/hopper-inc/pipecat-hopper"
+  >
+    Source code, runnable example, changelog, and issues
+  </Card>
+  <Card
+    title="PyPI Package"
+    icon="cube"
+    href="https://pypi.org/project/pipecat-hopper/"
+  >
+    The `pipecat-hopper` package on PyPI
+  </Card>
+  <Card title="Hopper" icon="book" href="https://docs.withhopper.com">
+    Hopper API documentation and model catalog
+  </Card>
+  <Card title="API Keys" icon="key" href="https://withhopper.com/console/keys">
+    Create and manage Hopper API keys
+  </Card>
+</CardGroup>
+
+## Installation
+
+This is a community-maintained package distributed separately from `pipecat-ai`:
+
+```bash
+uv add pipecat-hopper
+```
+
+## Prerequisites
+
+Before using the Hopper LLM service, create a Hopper account and a server-side
+API key in the [Hopper Console](https://withhopper.com/console/keys).
+
+### Required Environment Variables
+
+- `HOPPER_API_KEY`: Hopper API key used to authenticate requests
+
+Keep this key on the server. Do not expose it in browser code or commit it to
+source control.
+
+## Configuration
+
+<ParamField path="api_key" type="str" required>
+  Hopper API key used to authenticate requests.
+</ParamField>
+
+<ParamField path="base_url" type="str" default="https://api.withhopper.com/v1">
+  Hopper's OpenAI-compatible API base URL.
+</ParamField>
+
+<ParamField path="model" type="str" default="None">
+  Convenience model override. Prefer setting the model through `settings` in new
+  code.
+</ParamField>
+
+<ParamField path="settings" type="HopperLLMService.Settings" default="None">
+  Runtime-updatable LLM settings merged into the service defaults. The default
+  model is `gemma-4-31b`.
+</ParamField>
+
+<Note>
+  `HopperLLMService.Settings` inherits Pipecat's
+  `BaseOpenAILLMService.Settings`. See the [source
+  repository](https://github.com/hopper-inc/pipecat-hopper) for the
+  authoritative settings list and compatibility information.
+</Note>
+
+## Usage
+
+```python
+import os
+
+from pipecat_hopper import HopperLLMService
+
+llm = HopperLLMService(
+    api_key=os.environ["HOPPER_API_KEY"],
+    settings=HopperLLMService.Settings(
+        system_instruction=(
+            "You are a helpful voice assistant. Keep responses brief and conversational."
+        ),
+        temperature=0.2,
+    ),
+)
+
+# ...add llm between the user context aggregator and TTS service
+```
+
+The source repository includes a complete browser voice-agent example with
+function calling and interruption handling.
+
+## Compatibility
+
+Version `0.1.x` is tested with Pipecat v1.7.0 and supports
+`pipecat-ai>=1.7.0,<2.0.0`. Check the [source
+repository](https://github.com/hopper-inc/pipecat-hopper) for the latest tested
+version and changelog.

--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -90,6 +90,7 @@ LLMs receive text or audio based input and output a streaming text response.
 | [Google Vertex AI](/api-reference/server/services/llm/google-vertex)    | `uv add "pipecat-ai[google]"`     | Pipecat    |
 | [Grok](/api-reference/server/services/llm/grok)                         | `uv add "pipecat-ai[grok]"`       | Pipecat    |
 | [Groq](/api-reference/server/services/llm/groq)                         | `uv add "pipecat-ai[groq]"`       | Pipecat    |
+| [Hopper](/api-reference/server/services/llm/hopper)                     | `uv add pipecat-hopper`           | Community  |
 | [Inception](/api-reference/server/services/llm/inception)               | `uv add "pipecat-ai[inception]"`  | Pipecat    |
 | [Mistral](/api-reference/server/services/llm/mistral)                   | `uv add "pipecat-ai[mistral]"`    | Pipecat    |
 | [Nebius](/api-reference/server/services/llm/nebius)                     | `uv add "pipecat-ai[nebius]"`     | Pipecat    |

--- a/docs.json
+++ b/docs.json
@@ -425,6 +425,7 @@
                       "api-reference/server/services/llm/google-vertex",
                       "api-reference/server/services/llm/grok",
                       "api-reference/server/services/llm/groq",
+                      "api-reference/server/services/llm/hopper",
                       "api-reference/server/services/llm/inception",
                       "api-reference/server/services/llm/mistral",
                       "api-reference/server/services/llm/nebius",
@@ -1696,6 +1697,10 @@
     {
       "source": "/server/services/llm/anannas",
       "destination": "/api-reference/server/services/llm/anannas"
+    },
+    {
+      "source": "/server/services/llm/hopper",
+      "destination": "/api-reference/server/services/llm/hopper"
     },
     {
       "source": "/server/services/llm/simplismart",


### PR DESCRIPTION
## Summary

- add Hopper to the supported LLM services table as a community-maintained integration
- document installation, configuration, usage, metrics, and model selection
- add navigation and redirect entries for the Hopper reference page

## Integration

- Repository: https://github.com/hopper-inc/pipecat-hopper
- Release: https://github.com/hopper-inc/pipecat-hopper/releases/tag/v0.1.0
- Package: `pipecat-hopper`
- Maintainer: Hopper

## Validation

- Prettier passes on all changed files
- Mint broken-link validation passes on Node.js 24
- Integration CI passes on Python 3.11, 3.13, and 3.14 against minimum, locked, and latest Pipecat versions

## Before marking ready

- [ ] Complete the PyPI trusted-publisher registration and verify `pip install pipecat-hopper`
- [ ] Add a 30–60 second real voice-agent demo link

This is intentionally a draft until those two publication requirements are complete.