### PR TITLE
Gandr TTS: drop the first-turn millisecond figure

### DIFF
--- a/api-reference/server/services/tts/gandr.mdx
+++ b/api-reference/server/services/tts/gandr.mdx
@@ -157,7 +157,7 @@ waiting for that render to finish.
 ## Notes
 
 <Note>
-  **The first turn on a fresh connection is slower**, roughly 700 ms while the
+  **The first turn on a fresh connection is slower** while the
   session voice cache fills. Every turn after it is materially quicker, which
   is why the connection is held warm across turns. A benchmark that measures
   only turn one is measuring the cache filling rather than the engine.


### PR DESCRIPTION
One-line edit to the community-maintained Gandr page: removes the 'roughly 700 ms' first-turn figure and keeps the behavior note as written. Numbers on this page should stay limited to what Gandr publishes on its own surfaces; the warm-connection guidance is unchanged.