### PR TITLE
Clarify that Gandr's latency figures are byte-arrival metrics

### DIFF
--- a/api-reference/server/services/tts/gandr.mdx
+++ b/api-reference/server/services/tts/gandr.mdx
@@ -162,7 +162,9 @@ waiting for that render to finish.
   is why the connection is held warm across turns. A benchmark that measures
   only turn one is measuring the cache filling rather than the engine.
   Gandr's published steady-state numbers: first audio byte in 146 ms over the
-  open internet, and 116 ms p50 first audio, server side warm.
+  open internet, and 116 ms p50 first audio, server side warm. Both are
+  byte-arrival metrics rather than heard-sound timing: the engine's first
+  rendered chunk can be silence.
 </Note>
 
 <Note>


### PR DESCRIPTION
Follow-up to #1131 as offered in review: makes explicit that both published figures are byte-arrival metrics rather than heard-sound (TTFA) timing, since the first rendered chunk can be silence.

Disclosure: I maintain the Gandr integration.