### PR TITLE
Add Vakyam AI TTS community integration

### DIFF
--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -240,6 +240,7 @@ Text-to-Speech services receive text input and output audio streams or chunks.
 | [Together AI](/api-reference/server/services/tts/together)        | `uv add "pipecat-ai[together]"`                                               | Pipecat    |
 | [Typecast](/api-reference/server/services/tts/typecast)           | `uv add pipecat-ai-typecast`                                                  | Community  |
 | [Uplift AI](/api-reference/server/services/tts/upliftai)          | `uv pip install git+https://github.com/havkerboi123/pipecat-upliftai-tts.git` | Community  |
+| [Vakyam AI](/api-reference/server/services/tts/vakyam)            | `uv add pipecat-vakyam`                                                       | Community  |
 | [Voice.ai](/api-reference/server/services/tts/voiceai)            | `uv pip install git+https://github.com/voice-ai/voice-ai-pipecat-tts.git`     | Community  |
 | [xAI](/api-reference/server/services/tts/xai)                     | `uv add "pipecat-ai[xai]"`                                                    | Pipecat    |
 | [XTTS](/api-reference/server/services/tts/xtts) (deprecated)      | `uv add "pipecat-ai[xtts]"`                                                   | Pipecat    |

--- a/api-reference/server/services/tts/vakyam.mdx
+++ b/api-reference/server/services/tts/vakyam.mdx
@@ -1,0 +1,178 @@
+---
+title: "Vakyam AI Text-to-Speech"
+sidebarTitle: "Vakyam AI"
+description: "Add Tamil, Hindi, Telugu, and other Indian-language voices to a Pipecat pipeline with VakyamTTSService."
+---
+
+import { CommunityMaintained } from "/snippets/community-maintained.mdx";
+
+<CommunityMaintained
+  maintainer="Vakyam-AI"
+  maintainerUrl="https://github.com/Vakyam-AI"
+  repo="https://github.com/Vakyam-AI/pipecat-vakyam"
+/>
+
+## Overview
+
+Use `VakyamTTSService` when your voice agent should speak Indian languages.
+The service calls [Vakyam AI](https://www.vakyam.ai/) and returns streaming audio
+you can play through any Pipecat transport.
+
+Supported languages include Tamil, Hindi, Telugu, Marathi, Gujarati, Kannada,
+Bengali, and Indian English. Choose a preset voice or a custom voice you have
+cloned in Vakyam.
+
+<CardGroup cols={2}>
+  <Card
+    title="Source Repository"
+    icon="github"
+    href="https://github.com/Vakyam-AI/pipecat-vakyam"
+  >
+    Package source, the Daily example, and issue tracker
+  </Card>
+  <Card
+    title="PyPI Package"
+    icon="cube"
+    href="https://pypi.org/project/pipecat-vakyam/"
+  >
+    The `pipecat-vakyam` package on PyPI
+  </Card>
+  <Card title="Vakyam AI" icon="book" href="https://www.vakyam.ai/">
+    Product overview, voices, and supported Indian languages
+  </Card>
+  <Card title="API Keys" icon="key" href="https://dashboard.vakyam.ai/api-keys">
+    Create and manage your Vakyam AI API keys
+  </Card>
+</CardGroup>
+
+## Installation
+
+Install the community package. It is published separately from `pipecat-ai`:
+
+```bash
+uv add pipecat-vakyam
+```
+
+## Prerequisites
+
+### Account and API key
+
+1. Create an account at [Vakyam AI](https://www.vakyam.ai/)
+2. Copy an API key from [API Keys](https://dashboard.vakyam.ai/api-keys). Keys
+   look like `vak_live_...`
+
+Set it in the environment:
+
+```bash
+export VAKYAM_API_KEY="vak_live_..."
+```
+
+## Configuration
+
+<ParamField path="api_key" type="str" default="None">
+  Vakyam API key. If omitted, the service reads `VAKYAM_API_KEY`.
+</ParamField>
+
+<ParamField path="settings" type="VakyamTTSService.Settings" default="None">
+  Voice, language, model, and speaking rate. See [Settings](#settings).
+</ParamField>
+
+<ParamField path="base_url" type="str" default="https://api.vakyam.ai">
+  Override this only for a non-production Vakyam endpoint.
+</ParamField>
+
+<ParamField path="allow_insecure_base_url" type="bool" default="False">
+  Permit `http://` URLs that are not localhost. Leave this off in production.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="None">
+  Output rate in Hz (`8000`, `16000`, `24000`, or `48000`). Leave unset to use
+  the pipeline's output sample rate.
+</ParamField>
+
+<ParamField
+  path="text_aggregation_mode"
+  type="TextAggregationMode"
+  default="TextAggregationMode.SENTENCE"
+>
+  Defaults to sentence-sized chunks, which produces more natural spoken replies.
+</ParamField>
+
+### Settings
+
+Pass these through `VakyamTTSService.Settings(...)`. They can also be updated
+while the pipeline is running.
+
+| Parameter  | Type    | Default      | Description                                                                   |
+| ---------- | ------- | ------------ | ----------------------------------------------------------------------------- |
+| `model`    | `str`   | `"raaga-v1"` | Vakyam model to use.                                                          |
+| `voice`    | `str`   | `"Archana"`  | Preset name (for example `Archana`) or a custom voice ID starting with `vc_`. |
+| `language` | `str`   | `"ta-IN"`    | Language code. See the table below.                                           |
+| `speed`    | `float` | `1.0`        | Speaking rate from `0.5` (slower) to `2.0` (faster).                          |
+
+### Languages
+
+| Language       | Code    |
+| -------------- | ------- |
+| Tamil          | `ta-IN` |
+| Hindi          | `hi-IN` |
+| Marathi        | `mr-IN` |
+| Telugu         | `te-IN` |
+| Indian English | `en-IN` |
+| Gujarati       | `gu-IN` |
+| Bengali        | `bn-IN` |
+| Kannada        | `kn-IN` |
+
+<Note>
+  Voice catalogs and language coverage can change. The [pipecat-vakyam
+  repository](https://github.com/Vakyam-AI/pipecat-vakyam) is the source of
+  truth.
+</Note>
+
+## Usage
+
+```python
+import os
+
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat_vakyam import VakyamTTSService
+
+tts = VakyamTTSService(
+    api_key=os.getenv("VAKYAM_API_KEY"),
+    settings=VakyamTTSService.Settings(
+        voice="Archana",
+        language="ta-IN",
+    ),
+)
+
+pipeline = Pipeline(
+    [
+        transport.input(),
+        stt,
+        context_aggregator.user(),
+        llm,
+        tts,
+        transport.output(),
+        context_aggregator.assistant(),
+    ]
+)
+task = PipelineTask(pipeline, params=PipelineParams(allow_interruptions=True))
+```
+
+To speak Hindi instead of Tamil, change the language code:
+
+```python
+tts = VakyamTTSService(
+    settings=VakyamTTSService.Settings(
+        voice="Archana",
+        language="hi-IN",
+    ),
+)
+```
+
+## Compatibility
+
+Last tested with Pipecat v1.7.0 (`pipecat-ai>=1.5,<2`). See the
+[changelog](https://github.com/Vakyam-AI/pipecat-vakyam/blob/main/CHANGELOG.md)
+for updates.

--- a/api-reference/server/services/tts/vakyam.mdx
+++ b/api-reference/server/services/tts/vakyam.mdx
@@ -124,9 +124,9 @@ while the pipeline is running.
 | Kannada        | `kn-IN` |
 
 <Note>
-  Voice catalogs and language coverage can change. The [pipecat-vakyam
-  repository](https://github.com/Vakyam-AI/pipecat-vakyam) is the source of
-  truth.
+  Voice catalogs and language coverage can change. See [Voices and
+  languages](https://docs.vakyam.ai/concepts/voices-and-languages) for the
+  current list.
 </Note>
 
 ## Usage

--- a/docs.json
+++ b/docs.json
@@ -493,6 +493,7 @@
                       "api-reference/server/services/tts/tts-cache",
                       "api-reference/server/services/tts/typecast",
                       "api-reference/server/services/tts/upliftai",
+                      "api-reference/server/services/tts/vakyam",
                       "api-reference/server/services/tts/voiceai",
                       "api-reference/server/services/tts/xai",
                       "api-reference/server/services/tts/xtts",
@@ -1748,6 +1749,10 @@
     {
       "source": "/server/services/tts/upliftai",
       "destination": "/api-reference/server/services/tts/upliftai"
+    },
+    {
+      "source": "/server/services/tts/vakyam",
+      "destination": "/api-reference/server/services/tts/vakyam"
     },
     {
       "source": "/server/services/tts/voiceai",


### PR DESCRIPTION
Adds [Vakyam AI TTS](https://www.vakyam.ai/) (`pipecat-vakyam`) as a community-maintained integration for Indian-language voice agents (Tamil, Hindi, Telugu, and others).

## Docs changes

- Adds a row to the Supported Services page (Text-to-Speech table)
- Adds a dedicated service page at `api-reference/server/services/tts/vakyam.mdx`
- Registers the page in `docs.json` nav and redirects

## Integration

- **Repository:** https://github.com/Vakyam-AI/pipecat-vakyam
- **PyPI:** https://pypi.org/project/pipecat-vakyam/ (`uv add pipecat-vakyam`)
- **License:** MIT
- **Maintainer:** [Vakyam-AI](https://github.com/Vakyam-AI)
- **Company attribution:** This integration is maintained by [Vakyam AI](https://www.vakyam.ai/), the company providing the TTS service.

### Against the community-integration requirements

| Requirement | Status |
|---|---|
| Source following Pipecat patterns | `VakyamTTSService(WebsocketTTSService)` with persistent WebSocket and in-band barge-in |
| Foundational example | `examples/foundational/vakyam_tts.py` |
| README with install/usage/compatibility | yes |
| Permissive license | MIT |
| Docstrings | public API in `tts.py` |
| Changelog | `CHANGELOG.md` |
| Demo video (core TTS + interruption) | linked below |

## Verification

**Tested with Pipecat v1.7.0** (`pipecat-ai>=1.5,<2`).

## Demo

https://drive.google.com/file/d/1Q9tlysccxcwnrChhed-CUvoSiEZSlxzR/view?usp=sharing

Shows core TTS in a Pipecat pipeline and interruption / barge-in handling.
