### PR TITLE
docs: mark the deprecated APIs the docs still taught

### DIFF
--- a/api-reference/pipecat-flows/flow-manager.mdx
+++ b/api-reference/pipecat-flows/flow-manager.mdx
@@ -239,7 +239,7 @@ node_config = NodeConfig(
 ### Basic Setup
 
 ```python
-from pipecat.flows import FlowManager, FlowResult, NodeConfig
+from pipecat.flows import FlowManager, NodeConfig
 
 async def create_initial_node() -> NodeConfig:
     return NodeConfig(

--- a/api-reference/server/frames/control-frames.mdx
+++ b/api-reference/server/frames/control-frames.mdx
@@ -248,8 +248,9 @@ Base frame for runtime service settings updates.
 
 Inherits from `UninterruptibleFrame`.
 
-<ParamField path="settings" type="Mapping[str, Any]" default="{}">
-  Dictionary of settings to update.
+<ParamField path="settings" type="Mapping[str, Any]" default="{}" deprecated>
+  Dictionary of settings to update. _Deprecated in v0.0.104. Use `delta` with a
+  typed settings object instead. Will be removed in 2.0.0._
 </ParamField>
 
 <ParamField path="delta" type="ServiceSettings | None" default="None">

--- a/api-reference/server/services/analytics/floe.mdx
+++ b/api-reference/server/services/analytics/floe.mdx
@@ -97,14 +97,14 @@ override for a negotiated rate.
 ## Usage
 
 Place the processor **directly after the LLM service**, and create the
-`PipelineTask` with usage metrics enabled (Pipecat only emits usage frames when
+`PipelineWorker` with usage metrics enabled (Pipecat only emits usage frames when
 they are on):
 
 ```python
 from floe_guard import BudgetGuard
 from floe_guard.integrations.pipecat import FloeBudgetGuardProcessor
 from pipecat.pipeline.pipeline import Pipeline
-from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 
 guard = BudgetGuard(limit_usd=1.00)                  # your ceiling
 budget = FloeBudgetGuardProcessor(
@@ -115,7 +115,7 @@ budget = FloeBudgetGuardProcessor(
 )
 
 pipeline = Pipeline([transport.input(), stt, llm, budget, tts, transport.output()])
-task = PipelineTask(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
 )

--- a/api-reference/server/services/translation/pinch.mdx
+++ b/api-reference/server/services/translation/pinch.mdx
@@ -102,7 +102,7 @@ Configuration passed via the `options` constructor argument using
 
 ```python
 from pipecat.pipeline.pipeline import Pipeline
-from pipecat.pipeline.runner import PipelineRunner
+from pipecat.workers.runner import WorkerRunner
 from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 from pipecat.plugins.pinch import PinchTranslatorService, TranslatorOptions
 

--- a/api-reference/server/services/transport/transport-params.mdx
+++ b/api-reference/server/services/transport/transport-params.mdx
@@ -5,7 +5,7 @@ description: "TransportParams is the base configuration class shared by all Pipe
 
 ## Overview
 
-`TransportParams` is the base configuration class for all Pipecat transports. It controls audio input/output settings, video settings, and voice activity detection. Every transport's params class (`DailyParams`, `LiveKitParams`, `WebsocketServerParams`, etc.) inherits from `TransportParams`.
+`TransportParams` is the base configuration class for all Pipecat transports. It controls audio input/output settings, video settings, and voice activity detection. Every transport's params class (`DailyParams`, `LiveKitParams`, `SingleClientWebsocketServerParams`, etc.) inherits from `TransportParams`.
 
 You typically pass these via the transport's `params` argument:
 
@@ -170,10 +170,10 @@ removed in 2.0.0.
 
 Each transport extends `TransportParams` with provider-specific fields:
 
-| Transport                                                                               | Params Class             | Additional Fields                                                                          |
-| --------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------ |
-| [DailyTransport](/api-reference/server/services/transport/daily)                        | `DailyParams`            | `api_key`, `api_url`, `dialin_settings`, `transcription_enabled`, `transcription_settings` |
-| [LiveKitTransport](/api-reference/server/services/transport/livekit)                    | `LiveKitParams`          | (no additional fields)                                                                     |
-| [SmallWebRTCTransport](/api-reference/server/services/transport/small-webrtc)           | `TransportParams`        | Uses base class directly                                                                   |
-| [WebsocketServerTransport](/api-reference/server/services/transport/websocket-server)   | `WebsocketServerParams`  | `add_wav_header`, `serializer`, `session_timeout`                                          |
-| [FastAPIWebsocketTransport](/api-reference/server/services/transport/fastapi-websocket) | `FastAPIWebsocketParams` | `serializer`, `session_timeout`                                                            |
+| Transport                                                                                         | Params Class                        | Additional Fields                                                                          |
+| ------------------------------------------------------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------ |
+| [DailyTransport](/api-reference/server/services/transport/daily)                                  | `DailyParams`                       | `api_key`, `api_url`, `dialin_settings`, `transcription_enabled`, `transcription_settings` |
+| [LiveKitTransport](/api-reference/server/services/transport/livekit)                              | `LiveKitParams`                     | (no additional fields)                                                                     |
+| [SmallWebRTCTransport](/api-reference/server/services/transport/small-webrtc)                     | `TransportParams`                   | Uses base class directly                                                                   |
+| [SingleClientWebsocketServerTransport](/api-reference/server/services/transport/websocket-server) | `SingleClientWebsocketServerParams` | `add_wav_header`, `serializer`, `session_timeout`                                          |
+| [FastAPIWebsocketTransport](/api-reference/server/services/transport/fastapi-websocket)           | `FastAPIWebsocketParams`            | `serializer`, `session_timeout`                                                            |

--- a/api-reference/server/services/transport/websocket-server.mdx
+++ b/api-reference/server/services/transport/websocket-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: "WebSocket Transports"
 sidebarTitle: "WebSocket"
-description: "WebsocketServerTransport and WebsocketClientTransport connect Pipecat to clients over plain WebSockets for real-time audio."
+description: "SingleClientWebsocketServerTransport and WebsocketClientTransport connect Pipecat to clients over plain WebSockets for real-time audio."
 ---
 
 ## Overview
@@ -81,9 +81,17 @@ Before using WebSocket transports, you need:
 
 ## Configuration
 
-### WebsocketServerTransport
+### SingleClientWebsocketServerTransport
 
-<ParamField path="params" type="WebsocketServerParams" required>
+<Warning>
+  `WebsocketServerTransport` and `WebsocketServerParams` are deprecated since
+  v1.4.0 and will be removed in 2.0.0. They remain as aliases for
+  `SingleClientWebsocketServerTransport` and
+  `SingleClientWebsocketServerParams`, whose names say what they do: the server
+  accepts a single client connection.
+</Warning>
+
+<ParamField path="params" type="SingleClientWebsocketServerParams" required>
   Transport configuration parameters.
 </ParamField>
 
@@ -103,7 +111,7 @@ Before using WebSocket transports, you need:
   Optional name for the output transport processor.
 </ParamField>
 
-### WebsocketServerParams
+### SingleClientWebsocketServerParams
 
 Inherits from `TransportParams` with additional WebSocket-specific parameters.
 
@@ -181,7 +189,7 @@ See the [complete examples](https://github.com/pipecat-ai/pipecat-examples/tree/
 
 WebSocket transports provide event handlers for client connection lifecycle and session management. Register handlers using the `@event_handler` decorator on the transport instance.
 
-### WebsocketServerTransport Events
+### SingleClientWebsocketServerTransport Events
 
 #### Events Summary
 
@@ -204,10 +212,10 @@ async def on_client_connected(transport, websocket):
 
 **Parameters:**
 
-| Parameter   | Type                       | Description                     |
-| ----------- | -------------------------- | ------------------------------- |
-| `transport` | `WebsocketServerTransport` | The transport instance          |
-| `websocket` | `WebSocketServerProtocol`  | The WebSocket connection object |
+| Parameter   | Type                                   | Description                     |
+| ----------- | -------------------------------------- | ------------------------------- |
+| `transport` | `SingleClientWebsocketServerTransport` | The transport instance          |
+| `websocket` | `WebSocketServerProtocol`              | The WebSocket connection object |
 
 #### on_client_disconnected
 
@@ -221,10 +229,10 @@ async def on_client_disconnected(transport, websocket):
 
 **Parameters:**
 
-| Parameter   | Type                       | Description                     |
-| ----------- | -------------------------- | ------------------------------- |
-| `transport` | `WebsocketServerTransport` | The transport instance          |
-| `websocket` | `WebSocketServerProtocol`  | The WebSocket connection object |
+| Parameter   | Type                                   | Description                     |
+| ----------- | -------------------------------------- | ------------------------------- |
+| `transport` | `SingleClientWebsocketServerTransport` | The transport instance          |
+| `websocket` | `WebSocketServerProtocol`              | The WebSocket connection object |
 
 #### on_session_timeout
 
@@ -238,10 +246,10 @@ async def on_session_timeout(transport, websocket):
 
 **Parameters:**
 
-| Parameter   | Type                       | Description                     |
-| ----------- | -------------------------- | ------------------------------- |
-| `transport` | `WebsocketServerTransport` | The transport instance          |
-| `websocket` | `WebSocketServerProtocol`  | The WebSocket connection object |
+| Parameter   | Type                                   | Description                     |
+| ----------- | -------------------------------------- | ------------------------------- |
+| `transport` | `SingleClientWebsocketServerTransport` | The transport instance          |
+| `websocket` | `WebSocketServerProtocol`              | The WebSocket connection object |
 
 #### on_websocket_ready
 
@@ -255,9 +263,9 @@ async def on_websocket_ready(transport):
 
 **Parameters:**
 
-| Parameter   | Type                       | Description            |
-| ----------- | -------------------------- | ---------------------- |
-| `transport` | `WebsocketServerTransport` | The transport instance |
+| Parameter   | Type                                   | Description            |
+| ----------- | -------------------------------------- | ---------------------- |
+| `transport` | `SingleClientWebsocketServerTransport` | The transport instance |
 
 ### WebsocketClientTransport Events
 

--- a/api-reference/server/services/tts/tts-cache.mdx
+++ b/api-reference/server/services/tts/tts-cache.mdx
@@ -191,12 +191,12 @@ await tts.clear_cache(namespace="user_123")
 The caching layer works with all Pipecat TTS services, applying a different
 caching strategy depending on the service architecture:
 
-| Service type          | Caching strategy                                                | Supported providers (examples)  |
-| --------------------- | --------------------------------------------------------------- | ------------------------------- |
-| `AudioContextWordTTS` | Batch caching — splits audio at word boundaries per sentence    | Cartesia, Rime                  |
-| `WordTTSService`      | Full caching with preserved word-level timestamps               | ElevenLabs, Hume                |
-| `TTSService`          | Standard caching of the full audio response (no alignment data) | Google, OpenAI, Deepgram (HTTP) |
-| `InterruptibleTTS`    | Sentence caching — single-sentence responses only               | Sarvam, Deepgram (WebSocket)    |
+| Service type          | Caching strategy                                                                                                 | Supported providers (examples)  |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `AudioContextWordTTS` | Batch caching — splits audio at word boundaries per sentence                                                     | Cartesia, Rime                  |
+| `WordTTSService`      | Full caching with preserved word-level timestamps. _Deprecated in v0.0.105; use `TTSService`. Removed in 2.0.0._ | ElevenLabs, Hume                |
+| `TTSService`          | Standard caching of the full audio response (no alignment data)                                                  | Google, OpenAI, Deepgram (HTTP) |
+| `InterruptibleTTS`    | Sentence caching — single-sentence responses only                                                                | Sarvam, Deepgram (WebSocket)    |
 
 Tested with Pipecat v0.0.91+. Check the [source
 repository](https://github.com/omChauhanDev/pipecat-tts-cache) for the latest

--- a/api-reference/server/services/tts/vakyam.mdx
+++ b/api-reference/server/services/tts/vakyam.mdx
@@ -135,7 +135,7 @@ while the pipeline is running.
 import os
 
 from pipecat.pipeline.pipeline import Pipeline
-from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 from pipecat_vakyam import VakyamTTSService
 
 tts = VakyamTTSService(
@@ -157,7 +157,7 @@ pipeline = Pipeline(
         context_aggregator.assistant(),
     ]
 )
-task = PipelineTask(pipeline, params=PipelineParams(allow_interruptions=True))
+worker = PipelineWorker(pipeline, params=PipelineParams(allow_interruptions=True))
 ```
 
 To speak Hindi instead of Tamil, change the language code:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3455,28 +3455,32 @@ Each STT service has its own customization options. Refer to specific service do
   Explore configuration options for each supported STT provider
 </Card>
 
-For example, let's look at configuring the **DeepgramSTTService** using the `LiveOptions` class:
+For example, let's look at configuring the **DeepgramSTTService**:
 
 ```python
-from deepgram import LiveOptions
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.transcriptions.language import Language
 
-# Configure using LiveOptions for full control
-live_options = LiveOptions(
-    model="nova-2",
-    language=Language.EN_US,
-    interim_results=True,        # Enable interim transcripts
-    punctuate=True,              # Add punctuation
-    profanity_filter=True,       # Filter profanity
-    vad_events=False,            # Use pipeline VAD instead
-)
-
 stt = DeepgramSTTService(
     api_key=os.getenv("DEEPGRAM_API_KEY"),
-    live_options=live_options,
+    settings=DeepgramSTTService.Settings(
+        model="nova-2",
+        language=Language.EN_US,
+        interim_results=True,    # Enable interim transcripts
+        punctuate=True,          # Add punctuation
+        profanity_filter=True,   # Filter profanity
+        vad_events=False,        # Use pipeline VAD instead
+    ),
 )
 ```
+
+<Warning>
+  The `live_options` parameter and the `LiveOptions` class re-exported from
+  `pipecat.services.deepgram.stt` are deprecated since v0.0.105 and will be
+  removed in 2.0.0. Use `DeepgramSTTService.Settings` instead. Settings are also
+  updatable mid-conversation — see [Service
+  Settings](/pipecat/fundamentals/service-settings).
+</Warning>
 
 ### STTService Base Class Configuration
 
@@ -11457,10 +11461,10 @@ This guide takes an existing agent, starts it with the eval transport, and runs 
     If your agent uses `create_transport()`, it supports the eval transport with a one-line addition to its `transport_params`:
 
     ```python
-    from pipecat.transports.websocket.server import WebsocketServerParams
+    from pipecat.transports.websocket.server import SingleClientWebsocketServerParams
 
     transport_params = {
-        "eval": lambda: WebsocketServerParams(
+        "eval": lambda: SingleClientWebsocketServerParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
         ),
@@ -25293,7 +25297,7 @@ Deleting an agent deployment will block any new sessions from starting, but will
 
 Every service has a maximum session duration. When a session reaches this limit, the session is stopped: your `bot()` function is cancelled.
 
-This is a platform-level safeguard, not a polite signal. If your bot runs its pipeline through `PipelineRunner`, the runner absorbs the cancellation and unwinds the pipeline for you, so each processor's `cleanup()` still runs. Otherwise your `bot()` simply sees a `CancelledError` wherever it is currently awaiting, and any cleanup is up to you. Either way the bot gets no opportunity to say anything before the session ends — if you want it to say goodbye, implement your own timer in bot code that fires slightly earlier.
+This is a platform-level safeguard, not a polite signal. If your bot runs its pipeline through `WorkerRunner`, the runner absorbs the cancellation and unwinds the pipeline for you, so each processor's `cleanup()` still runs. Otherwise your `bot()` simply sees a `CancelledError` wherever it is currently awaiting, and any cleanup is up to you. Either way the bot gets no opportunity to say anything before the session ends — if you want it to say goodbye, implement your own timer in bot code that fires slightly earlier.
 
 <Note>
   Enforcing the limit inside the bot process requires **base image 0.1.27 or
@@ -34065,7 +34069,7 @@ async def on_client_disconnected(transport, data):
 # WebSocket Transports
 Source: https://docs.pipecat.ai/api-reference/server/services/transport/websocket-server.md
 
-WebsocketServerTransport and WebsocketClientTransport connect Pipecat to clients over plain WebSockets for real-time audio.
+SingleClientWebsocketServerTransport and WebsocketClientTransport connect Pipecat to clients over plain WebSockets for real-time audio.
 
 ## Overview
 
@@ -34144,9 +34148,17 @@ Before using WebSocket transports, you need:
 
 ## Configuration
 
-### WebsocketServerTransport
+### SingleClientWebsocketServerTransport
 
-<ParamField path="params" type="WebsocketServerParams" required>
+<Warning>
+  `WebsocketServerTransport` and `WebsocketServerParams` are deprecated since
+  v1.4.0 and will be removed in 2.0.0. They remain as aliases for
+  `SingleClientWebsocketServerTransport` and
+  `SingleClientWebsocketServerParams`, whose names say what they do: the server
+  accepts a single client connection.
+</Warning>
+
+<ParamField path="params" type="SingleClientWebsocketServerParams" required>
   Transport configuration parameters.
 </ParamField>
 
@@ -34166,7 +34178,7 @@ Before using WebSocket transports, you need:
   Optional name for the output transport processor.
 </ParamField>
 
-### WebsocketServerParams
+### SingleClientWebsocketServerParams
 
 Inherits from `TransportParams` with additional WebSocket-specific parameters.
 
@@ -34244,7 +34256,7 @@ See the [complete examples](https://github.com/pipecat-ai/pipecat-examples/tree/
 
 WebSocket transports provide event handlers for client connection lifecycle and session management. Register handlers using the `@event_handler` decorator on the transport instance.
 
-### WebsocketServerTransport Events
+### SingleClientWebsocketServerTransport Events
 
 #### Events Summary
 
@@ -34267,10 +34279,10 @@ async def on_client_connected(transport, websocket):
 
 **Parameters:**
 
-| Parameter   | Type                       | Description                     |
-| ----------- | -------------------------- | ------------------------------- |
-| `transport` | `WebsocketServerTransport` | The transport instance          |
-| `websocket` | `WebSocketServerProtocol`  | The WebSocket connection object |
+| Parameter   | Type                                   | Description                     |
+| ----------- | -------------------------------------- | ------------------------------- |
+| `transport` | `SingleClientWebsocketServerTransport` | The transport instance          |
+| `websocket` | `WebSocketServerProtocol`              | The WebSocket connection object |
 
 #### on_client_disconnected
 
@@ -34284,10 +34296,10 @@ async def on_client_disconnected(transport, websocket):
 
 **Parameters:**
 
-| Parameter   | Type                       | Description                     |
-| ----------- | -------------------------- | ------------------------------- |
-| `transport` | `WebsocketServerTransport` | The transport instance          |
-| `websocket` | `WebSocketServerProtocol`  | The WebSocket connection object |
+| Parameter   | Type                                   | Description                     |
+| ----------- | -------------------------------------- | ------------------------------- |
+| `transport` | `SingleClientWebsocketServerTransport` | The transport instance          |
+| `websocket` | `WebSocketServerProtocol`              | The WebSocket connection object |
 
 #### on_session_timeout
 
@@ -34301,10 +34313,10 @@ async def on_session_timeout(transport, websocket):
 
 **Parameters:**
 
-| Parameter   | Type                       | Description                     |
-| ----------- | -------------------------- | ------------------------------- |
-| `transport` | `WebsocketServerTransport` | The transport instance          |
-| `websocket` | `WebSocketServerProtocol`  | The WebSocket connection object |
+| Parameter   | Type                                   | Description                     |
+| ----------- | -------------------------------------- | ------------------------------- |
+| `transport` | `SingleClientWebsocketServerTransport` | The transport instance          |
+| `websocket` | `WebSocketServerProtocol`              | The WebSocket connection object |
 
 #### on_websocket_ready
 
@@ -34318,9 +34330,9 @@ async def on_websocket_ready(transport):
 
 **Parameters:**
 
-| Parameter   | Type                       | Description            |
-| ----------- | -------------------------- | ---------------------- |
-| `transport` | `WebsocketServerTransport` | The transport instance |
+| Parameter   | Type                                   | Description            |
+| ----------- | -------------------------------------- | ---------------------- |
+| `transport` | `SingleClientWebsocketServerTransport` | The transport instance |
 
 ### WebsocketClientTransport Events
 
@@ -34533,7 +34545,7 @@ TransportParams is the base configuration class shared by all Pipecat transports
 
 ## Overview
 
-`TransportParams` is the base configuration class for all Pipecat transports. It controls audio input/output settings, video settings, and voice activity detection. Every transport's params class (`DailyParams`, `LiveKitParams`, `WebsocketServerParams`, etc.) inherits from `TransportParams`.
+`TransportParams` is the base configuration class for all Pipecat transports. It controls audio input/output settings, video settings, and voice activity detection. Every transport's params class (`DailyParams`, `LiveKitParams`, `SingleClientWebsocketServerParams`, etc.) inherits from `TransportParams`.
 
 You typically pass these via the transport's `params` argument:
 
@@ -34698,13 +34710,13 @@ removed in 2.0.0.
 
 Each transport extends `TransportParams` with provider-specific fields:
 
-| Transport                                                                               | Params Class             | Additional Fields                                                                          |
-| --------------------------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------ |
-| [DailyTransport](/api-reference/server/services/transport/daily)                        | `DailyParams`            | `api_key`, `api_url`, `dialin_settings`, `transcription_enabled`, `transcription_settings` |
-| [LiveKitTransport](/api-reference/server/services/transport/livekit)                    | `LiveKitParams`          | (no additional fields)                                                                     |
-| [SmallWebRTCTransport](/api-reference/server/services/transport/small-webrtc)           | `TransportParams`        | Uses base class directly                                                                   |
-| [WebsocketServerTransport](/api-reference/server/services/transport/websocket-server)   | `WebsocketServerParams`  | `add_wav_header`, `serializer`, `session_timeout`                                          |
-| [FastAPIWebsocketTransport](/api-reference/server/services/transport/fastapi-websocket) | `FastAPIWebsocketParams` | `serializer`, `session_timeout`                                                            |
+| Transport                                                                                         | Params Class                        | Additional Fields                                                                          |
+| ------------------------------------------------------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------ |
+| [DailyTransport](/api-reference/server/services/transport/daily)                                  | `DailyParams`                       | `api_key`, `api_url`, `dialin_settings`, `transcription_enabled`, `transcription_settings` |
+| [LiveKitTransport](/api-reference/server/services/transport/livekit)                              | `LiveKitParams`                     | (no additional fields)                                                                     |
+| [SmallWebRTCTransport](/api-reference/server/services/transport/small-webrtc)                     | `TransportParams`                   | Uses base class directly                                                                   |
+| [SingleClientWebsocketServerTransport](/api-reference/server/services/transport/websocket-server) | `SingleClientWebsocketServerParams` | `add_wav_header`, `serializer`, `session_timeout`                                          |
+| [FastAPIWebsocketTransport](/api-reference/server/services/transport/fastapi-websocket)           | `FastAPIWebsocketParams`            | `serializer`, `session_timeout`                                                            |
 
 # Frame Serializer Overview
 Source: https://docs.pipecat.ai/api-reference/server/services/serializers/introduction.md
@@ -58147,12 +58159,12 @@ await tts.clear_cache(namespace="user_123")
 The caching layer works with all Pipecat TTS services, applying a different
 caching strategy depending on the service architecture:
 
-| Service type          | Caching strategy                                                | Supported providers (examples)  |
-| --------------------- | --------------------------------------------------------------- | ------------------------------- |
-| `AudioContextWordTTS` | Batch caching — splits audio at word boundaries per sentence    | Cartesia, Rime                  |
-| `WordTTSService`      | Full caching with preserved word-level timestamps               | ElevenLabs, Hume                |
-| `TTSService`          | Standard caching of the full audio response (no alignment data) | Google, OpenAI, Deepgram (HTTP) |
-| `InterruptibleTTS`    | Sentence caching — single-sentence responses only               | Sarvam, Deepgram (WebSocket)    |
+| Service type          | Caching strategy                                                                                                 | Supported providers (examples)  |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `AudioContextWordTTS` | Batch caching — splits audio at word boundaries per sentence                                                     | Cartesia, Rime                  |
+| `WordTTSService`      | Full caching with preserved word-level timestamps. _Deprecated in v0.0.105; use `TTSService`. Removed in 2.0.0._ | ElevenLabs, Hume                |
+| `TTSService`          | Standard caching of the full audio response (no alignment data)                                                  | Google, OpenAI, Deepgram (HTTP) |
+| `InterruptibleTTS`    | Sentence caching — single-sentence responses only                                                                | Sarvam, Deepgram (WebSocket)    |
 
 Tested with Pipecat v0.0.91+. Check the [source
 repository](https://github.com/omChauhanDev/pipecat-tts-cache) for the latest
@@ -58623,7 +58635,7 @@ while the pipeline is running.
 import os
 
 from pipecat.pipeline.pipeline import Pipeline
-from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 from pipecat_vakyam import VakyamTTSService
 
 tts = VakyamTTSService(
@@ -58645,7 +58657,7 @@ pipeline = Pipeline(
         context_aggregator.assistant(),
     ]
 )
-task = PipelineTask(pipeline, params=PipelineParams(allow_interruptions=True))
+worker = PipelineWorker(pipeline, params=PipelineParams(allow_interruptions=True))
 ```
 
 To speak Hindi instead of Tamil, change the language code:
@@ -64415,14 +64427,14 @@ override for a negotiated rate.
 ## Usage
 
 Place the processor **directly after the LLM service**, and create the
-`PipelineTask` with usage metrics enabled (Pipecat only emits usage frames when
+`PipelineWorker` with usage metrics enabled (Pipecat only emits usage frames when
 they are on):
 
 ```python
 from floe_guard import BudgetGuard
 from floe_guard.integrations.pipecat import FloeBudgetGuardProcessor
 from pipecat.pipeline.pipeline import Pipeline
-from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 
 guard = BudgetGuard(limit_usd=1.00)                  # your ceiling
 budget = FloeBudgetGuardProcessor(
@@ -64433,7 +64445,7 @@ budget = FloeBudgetGuardProcessor(
 )
 
 pipeline = Pipeline([transport.input(), stt, llm, budget, tts, transport.output()])
-task = PipelineTask(
+worker = PipelineWorker(
     pipeline,
     params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
 )
@@ -65696,7 +65708,7 @@ Configuration passed via the `options` constructor argument using
 
 ```python
 from pipecat.pipeline.pipeline import Pipeline
-from pipecat.pipeline.runner import PipelineRunner
+from pipecat.workers.runner import WorkerRunner
 from pipecat.pipeline.worker import PipelineParams, PipelineWorker
 from pipecat.plugins.pinch import PinchTranslatorService, TranslatorOptions
 
@@ -78207,8 +78219,9 @@ Base frame for runtime service settings updates.
 
 Inherits from `UninterruptibleFrame`.
 
-<ParamField path="settings" type="Mapping[str, Any]" default="{}">
-  Dictionary of settings to update.
+<ParamField path="settings" type="Mapping[str, Any]" default="{}" deprecated>
+  Dictionary of settings to update. _Deprecated in v0.0.104. Use `delta` with a
+  typed settings object instead. Will be removed in 2.0.0._
 </ParamField>
 
 <ParamField path="delta" type="ServiceSettings | None" default="None">
@@ -87595,7 +87608,7 @@ node_config = NodeConfig(
 ### Basic Setup
 
 ```python
-from pipecat.flows import FlowManager, FlowResult, NodeConfig
+from pipecat.flows import FlowManager, NodeConfig
 
 async def create_initial_node() -> NodeConfig:
     return NodeConfig(

--- a/llms.txt
+++ b/llms.txt
@@ -284,7 +284,7 @@ LLM, transports, serializers), pipelines, frames, workers, and utilities.
 - [Small WebRTC Transport](https://docs.pipecat.ai/api-reference/server/services/transport/small-webrtc.md): SmallWebRTCTransport makes serverless peer-to-peer WebRTC connections between a client and your Pipecat bot, no provider needed.
 - [Tavus Transport](https://docs.pipecat.ai/api-reference/server/services/transport/tavus.md): TavusTransport joins your Pipecat bot to the same virtual room as a Tavus avatar for conversational video sessions.
 - [Vonage Video Connector Transport](https://docs.pipecat.ai/api-reference/server/services/transport/vonage.md): VonageVideoConnectorTransport provides real-time WebRTC audio and video for Pipecat using the Vonage Video API.
-- [WebSocket Transports](https://docs.pipecat.ai/api-reference/server/services/transport/websocket-server.md): WebsocketServerTransport and WebsocketClientTransport connect Pipecat to clients over plain WebSockets for real-time audio.
+- [WebSocket Transports](https://docs.pipecat.ai/api-reference/server/services/transport/websocket-server.md): SingleClientWebsocketServerTransport and WebsocketClientTransport connect Pipecat to clients over plain WebSockets for real-time audio.
 - [WhatsApp Transport](https://docs.pipecat.ai/api-reference/server/services/transport/whatsapp.md): WhatsAppTransport connects Pipecat bots to WhatsApp voice calls via the WhatsApp Business API and SmallWebRTCTransport.
 - [TransportParams](https://docs.pipecat.ai/api-reference/server/services/transport/transport-params.md): TransportParams is the base configuration class shared by all Pipecat transports: audio, video, and VAD settings.
 

--- a/pipecat-cloud/fundamentals/active-sessions.mdx
+++ b/pipecat-cloud/fundamentals/active-sessions.mdx
@@ -336,7 +336,7 @@ Deleting an agent deployment will block any new sessions from starting, but will
 
 Every service has a maximum session duration. When a session reaches this limit, the session is stopped: your `bot()` function is cancelled.
 
-This is a platform-level safeguard, not a polite signal. If your bot runs its pipeline through `PipelineRunner`, the runner absorbs the cancellation and unwinds the pipeline for you, so each processor's `cleanup()` still runs. Otherwise your `bot()` simply sees a `CancelledError` wherever it is currently awaiting, and any cleanup is up to you. Either way the bot gets no opportunity to say anything before the session ends — if you want it to say goodbye, implement your own timer in bot code that fires slightly earlier.
+This is a platform-level safeguard, not a polite signal. If your bot runs its pipeline through `WorkerRunner`, the runner absorbs the cancellation and unwinds the pipeline for you, so each processor's `cleanup()` still runs. Otherwise your `bot()` simply sees a `CancelledError` wherever it is currently awaiting, and any cleanup is up to you. Either way the bot gets no opportunity to say anything before the session ends — if you want it to say goodbye, implement your own timer in bot code that fires slightly earlier.
 
 <Note>
   Enforcing the limit inside the bot process requires **base image 0.1.27 or

--- a/pipecat/evals/quickstart.mdx
+++ b/pipecat/evals/quickstart.mdx
@@ -19,10 +19,10 @@ This guide takes an existing agent, starts it with the eval transport, and runs 
     If your agent uses `create_transport()`, it supports the eval transport with a one-line addition to its `transport_params`:
 
     ```python
-    from pipecat.transports.websocket.server import WebsocketServerParams
+    from pipecat.transports.websocket.server import SingleClientWebsocketServerParams
 
     transport_params = {
-        "eval": lambda: WebsocketServerParams(
+        "eval": lambda: SingleClientWebsocketServerParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
         ),

--- a/pipecat/learn/speech-to-text.mdx
+++ b/pipecat/learn/speech-to-text.mdx
@@ -125,28 +125,32 @@ Each STT service has its own customization options. Refer to specific service do
   Explore configuration options for each supported STT provider
 </Card>
 
-For example, let's look at configuring the **DeepgramSTTService** using the `LiveOptions` class:
+For example, let's look at configuring the **DeepgramSTTService**:
 
 ```python
-from deepgram import LiveOptions
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.transcriptions.language import Language
 
-# Configure using LiveOptions for full control
-live_options = LiveOptions(
-    model="nova-2",
-    language=Language.EN_US,
-    interim_results=True,        # Enable interim transcripts
-    punctuate=True,              # Add punctuation
-    profanity_filter=True,       # Filter profanity
-    vad_events=False,            # Use pipeline VAD instead
-)
-
 stt = DeepgramSTTService(
     api_key=os.getenv("DEEPGRAM_API_KEY"),
-    live_options=live_options,
+    settings=DeepgramSTTService.Settings(
+        model="nova-2",
+        language=Language.EN_US,
+        interim_results=True,    # Enable interim transcripts
+        punctuate=True,          # Add punctuation
+        profanity_filter=True,   # Filter profanity
+        vad_events=False,        # Use pipeline VAD instead
+    ),
 )
 ```
+
+<Warning>
+  The `live_options` parameter and the `LiveOptions` class re-exported from
+  `pipecat.services.deepgram.stt` are deprecated since v0.0.105 and will be
+  removed in 2.0.0. Use `DeepgramSTTService.Settings` instead. Settings are also
+  updatable mid-conversation — see [Service
+  Settings](/pipecat/fundamentals/service-settings).
+</Warning>
 
 ### STTService Base Class Configuration
 


### PR DESCRIPTION
An audit against the framework's deprecation registry (`scripts/deprecations/deprecations.json`, 396 entries) found **11 places teaching an API that warns today and is removed in 2.0.0**.

None are from 1.8.0 — the recent PRs covered that release. The residue is 1.3–1.5 plus the old `0.0.105` settings migration.

| Page | Symbol | Deprecated |
| --- | --- | --- |
| `transport/websocket-server` | `WebsocketServerTransport`, `WebsocketServerParams` | 1.4.0 |
| `transport/transport-params` | same two | 1.4.0 |
| `evals/quickstart` | `WebsocketServerParams` | 1.4.0 |
| `analytics/floe` | `PipelineTask`, `pipecat.pipeline.task` | 1.3.0 |
| `tts/vakyam` | `PipelineTask`, `pipecat.pipeline.task` | 1.3.0 |
| `translation/pinch` | `PipelineRunner` | 1.3.0 |
| `pipecat-cloud/active-sessions` | `PipelineRunner` | 1.3.0 |
| `tts/tts-cache` | `WordTTSService` | 0.0.105 |
| `learn/speech-to-text` | `LiveOptions` / `live_options` | 0.0.105 |
| `pipecat-flows/flow-manager` | `FlowResult` | 1.5.0 |
| `frames/control-frames` | `ServiceUpdateSettingsFrame.settings` | 0.0.104 |

## Two different fixes

**Where the deprecated name was the subject of a code sample, the sample is rewritten** rather than annotated — someone copying a snippet should get working code, not a footnote. `PipelineTask` → `PipelineWorker`, `PipelineRunner` → `WorkerRunner`, and the Deepgram example now uses `Settings` instead of `live_options`.

**Where the page describes an API rather than teaching it, the item is marked in place** — `ServiceUpdateSettingsFrame.settings` gets the `deprecated` attribute pointing at `delta`, and the `WordTTSService` row in the caching table gets an inline note.

## The websocket page

Worst of the set, and worth a look on its own. It taught `WebsocketServerTransport` in its frontmatter description, its section headings, and all four event tables — while `SingleClientWebsocketServerTransport` appeared on **zero pages sitewide**. Since the old names are subclass aliases of the new ones, the page now documents the current names throughout, with a note that the aliases survive until 2.0.0.

## Note on method

The first automated pass flagged 1,656 findings; 11 survived verification. The false positives are instructive if we ever build a lint for this: `InputParams` is deprecated *per service* so the bare name hits pages with their own live class, `model=` inside `Settings(...)` is the correct modern form, and module deprecations reduce to leaf words like `tts` that match everywhere. A naive check would be unusable.

A companion PR on pipecat adds a deprecations rule to the `update-docs` skill so this is handled per-PR rather than by periodic audit.

Checks: `docs-meta-lint` 0 errors, `mint broken-links --check-anchors --check-redirects` clean, `llms.txt` and `llms-full.txt` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)