### PR TITLE
Document word_timestamps, correct the seed description

### DIFF
--- a/api-reference/server/services/tts/gandr.mdx
+++ b/api-reference/server/services/tts/gandr.mdx
@@ -108,8 +108,9 @@ Passed via `params=GandrTTSService.InputParams(...)`.
 | `volume`        | `float` | `None`         | 0.5-2.0, soft-ceiling mastered.                                                |
 | `temperature`   | `float` | `None`         | Expression control. Omit to let the service choose.                            |
 | `cfg_weight`    | `float` | `None`         | Expression control. Omit to send nothing at all.                               |
-| `seed`          | `int`   | `None`         | Fixes the render for a reproducible result.                                    |
+| `seed`          | `int`   | `None`         | Accepted and forwarded to the engine; results are currently non-deterministic regardless of the value. |
 | `voice_wav_b64` | `str`   | `None`         | Base64 WAV reference audio for a cloned voice, registered on first utterance.  |
+| `word_timestamps` | `bool`  | `None`         | Ask for word-level timing: the closing frame then carries per-word offsets, fed into Pipecat's word-timestamp machinery. Requires `pipecat-gandr>=0.1.3`. |
 
 Stock voices: `gandr-mia`, `gandr-ava`, `gandr-jenny`, `gandr-dane`,
 `gandr-leo`, `gandr-lewis`.


### PR DESCRIPTION
Two small accuracy fixes to the Gandr community page:

1. Documents `InputParams(word_timestamps=True)`, shipped in pipecat-gandr 0.1.3: the utterance asks for word-level timing, the closing frame carries per-word offsets, and they feed Pipecat's existing word-timestamp machinery.
2. Corrects the `seed` row: results are currently non-deterministic even with a fixed seed, so the previous "reproducible result" wording overstated it.

Disclosure: I maintain the Gandr integration.
