### PR TITLE
Document both YAML suffixes in eval scenario directories

### DIFF
--- a/api-reference/cli/eval.mdx
+++ b/api-reference/cli/eval.mdx
@@ -24,7 +24,7 @@ pipecat eval run [OPTIONS] SCENARIOS...
 
 <ParamField path="SCENARIOS..." type="path" required>
   One or more scenario YAML files, or directories of them. A directory expands
-  to its `*.yaml` files in filename order, non-recursively.
+  to its `.yaml` and `.yml` files in filename order, non-recursively.
 </ParamField>
 
 **Options:**
@@ -173,8 +173,8 @@ pipecat eval suite [OPTIONS] MANIFEST_PATH
 # Run one scenario against a running agent
 pipecat eval run scenarios/capital_question.yaml
 
-# Run a batch of scenarios, verbosely
-pipecat eval run scenarios/*.yaml -v
+# Run every scenario in a directory, verbosely
+pipecat eval run scenarios/ -v
 
 # Run a full suite
 pipecat eval suite manifest.yaml

--- a/pipecat/evals/suites.mdx
+++ b/pipecat/evals/suites.mdx
@@ -94,7 +94,7 @@ pipecat eval run scenarios/*.yaml --bot-url ws://localhost:7860
 pipecat eval run scenarios/ --bot-url ws://localhost:7860       # the whole directory
 ```
 
-A directory expands to its `*.yaml` files in filename order, non-recursively, and files and directories can be mixed in one invocation. A directory holding no `.yaml` files is an error rather than an empty run.
+A directory expands to its `.yaml` and `.yml` files in filename order, non-recursively, and files and directories can be mixed in one invocation. A directory holding no scenarios is an error rather than an empty run.
 
 By default the agent is left running afterward so it can serve more evals; pass `--stop-bot` to shut it down when the batch finishes.
 

--- a/pipecat/evals/the-eval-loop.mdx
+++ b/pipecat/evals/the-eval-loop.mdx
@@ -21,7 +21,7 @@ Steps 2 through 5 need no human in the loop. You review the final diff with the 
 
 The framework was built to be driven by tools, not just humans:
 
-- **One command, one exit code.** `pipecat eval run scenarios/*.yaml` exits `0` on success and `1` on failure, so an assistant knows mechanically whether it's done.
+- **One command, one exit code.** `pipecat eval run scenarios/` exits `0` on success and `1` on failure, so an assistant knows mechanically whether it's done.
 - **Plain-text output when piped.** Outside a terminal the CLI streams one result line per scenario instead of rendering a live dashboard, which is exactly what an assistant running shell commands sees.
 - **Actionable failures.** Failures name the turn, the expectation, and the reason, including what the judge said. The `.eval.log` decision trace shows every event the harness observed, so "why did this fail" is answerable from files.
 - **Suites are self-contained.** `pipecat eval suite` spawns the agents itself, so an autonomous loop doesn't need to manage processes: edit, run one command, read the result.
@@ -37,7 +37,7 @@ Keep scenarios in the repo next to the agent and tell your assistant how to run 
 Evals live in `scenarios/`. To verify any change to the agent's behavior:
 
 1. Start the agent: `uv run bot.py -t eval` (serves ws://localhost:7860)
-2. Run the evals: `pipecat eval run scenarios/*.yaml`
+2. Run the evals: `pipecat eval run scenarios/`
 
 The command exits non-zero on failure and prints each failed assertion.
 Each scenario writes a decision trace to `<scenario>.eval.log`; read it


### PR DESCRIPTION
Follows pipecat-ai/pipecat#5463, which makes a directory passed to `pipecat eval run` contribute its `.yml` files as well as its `.yaml` ones. Both pages said `*.yaml`.

- `api-reference/cli/eval.mdx` — the `SCENARIOS...` argument now says `.yaml` and `.yml`.
- `pipecat/evals/suites.mdx` — same, and an empty directory is described as holding no scenarios rather than no `.yaml` files.

The pages also ran `pipecat eval run scenarios/*.yaml` in three places. A shell glob doesn't expand in `cmd.exe`, and it fixes the list at the moment it's typed, so a scenario added later is silently skipped. Those now pass the directory, which is the form the argument description already advertises:

- `api-reference/cli/eval.mdx` — the Examples block.
- `pipecat/evals/the-eval-loop.mdx` — the "one command, one exit code" bullet and the instructions a project is told to give its coding assistant. Both are lines meant to be copied verbatim.

`pipecat/evals/suites.mdx` keeps its glob: it sits directly above the directory form and is there to show that several files can be passed at once.

Merge after the pipecat PR lands.