### PR TITLE
Add missing transports to the Transports page

### DIFF
--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -258,19 +258,19 @@ Translation services enable real-time speech-to-speech and speech-to-text transl
 
 Transports exchange audio and video streams between the user and bot.
 
-| Service                                                                                 | Setup                                         | Maintainer |
-| --------------------------------------------------------------------------------------- | --------------------------------------------- | ---------- |
-| [BeyTransport](/api-reference/server/services/transport/beyond-presence)                | `uv add pipecat-ai-bey`                       | Community  |
-| [DailyTransport](/api-reference/server/services/transport/daily)                        | `uv add "pipecat-ai[daily]"`                  | Pipecat    |
-| [FastAPIWebSocketTransport](/api-reference/server/services/transport/fastapi-websocket) | `uv add "pipecat-ai[websocket]"`              | Pipecat    |
-| [HeyGenTransport](/api-reference/server/services/transport/heygen)                      | `uv add "pipecat-ai[heygen]"`                 | Pipecat    |
-| [LemonSliceTransport](/api-reference/server/services/transport/lemonslice)              | `uv add "pipecat-ai[lemonslice]"`             | Pipecat    |
-| [LiveKitTransport](/api-reference/server/services/transport/livekit)                    | `uv add "pipecat-ai[livekit]"`                | Pipecat    |
-| [SmallWebRTCTransport](/api-reference/server/services/transport/small-webrtc)           | `uv add "pipecat-ai[webrtc]"`                 | Pipecat    |
-| [TavusTransport](/api-reference/server/services/transport/tavus)                        | `uv add "pipecat-ai[tavus]"`                  | Pipecat    |
-| [VonageVideoConnectorTransport](/api-reference/server/services/transport/vonage)        | `uv add "pipecat-ai[vonage-video-connector]"` | Pipecat    |
-| [WebSocket Transports](/api-reference/server/services/transport/websocket-server)       | `uv add "pipecat-ai[websocket]"`              | Pipecat    |
-| [WhatsAppTransport](/api-reference/server/services/transport/whatsapp)                  | `uv add "pipecat-ai[webrtc]"`                 | Pipecat    |
+| Service                                                                         | Setup                                         | Maintainer |
+| ------------------------------------------------------------------------------- | --------------------------------------------- | ---------- |
+| [Beyond Presence](/api-reference/server/services/transport/beyond-presence)     | `uv add pipecat-ai-bey`                       | Community  |
+| [Daily](/api-reference/server/services/transport/daily)                         | `uv add "pipecat-ai[daily]"`                  | Pipecat    |
+| [FastAPI WebSocket](/api-reference/server/services/transport/fastapi-websocket) | `uv add "pipecat-ai[websocket]"`              | Pipecat    |
+| [HeyGen](/api-reference/server/services/transport/heygen)                       | `uv add "pipecat-ai[heygen]"`                 | Pipecat    |
+| [LemonSlice](/api-reference/server/services/transport/lemonslice)               | `uv add "pipecat-ai[lemonslice]"`             | Pipecat    |
+| [LiveKit](/api-reference/server/services/transport/livekit)                     | `uv add "pipecat-ai[livekit]"`                | Pipecat    |
+| [SmallWebRTC](/api-reference/server/services/transport/small-webrtc)            | `uv add "pipecat-ai[webrtc]"`                 | Pipecat    |
+| [Tavus](/api-reference/server/services/transport/tavus)                         | `uv add "pipecat-ai[tavus]"`                  | Pipecat    |
+| [Vonage Video Connector](/api-reference/server/services/transport/vonage)       | `uv add "pipecat-ai[vonage-video-connector]"` | Pipecat    |
+| [WebSocket](/api-reference/server/services/transport/websocket-server)          | `uv add "pipecat-ai[websocket]"`              | Pipecat    |
+| [WhatsApp](/api-reference/server/services/transport/whatsapp)                   | `uv add "pipecat-ai[webrtc]"`                 | Pipecat    |
 
 ## Turn Detection
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -45,7 +45,7 @@ Pipecat is an open source ecosystem for building voice and multimodal AI agents.
     href="/pipecat/get-started/introduction"
   >
     Open source Python framework for building voice and multimodal AI pipelines.
-    Orchestrate 100+ AI services with ultra-low latency.
+    Orchestrate 150+ AI services with ultra-low latency.
   </Card>
   <Card title="Pipecat Clients" icon="display" href="/client/introduction">
     Client SDKs for JavaScript, React, React Native, iOS, Android, and C++.
@@ -234,7 +234,7 @@ Agents can run together in one process over an in-process bus, or across separat
     icon="puzzle-piece"
     href="/api-reference/server/services/supported-services"
   >
-    Browse the complete list of 100+ AI service integrations
+    Browse the complete list of 150+ AI service integrations
   </Card>
   <Card title="Deploy" icon="cloud" href="/pipecat/deployment/overview">
     Deploy to Pipecat Cloud or self-host on your own infrastructure
@@ -609,7 +609,7 @@ uv sync
     icon="puzzle-piece"
     href="/api-reference/server/services/supported-services"
   >
-    Browse the complete list of 100+ AI service integrations
+    Browse the complete list of 150+ AI service integrations
   </Card>
   <Card title="Deploy" icon="cloud" href="/pipecat/deployment/overview">
     Deploy to Pipecat Cloud or self-host on your own infrastructure

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2534,7 +2534,15 @@ Pipecat supports multiple transport types to fit different use cases and deploym
 
 <CardGroup cols={2}>
   <Card
-    title="DailyTransport"
+    title="Beyond Presence"
+    icon="camera"
+    href="/api-reference/server/services/transport/beyond-presence"
+  >
+    Real-time Beyond Presence video avatars, built on Daily's WebRTC
+    infrastructure
+  </Card>
+  <Card
+    title="Daily"
     icon="microphone"
     href="/api-reference/server/services/transport/daily"
   >
@@ -2542,46 +2550,68 @@ Pipecat supports multiple transport types to fit different use cases and deploym
     conferencing
   </Card>
   <Card
-    title="FastAPIWebsocketTransport"
+    title="FastAPI WebSocket"
     icon="plug"
     href="/api-reference/server/services/transport/fastapi-websocket"
   >
     WebSocket transport for telephony providers and custom WebSocket connections
   </Card>
   <Card
-    title="HeyGenTransport"
+    title="HeyGen"
     icon="camera"
     href="/api-reference/server/services/transport/heygen"
   >
     Specialized transport for HeyGen LiveAvatar video generation and streaming
   </Card>
   <Card
-    title="LiveKitTransport"
+    title="LemonSlice"
+    icon="camera"
+    href="/api-reference/server/services/transport/lemonslice"
+  >
+    Joins your bot to a room with a LemonSlice avatar, layered on the Daily
+    transport
+  </Card>
+  <Card
+    title="LiveKit"
     icon="microphone"
     href="/api-reference/server/services/transport/livekit"
   >
     WebRTC transport using LiveKit's real-time communication platform
   </Card>
   <Card
-    title="SmallWebRTCTransport"
+    title="SmallWebRTC"
     icon="link"
     href="/api-reference/server/services/transport/small-webrtc"
   >
     Direct peer-to-peer WebRTC connections without cloud infrastructure
   </Card>
   <Card
-    title="TavusTransport"
+    title="Tavus"
     icon="camera"
     href="/api-reference/server/services/transport/tavus"
   >
     Specialized transport for Tavus video generation and streaming
   </Card>
   <Card
-    title="WebsocketTransport"
+    title="Vonage Video Connector"
+    icon="microphone"
+    href="/api-reference/server/services/transport/vonage"
+  >
+    Real-time WebRTC audio and video using the Vonage Video API
+  </Card>
+  <Card
+    title="WebSocket"
     icon="globe"
     href="/api-reference/server/services/transport/websocket-server"
   >
     General-purpose WebSocket transport for custom implementations
+  </Card>
+  <Card
+    title="WhatsApp"
+    icon="whatsapp"
+    href="/api-reference/server/services/transport/whatsapp"
+  >
+    WhatsApp voice calls via the WhatsApp Business API and SmallWebRTC
   </Card>
 </CardGroup>
 
@@ -30102,6 +30132,7 @@ Text-to-Speech services receive text input and output audio streams or chunks.
 | [Together AI](/api-reference/server/services/tts/together)        | `uv add "pipecat-ai[together]"`                                               | Pipecat    |
 | [Typecast](/api-reference/server/services/tts/typecast)           | `uv add pipecat-ai-typecast`                                                  | Community  |
 | [Uplift AI](/api-reference/server/services/tts/upliftai)          | `uv pip install git+https://github.com/havkerboi123/pipecat-upliftai-tts.git` | Community  |
+| [Vakyam AI](/api-reference/server/services/tts/vakyam)            | `uv add pipecat-vakyam`                                                       | Community  |
 | [Voice.ai](/api-reference/server/services/tts/voiceai)            | `uv pip install git+https://github.com/voice-ai/voice-ai-pipecat-tts.git`     | Community  |
 | [xAI](/api-reference/server/services/tts/xai)                     | `uv add "pipecat-ai[xai]"`                                                    | Pipecat    |
 | [XTTS](/api-reference/server/services/tts/xtts) (deprecated)      | `uv add "pipecat-ai[xtts]"`                                                   | Pipecat    |
@@ -30119,19 +30150,19 @@ Translation services enable real-time speech-to-speech and speech-to-text transl
 
 Transports exchange audio and video streams between the user and bot.
 
-| Service                                                                                 | Setup                                         | Maintainer |
-| --------------------------------------------------------------------------------------- | --------------------------------------------- | ---------- |
-| [BeyTransport](/api-reference/server/services/transport/beyond-presence)                | `uv add pipecat-ai-bey`                       | Community  |
-| [DailyTransport](/api-reference/server/services/transport/daily)                        | `uv add "pipecat-ai[daily]"`                  | Pipecat    |
-| [FastAPIWebSocketTransport](/api-reference/server/services/transport/fastapi-websocket) | `uv add "pipecat-ai[websocket]"`              | Pipecat    |
-| [HeyGenTransport](/api-reference/server/services/transport/heygen)                      | `uv add "pipecat-ai[heygen]"`                 | Pipecat    |
-| [LemonSliceTransport](/api-reference/server/services/transport/lemonslice)              | `uv add "pipecat-ai[lemonslice]"`             | Pipecat    |
-| [LiveKitTransport](/api-reference/server/services/transport/livekit)                    | `uv add "pipecat-ai[livekit]"`                | Pipecat    |
-| [SmallWebRTCTransport](/api-reference/server/services/transport/small-webrtc)           | `uv add "pipecat-ai[webrtc]"`                 | Pipecat    |
-| [TavusTransport](/api-reference/server/services/transport/tavus)                        | `uv add "pipecat-ai[tavus]"`                  | Pipecat    |
-| [VonageVideoConnectorTransport](/api-reference/server/services/transport/vonage)        | `uv add "pipecat-ai[vonage-video-connector]"` | Pipecat    |
-| [WebSocket Transports](/api-reference/server/services/transport/websocket-server)       | `uv add "pipecat-ai[websocket]"`              | Pipecat    |
-| [WhatsAppTransport](/api-reference/server/services/transport/whatsapp)                  | `uv add "pipecat-ai[webrtc]"`                 | Pipecat    |
+| Service                                                                         | Setup                                         | Maintainer |
+| ------------------------------------------------------------------------------- | --------------------------------------------- | ---------- |
+| [Beyond Presence](/api-reference/server/services/transport/beyond-presence)     | `uv add pipecat-ai-bey`                       | Community  |
+| [Daily](/api-reference/server/services/transport/daily)                         | `uv add "pipecat-ai[daily]"`                  | Pipecat    |
+| [FastAPI WebSocket](/api-reference/server/services/transport/fastapi-websocket) | `uv add "pipecat-ai[websocket]"`              | Pipecat    |
+| [HeyGen](/api-reference/server/services/transport/heygen)                       | `uv add "pipecat-ai[heygen]"`                 | Pipecat    |
+| [LemonSlice](/api-reference/server/services/transport/lemonslice)               | `uv add "pipecat-ai[lemonslice]"`             | Pipecat    |
+| [LiveKit](/api-reference/server/services/transport/livekit)                     | `uv add "pipecat-ai[livekit]"`                | Pipecat    |
+| [SmallWebRTC](/api-reference/server/services/transport/small-webrtc)            | `uv add "pipecat-ai[webrtc]"`                 | Pipecat    |
+| [Tavus](/api-reference/server/services/transport/tavus)                         | `uv add "pipecat-ai[tavus]"`                  | Pipecat    |
+| [Vonage Video Connector](/api-reference/server/services/transport/vonage)       | `uv add "pipecat-ai[vonage-video-connector]"` | Pipecat    |
+| [WebSocket](/api-reference/server/services/transport/websocket-server)          | `uv add "pipecat-ai[websocket]"`              | Pipecat    |
+| [WhatsApp](/api-reference/server/services/transport/whatsapp)                   | `uv add "pipecat-ai[webrtc]"`                 | Pipecat    |
 
 ## Turn Detection
 
@@ -50463,7 +50494,7 @@ waiting for that render to finish.
 ## Notes
 
 <Note>
-  **The first turn on a fresh connection is slower**, roughly 700 ms while the
+  **The first turn on a fresh connection is slower** while the
   session voice cache fills. Every turn after it is materially quicker, which
   is why the connection is held warm across turns. A benchmark that measures
   only turn one is measuring the cache filling rather than the engine.
@@ -57393,6 +57424,176 @@ await tts.set_output_format("MP3_22050_128")
 Tested with Pipecat v0.0.86 and later. Check the [source
 repository](https://github.com/havkerboi123/pipecat-upliftai-tts) for the latest
 tested version and changelog.
+
+# Vakyam AI Text-to-Speech
+Source: https://docs.pipecat.ai/api-reference/server/services/tts/vakyam.md
+
+Add Tamil, Hindi, Telugu, and other Indian-language voices to a Pipecat pipeline with VakyamTTSService.
+
+## Overview
+
+Use `VakyamTTSService` when your voice agent should speak Indian languages.
+The service calls [Vakyam AI](https://www.vakyam.ai/) and returns streaming audio
+you can play through any Pipecat transport.
+
+Supported languages include Tamil, Hindi, Telugu, Marathi, Gujarati, Kannada,
+Bengali, and Indian English. Choose a preset voice or a custom voice you have
+cloned in Vakyam.
+
+<CardGroup cols={2}>
+  <Card
+    title="Source Repository"
+    icon="github"
+    href="https://github.com/Vakyam-AI/pipecat-vakyam"
+  >
+    Package source, the Daily example, and issue tracker
+  </Card>
+  <Card
+    title="PyPI Package"
+    icon="cube"
+    href="https://pypi.org/project/pipecat-vakyam/"
+  >
+    The `pipecat-vakyam` package on PyPI
+  </Card>
+  <Card title="Vakyam AI" icon="book" href="https://www.vakyam.ai/">
+    Product overview, voices, and supported Indian languages
+  </Card>
+  <Card title="API Keys" icon="key" href="https://dashboard.vakyam.ai/api-keys">
+    Create and manage your Vakyam AI API keys
+  </Card>
+</CardGroup>
+
+## Installation
+
+Install the community package. It is published separately from `pipecat-ai`:
+
+```bash
+uv add pipecat-vakyam
+```
+
+## Prerequisites
+
+### Account and API key
+
+1. Create an account at [Vakyam AI](https://www.vakyam.ai/)
+2. Copy an API key from [API Keys](https://dashboard.vakyam.ai/api-keys). Keys
+   look like `vak_live_...`
+
+Set it in the environment:
+
+```bash
+export VAKYAM_API_KEY="vak_live_..."
+```
+
+## Configuration
+
+<ParamField path="api_key" type="str" default="None">
+  Vakyam API key. If omitted, the service reads `VAKYAM_API_KEY`.
+</ParamField>
+
+<ParamField path="settings" type="VakyamTTSService.Settings" default="None">
+  Voice, language, model, and speaking rate. See [Settings](#settings).
+</ParamField>
+
+<ParamField path="base_url" type="str" default="https://api.vakyam.ai">
+  Override this only for a non-production Vakyam endpoint.
+</ParamField>
+
+<ParamField path="allow_insecure_base_url" type="bool" default="False">
+  Permit `http://` URLs that are not localhost. Leave this off in production.
+</ParamField>
+
+<ParamField path="sample_rate" type="int" default="None">
+  Output rate in Hz (`8000`, `16000`, `24000`, or `48000`). Leave unset to use
+  the pipeline's output sample rate.
+</ParamField>
+
+<ParamField
+  path="text_aggregation_mode"
+  type="TextAggregationMode"
+  default="TextAggregationMode.SENTENCE"
+>
+  Defaults to sentence-sized chunks, which produces more natural spoken replies.
+</ParamField>
+
+### Settings
+
+Pass these through `VakyamTTSService.Settings(...)`. They can also be updated
+while the pipeline is running.
+
+| Parameter  | Type    | Default      | Description                                                                   |
+| ---------- | ------- | ------------ | ----------------------------------------------------------------------------- |
+| `model`    | `str`   | `"raaga-v1"` | Vakyam model to use.                                                          |
+| `voice`    | `str`   | `"Archana"`  | Preset name (for example `Archana`) or a custom voice ID starting with `vc_`. |
+| `language` | `str`   | `"ta-IN"`    | Language code. See the table below.                                           |
+| `speed`    | `float` | `1.0`        | Speaking rate from `0.5` (slower) to `2.0` (faster).                          |
+
+### Languages
+
+| Language       | Code    |
+| -------------- | ------- |
+| Tamil          | `ta-IN` |
+| Hindi          | `hi-IN` |
+| Marathi        | `mr-IN` |
+| Telugu         | `te-IN` |
+| Indian English | `en-IN` |
+| Gujarati       | `gu-IN` |
+| Bengali        | `bn-IN` |
+| Kannada        | `kn-IN` |
+
+<Note>
+  Voice catalogs and language coverage can change. See [Voices and
+  languages](https://docs.vakyam.ai/concepts/voices-and-languages) for the
+  current list.
+</Note>
+
+## Usage
+
+```python
+import os
+
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat_vakyam import VakyamTTSService
+
+tts = VakyamTTSService(
+    api_key=os.getenv("VAKYAM_API_KEY"),
+    settings=VakyamTTSService.Settings(
+        voice="Archana",
+        language="ta-IN",
+    ),
+)
+
+pipeline = Pipeline(
+    [
+        transport.input(),
+        stt,
+        context_aggregator.user(),
+        llm,
+        tts,
+        transport.output(),
+        context_aggregator.assistant(),
+    ]
+)
+task = PipelineTask(pipeline, params=PipelineParams(allow_interruptions=True))
+```
+
+To speak Hindi instead of Tamil, change the language code:
+
+```python
+tts = VakyamTTSService(
+    settings=VakyamTTSService.Settings(
+        voice="Archana",
+        language="hi-IN",
+    ),
+)
+```
+
+## Compatibility
+
+Last tested with Pipecat v1.7.0 (`pipecat-ai>=1.5,<2`). See the
+[changelog](https://github.com/Vakyam-AI/pipecat-vakyam/blob/main/CHANGELOG.md)
+for updates.
 
 # Voice.ai Text-to-Speech
 Source: https://docs.pipecat.ai/api-reference/server/services/tts/voiceai.md

--- a/llms.txt
+++ b/llms.txt
@@ -429,6 +429,7 @@ LLM, transports, serializers), pipelines, frames, workers, and utilities.
 - [Pipecat TTS Cache](https://docs.pipecat.ai/api-reference/server/services/tts/tts-cache.md): TTSCacheMixin transparently wraps any Pipecat TTS service, caching repeated phrases to cut API costs and response latency.
 - [Typecast Text-to-Speech](https://docs.pipecat.ai/api-reference/server/services/tts/typecast.md): TypecastTTSService synthesizes expressive TTS with Typecast's neural voices, with emotion control and audio customization.
 - [Uplift AI Text-to-Speech](https://docs.pipecat.ai/api-reference/server/services/tts/upliftai.md): UpliftHttpTTSService converts text to speech with Uplift AI's HTTP TTS API for high-quality, low-latency synthesis.
+- [Vakyam AI Text-to-Speech](https://docs.pipecat.ai/api-reference/server/services/tts/vakyam.md): Add Tamil, Hindi, Telugu, and other Indian-language voices to a Pipecat pipeline with VakyamTTSService.
 - [Voice.ai Text-to-Speech](https://docs.pipecat.ai/api-reference/server/services/tts/voiceai.md): VoiceAiTTSService streams TTS through Voice.ai's Multi-Context WebSocket API over a single persistent connection.
 - [xAI Text-to-Speech](https://docs.pipecat.ai/api-reference/server/services/tts/xai.md): TTS in 20 languages with XAITTSService (WebSocket streaming) and XAIHttpTTSService on xAI's speech synthesis APIs.
 - [Coqui XTTS Text-to-Speech](https://docs.pipecat.ai/api-reference/server/services/tts/xtts.md): XTTSTTSService provides multilingual TTS with voice cloning through a locally hosted Coqui XTTS streaming server.

--- a/overview/introduction.mdx
+++ b/overview/introduction.mdx
@@ -16,7 +16,7 @@ Pipecat is an open source ecosystem for building voice and multimodal AI agents.
     href="/pipecat/get-started/introduction"
   >
     Open source Python framework for building voice and multimodal AI pipelines.
-    Orchestrate 100+ AI services with ultra-low latency.
+    Orchestrate 150+ AI services with ultra-low latency.
   </Card>
   <Card title="Pipecat Clients" icon="display" href="/client/introduction">
     Client SDKs for JavaScript, React, React Native, iOS, Android, and C++.

--- a/overview/pipecat.mdx
+++ b/overview/pipecat.mdx
@@ -115,7 +115,7 @@ Agents can run together in one process over an in-process bus, or across separat
     icon="puzzle-piece"
     href="/api-reference/server/services/supported-services"
   >
-    Browse the complete list of 100+ AI service integrations
+    Browse the complete list of 150+ AI service integrations
   </Card>
   <Card title="Deploy" icon="cloud" href="/pipecat/deployment/overview">
     Deploy to Pipecat Cloud or self-host on your own infrastructure

--- a/pipecat/get-started/introduction.mdx
+++ b/pipecat/get-started/introduction.mdx
@@ -139,7 +139,7 @@ uv sync
     icon="puzzle-piece"
     href="/api-reference/server/services/supported-services"
   >
-    Browse the complete list of 100+ AI service integrations
+    Browse the complete list of 150+ AI service integrations
   </Card>
   <Card title="Deploy" icon="cloud" href="/pipecat/deployment/overview">
     Deploy to Pipecat Cloud or self-host on your own infrastructure

--- a/pipecat/learn/transports.mdx
+++ b/pipecat/learn/transports.mdx
@@ -11,7 +11,15 @@ Pipecat supports multiple transport types to fit different use cases and deploym
 
 <CardGroup cols={2}>
   <Card
-    title="DailyTransport"
+    title="Beyond Presence"
+    icon="camera"
+    href="/api-reference/server/services/transport/beyond-presence"
+  >
+    Real-time Beyond Presence video avatars, built on Daily's WebRTC
+    infrastructure
+  </Card>
+  <Card
+    title="Daily"
     icon="microphone"
     href="/api-reference/server/services/transport/daily"
   >
@@ -19,46 +27,68 @@ Pipecat supports multiple transport types to fit different use cases and deploym
     conferencing
   </Card>
   <Card
-    title="FastAPIWebsocketTransport"
+    title="FastAPI WebSocket"
     icon="plug"
     href="/api-reference/server/services/transport/fastapi-websocket"
   >
     WebSocket transport for telephony providers and custom WebSocket connections
   </Card>
   <Card
-    title="HeyGenTransport"
+    title="HeyGen"
     icon="camera"
     href="/api-reference/server/services/transport/heygen"
   >
     Specialized transport for HeyGen LiveAvatar video generation and streaming
   </Card>
   <Card
-    title="LiveKitTransport"
+    title="LemonSlice"
+    icon="camera"
+    href="/api-reference/server/services/transport/lemonslice"
+  >
+    Joins your bot to a room with a LemonSlice avatar, layered on the Daily
+    transport
+  </Card>
+  <Card
+    title="LiveKit"
     icon="microphone"
     href="/api-reference/server/services/transport/livekit"
   >
     WebRTC transport using LiveKit's real-time communication platform
   </Card>
   <Card
-    title="SmallWebRTCTransport"
+    title="SmallWebRTC"
     icon="link"
     href="/api-reference/server/services/transport/small-webrtc"
   >
     Direct peer-to-peer WebRTC connections without cloud infrastructure
   </Card>
   <Card
-    title="TavusTransport"
+    title="Tavus"
     icon="camera"
     href="/api-reference/server/services/transport/tavus"
   >
     Specialized transport for Tavus video generation and streaming
   </Card>
   <Card
-    title="WebsocketTransport"
+    title="Vonage Video Connector"
+    icon="microphone"
+    href="/api-reference/server/services/transport/vonage"
+  >
+    Real-time WebRTC audio and video using the Vonage Video API
+  </Card>
+  <Card
+    title="WebSocket"
     icon="globe"
     href="/api-reference/server/services/transport/websocket-server"
   >
     General-purpose WebSocket transport for custom implementations
+  </Card>
+  <Card
+    title="WhatsApp"
+    icon="whatsapp"
+    href="/api-reference/server/services/transport/whatsapp"
+  >
+    WhatsApp voice calls via the WhatsApp Business API and SmallWebRTC
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
## Why

The card grid on `pipecat/learn/transports.mdx` listed 7 transports while the supported services table listed 11, so Beyond Presence, LemonSlice, Vonage Video Connector, and WhatsApp had no card.

## What

- **Supported services table**: list transports by service name instead of Python class name (`DailyTransport` → `Daily`), matching every other table on that page.
- **Transports page**: add the 4 missing cards in the table's alphabetical order, and align the existing titles to the same service names. Also fixes `Websocket` → `WebSocket` casing to match the target pages' `sidebarTitle`s.
- **llms.txt / llms-full.txt**: regenerated. This also picks up the Vakyam TTS entry, which was already missing from the checked-in `llms.txt` before this branch.

Naming follows the official product names: `Beyond Presence` and `Vonage Video Connector`.

## Checks

`mint broken-links` and `scripts/docs-meta-lint.mjs` both pass (0 errors; the 183 warnings are pre-existing).
