### PR TITLE
Add Gandr published latency numbers to the notes

### DIFF
--- a/api-reference/server/services/tts/gandr.mdx
+++ b/api-reference/server/services/tts/gandr.mdx
@@ -161,6 +161,8 @@ waiting for that render to finish.
   session voice cache fills. Every turn after it is materially quicker, which
   is why the connection is held warm across turns. A benchmark that measures
   only turn one is measuring the cache filling rather than the engine.
+  Gandr's published steady-state numbers: first audio byte in 146 ms over the
+  open internet, and 116 ms p50 first audio, server side warm.
 </Note>
 
 <Note>


### PR DESCRIPTION
Follow-up to #1126: the notes now say the first turn is slower without saying by how much. This adds Gandr's published steady-state numbers so the page carries the measured figure instead of nothing:

first audio byte in 146 ms over the open internet, 116 ms p50 first audio, server side warm.

These are the same numbers published on gandr.ai and in gandr.ai/llms.txt, quoted verbatim with their basis.

Disclosure: I maintain the Gandr integration.
