### PR TITLE
docs: document STT usage metrics

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8929,6 +8929,7 @@ When metrics are enabled, Pipecat emits a `MetricsFrame` for each interaction. T
 - `TTFATMetricsData` — Time To First Answer Token (LLM)
 - `ProcessingMetricsData` — Processing time
 - `LLMUsageMetricsData` — LLM token usage
+- `STTUsageMetricsData` — STT audio-seconds usage
 - `TTSUsageMetricsData` — TTS character usage
 - `TextAggregationMetricsData` — Sentence aggregation latency (TTS)
 - `TurnMetricsData` — Turn completion predictions
@@ -9083,6 +9084,16 @@ Token usage for an LLM interaction. The `value` field is an `LLMTokenUsage` obje
 | `input_audio_tokens`            | `Optional[int]` | Prompt tokens that were audio (realtime models)     |
 | `output_audio_tokens`           | `Optional[int]` | Completion tokens that were audio (realtime models) |
 | `cache_read_input_audio_tokens` | `Optional[int]` | Cache-read tokens that were audio (realtime models) |
+
+### STTUsageMetricsData
+
+Audio usage for an STT interaction, measured client-side as the seconds of audio submitted to the service. Streaming services report incrementally, once per final transcript and again on stop or cancel; segmented services report once per transcribed segment.
+
+| Field   | Type       | Description                                  |
+| ------- | ---------- | -------------------------------------------- |
+| `value` | `STTUsage` | Holds `audio_seconds`, the seconds submitted |
+
+Usage reaches RTVI clients as `stt_usage`, is logged by `MetricsLogObserver`, and is attached to OpenTelemetry `stt` spans as `metrics.audio_seconds`.
 
 ### TTSUsageMetricsData
 

--- a/pipecat/fundamentals/metrics.mdx
+++ b/pipecat/fundamentals/metrics.mdx
@@ -117,6 +117,7 @@ When metrics are enabled, Pipecat emits a `MetricsFrame` for each interaction. T
 - `TTFATMetricsData` — Time To First Answer Token (LLM)
 - `ProcessingMetricsData` — Processing time
 - `LLMUsageMetricsData` — LLM token usage
+- `STTUsageMetricsData` — STT audio-seconds usage
 - `TTSUsageMetricsData` — TTS character usage
 - `TextAggregationMetricsData` — Sentence aggregation latency (TTS)
 - `TurnMetricsData` — Turn completion predictions
@@ -271,6 +272,16 @@ Token usage for an LLM interaction. The `value` field is an `LLMTokenUsage` obje
 | `input_audio_tokens`            | `Optional[int]` | Prompt tokens that were audio (realtime models)     |
 | `output_audio_tokens`           | `Optional[int]` | Completion tokens that were audio (realtime models) |
 | `cache_read_input_audio_tokens` | `Optional[int]` | Cache-read tokens that were audio (realtime models) |
+
+### STTUsageMetricsData
+
+Audio usage for an STT interaction, measured client-side as the seconds of audio submitted to the service. Streaming services report incrementally, once per final transcript and again on stop or cancel; segmented services report once per transcribed segment.
+
+| Field   | Type       | Description                                  |
+| ------- | ---------- | -------------------------------------------- |
+| `value` | `STTUsage` | Holds `audio_seconds`, the seconds submitted |
+
+Usage reaches RTVI clients as `stt_usage`, is logged by `MetricsLogObserver`, and is attached to OpenTelemetry `stt` spans as `metrics.audio_seconds`.
 
 ### TTSUsageMetricsData
 


### PR DESCRIPTION
Found while auditing 1.6.0 / 1.7.0 coverage.

Every STT service has reported audio-seconds usage as `STTUsageMetricsData` since 1.7.0 (#5055), but `fundamentals/metrics` listed only `LLMUsageMetricsData` and `TTSUsageMetricsData`. The one metric that tells you what STT is costing was missing from the list a reader scans to find it.

Adds it to the `MetricsFrame` list and gives it a section alongside the other usage types, including how it's emitted — streaming services report incrementally per final transcript with a flush on stop/cancel, segmented services report per segment — and where the value shows up besides the frame: RTVI clients (`stt_usage`), `MetricsLogObserver`, and OpenTelemetry `stt` spans as `metrics.audio_seconds`.

Checks: `docs-meta-lint` 0 errors, `mint broken-links --check-anchors --check-redirects` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)