### PR TITLE
docs: fix pages describing pre-fix behavior (1.6/1.7 sweep)

### DIFF
--- a/api-reference/server/frames/data-frames.mdx
+++ b/api-reference/server/frames/data-frames.mdx
@@ -181,13 +181,16 @@ A non-interim transcription result from an STT service: the service's best recog
 
 <ParamField path="finalized" type="bool" default="False">
   Whether the STT service has explicitly committed this transcription via a
-  finalize signal. Reported by AssemblyAI, Azure, Cartesia (Ink-2), Deepgram
-  Flux, Gemini Live, Google, NVIDIA (including SageMaker), Sarvam, Soniox, and
-  Speechmatics; other services leave it `False`. Turn detection strategies use
-  the flag to close a turn without waiting out the STT fallback timer.
+  finalize signal. Turn detection strategies use the flag to close a turn
+  without waiting out the STT fallback timer.
 
-Note that `DeepgramFluxSTTService` reports it and `DeepgramSTTService` does
-not.
+A service reports it in one of two ways: by marking the frame directly, when
+its provider's response is inherently final, or by calling
+`request_finalize()` and then `confirm_finalize()` once the provider
+acknowledges — in which case the flag is set for that requested finalization
+rather than for every final transcript. Whether a given service does either,
+and under what conditions, is documented on its own page. Services that do
+neither leave it `False`.
 
 </ParamField>
 

--- a/api-reference/server/frames/data-frames.mdx
+++ b/api-reference/server/frames/data-frames.mdx
@@ -181,10 +181,14 @@ A non-interim transcription result from an STT service: the service's best recog
 
 <ParamField path="finalized" type="bool" default="False">
   Whether the STT service has explicitly committed this transcription via a
-  finalize signal. Some services (AssemblyAI, Deepgram, Soniox, Speechmatics)
-  support this; others don't, so it defaults to `False`. Turn detection
-  strategies can use this flag to trigger the bot's response immediately rather
-  than waiting for a timeout.
+  finalize signal. Reported by AssemblyAI, Azure, Cartesia (Ink-2), Deepgram
+  Flux, Gemini Live, Google, NVIDIA (including SageMaker), Sarvam, Soniox, and
+  Speechmatics; other services leave it `False`. Turn detection strategies use
+  the flag to close a turn without waiting out the STT fallback timer.
+
+Note that `DeepgramFluxSTTService` reports it and `DeepgramSTTService` does
+not.
+
 </ParamField>
 
 #### InterimTranscriptionFrame

--- a/api-reference/server/services/serializers/awaazai.mdx
+++ b/api-reference/server/services/serializers/awaazai.mdx
@@ -103,7 +103,7 @@ from the initial websocket `start` message Awaaz AI sends when a call connects.
 
 ```python
 from pipecat_awaazai import AwaazAIFrameSerializer
-from pipecat.transports.network.fastapi_websocket import (
+from pipecat.transports.websocket.fastapi import (
     FastAPIWebsocketTransport,
     FastAPIWebsocketParams,
 )

--- a/api-reference/server/services/serializers/exotel.mdx
+++ b/api-reference/server/services/serializers/exotel.mdx
@@ -93,15 +93,19 @@ Before using ExotelFrameSerializer, you need:
 
 ```python
 from pipecat.serializers.exotel import ExotelFrameSerializer
-from pipecat.transports.network.websocket_server import WebSocketServerTransport
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
 
 serializer = ExotelFrameSerializer(
     stream_sid=stream_sid,
     call_sid=call_sid,
 )
 
-transport = WebSocketServerTransport(
-    params=WebSocketServerParams(
+transport = FastAPIWebsocketTransport(
+    websocket=websocket,
+    params=FastAPIWebsocketParams(
         audio_out_enabled=True,
         add_wav_header=False,
         serializer=serializer,

--- a/api-reference/server/services/serializers/genesys.mdx
+++ b/api-reference/server/services/serializers/genesys.mdx
@@ -83,7 +83,7 @@ Before using GenesysAudioHookSerializer, you need:
 
 ```python
 from pipecat.serializers.genesys import GenesysAudioHookSerializer
-from pipecat.transports.network.fastapi_websocket import (
+from pipecat.transports.websocket.fastapi import (
     FastAPIWebsocketTransport,
     FastAPIWebsocketParams,
 )

--- a/api-reference/server/services/serializers/plivo.mdx
+++ b/api-reference/server/services/serializers/plivo.mdx
@@ -114,7 +114,10 @@ Before using PlivoFrameSerializer, you need:
 
 ```python
 from pipecat.serializers.plivo import PlivoFrameSerializer
-from pipecat.transports.network.websocket_server import WebSocketServerTransport
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
 
 serializer = PlivoFrameSerializer(
     stream_id=stream_id,
@@ -123,8 +126,9 @@ serializer = PlivoFrameSerializer(
     auth_token=os.getenv("PLIVO_AUTH_TOKEN"),
 )
 
-transport = WebSocketServerTransport(
-    params=WebSocketServerParams(
+transport = FastAPIWebsocketTransport(
+    websocket=websocket,
+    params=FastAPIWebsocketParams(
         audio_out_enabled=True,
         add_wav_header=False,
         serializer=serializer,

--- a/api-reference/server/services/serializers/telnyx.mdx
+++ b/api-reference/server/services/serializers/telnyx.mdx
@@ -120,7 +120,10 @@ Before using TelnyxFrameSerializer, you need:
 
 ```python
 from pipecat.serializers.telnyx import TelnyxFrameSerializer
-from pipecat.transports.network.websocket_server import WebSocketServerTransport
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
 
 serializer = TelnyxFrameSerializer(
     stream_id=stream_id,
@@ -130,8 +133,9 @@ serializer = TelnyxFrameSerializer(
     api_key=os.getenv("TELNYX_API_KEY"),
 )
 
-transport = WebSocketServerTransport(
-    params=WebSocketServerParams(
+transport = FastAPIWebsocketTransport(
+    websocket=websocket,
+    params=FastAPIWebsocketParams(
         audio_out_enabled=True,
         add_wav_header=False,
         serializer=serializer,

--- a/api-reference/server/services/serializers/twilio.mdx
+++ b/api-reference/server/services/serializers/twilio.mdx
@@ -130,7 +130,10 @@ Before using TwilioFrameSerializer, you need:
 
 ```python
 from pipecat.serializers.twilio import TwilioFrameSerializer
-from pipecat.transports.network.websocket_server import WebSocketServerTransport
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
 
 serializer = TwilioFrameSerializer(
     stream_sid=stream_sid,
@@ -139,8 +142,9 @@ serializer = TwilioFrameSerializer(
     auth_token=os.getenv("TWILIO_AUTH_TOKEN"),
 )
 
-transport = WebSocketServerTransport(
-    params=WebSocketServerParams(
+transport = FastAPIWebsocketTransport(
+    websocket=websocket,
+    params=FastAPIWebsocketParams(
         audio_out_enabled=True,
         add_wav_header=False,
         serializer=serializer,

--- a/api-reference/server/services/serializers/vonage.mdx
+++ b/api-reference/server/services/serializers/vonage.mdx
@@ -98,12 +98,16 @@ Before using VonageFrameSerializer, you need:
 
 ```python
 from pipecat.serializers.vonage import VonageFrameSerializer
-from pipecat.transports.network.websocket_server import WebSocketServerTransport
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
 
 serializer = VonageFrameSerializer()
 
-transport = WebSocketServerTransport(
-    params=WebSocketServerParams(
+transport = FastAPIWebsocketTransport(
+    websocket=websocket,
+    params=FastAPIWebsocketParams(
         audio_out_enabled=True,
         add_wav_header=False,
         serializer=serializer,

--- a/api-reference/server/services/serializers/wavix.mdx
+++ b/api-reference/server/services/serializers/wavix.mdx
@@ -112,7 +112,7 @@ Wire the serializer into a `FastAPIWebsocketTransport`:
 
 ```python
 from pipecat_wavix import WavixFrameSerializer
-from pipecat.transports.network.fastapi_websocket import (
+from pipecat.transports.websocket.fastapi import (
     FastAPIWebsocketTransport,
     FastAPIWebsocketParams,
 )

--- a/api-reference/server/utilities/opentelemetry.mdx
+++ b/api-reference/server/utilities/opentelemetry.mdx
@@ -199,7 +199,7 @@ Pipecat enriches spans with detailed attributes about service operations:
 
 ### TTS Service Spans
 
-- `gen_ai.system`: Service provider (e.g., "cartesia")
+- `gen_ai.provider.name`: Service provider (e.g., "cartesia")
 - `gen_ai.request.model`: Model ID/name
 - `voice_id`: Voice identifier
 - `text`: The text being synthesized
@@ -209,7 +209,7 @@ Pipecat enriches spans with detailed attributes about service operations:
 
 ### STT Service Spans
 
-- `gen_ai.system`: Service provider (e.g., "deepgram")
+- `gen_ai.provider.name`: Service provider (e.g., "deepgram")
 - `gen_ai.request.model`: Model ID/name
 - `transcript`: The transcribed text
 - `is_final`: Whether the transcription is final
@@ -220,16 +220,16 @@ Pipecat enriches spans with detailed attributes about service operations:
 
 ### LLM Service Spans
 
-- `gen_ai.system`: Service provider (e.g., "openai", "gcp.gemini")
+- `gen_ai.provider.name`: Service provider (e.g., "openai", "gcp.gemini")
 - `gen_ai.request.model`: Model ID/name
 - `gen_ai.operation.name`: Operation type (e.g., "chat")
 - `stream`: Whether streaming is enabled
 - `input`: JSON-serialized input messages
 - `output`: Complete response text
 - `tools`: JSON-serialized tools configuration
-- `tools.count`: Number of tools available
-- `tools.names`: Comma-separated tool names
-- `system`: System message content
+- `tool_count`: Number of tools available
+- `tool_choice`: The configured tool choice, when set
+- `gen_ai.system_instructions`: System instructions (truncated)
 - `gen_ai.usage.input_tokens`: Number of prompt tokens
 - `gen_ai.usage.output_tokens`: Number of completion tokens
 - `gen_ai.usage.cache_read.input_tokens`: Number of cached prompt tokens (when applicable)
@@ -243,11 +243,11 @@ Pipecat enriches spans with detailed attributes about service operations:
 
 #### Setup Spans
 
-- `gen_ai.system`: "gcp.gemini" or "openai"
+- `gen_ai.provider.name`: "gcp.gemini" or "openai"
 - `gen_ai.request.model`: Model identifier
 - `tools.count`: Number of available tools
 - `tools.definitions`: JSON-serialized tool schemas
-- `system_instruction`: System prompt (truncated)
+- `gen_ai.system_instructions`: System instructions (truncated). The OpenAI Realtime setup span reports this as `instructions`
 - `session.*`: Session configuration parameters
 
 #### Request Spans (OpenAI Realtime)
@@ -266,7 +266,8 @@ Pipecat enriches spans with detailed attributes about service operations:
 - `gen_ai.usage.audio.output_tokens`: Audio completion tokens (Gemini Live, OpenAI Realtime)
 - `gen_ai.usage.audio.cache_read.input_tokens`: Cached audio tokens (Gemini Live, OpenAI Realtime)
 - `function_calls.count`: Number of function calls made
-- `function_calls.names`: Comma-separated function names
+- `function_calls.first_name`: Name of the first function call
+- `function_calls.all_names`: Comma-separated names, when more than one call is made
 - `metrics.ttfb`: Time to first response in seconds
 
 #### Tool Call/Result Spans (Gemini Live)
@@ -275,7 +276,7 @@ Pipecat enriches spans with detailed attributes about service operations:
 - `tool.call_id`: Unique identifier for the call
 - `tool.arguments`: Function arguments (truncated)
 - `tool.result`: Function execution result (truncated)
-- `tool.result_status`: "completed", "error", or "parse_error"
+- `tool.result_status`: "completed", "success", or "error"
 
 ### Turn Spans
 

--- a/api-reference/server/utilities/runner/guide.mdx
+++ b/api-reference/server/utilities/runner/guide.mdx
@@ -53,7 +53,7 @@ Here's the basic structure:
 # Your imports
 from pipecat.runner.types import RunnerArguments
 from pipecat.transports.base_transport import BaseTransport, TransportParams
-from pipecat.transports.network.small_webrtc import SmallWebRTCTransport
+from pipecat.transports.smallwebrtc.transport import SmallWebRTCTransport
 
 async def run_bot(transport: BaseTransport):
     """Your core bot logic here:
@@ -128,7 +128,7 @@ async def bot(runner_args: RunnerArguments):
 
     elif isinstance(runner_args, SmallWebRTCRunnerArguments):
         from pipecat.transports.base_transport import TransportParams
-        from pipecat.transports.network.small_webrtc import SmallWebRTCTransport
+        from pipecat.transports.smallwebrtc.transport import SmallWebRTCTransport
 
         transport = SmallWebRTCTransport(
             params=TransportParams(

--- a/api-reference/server/utilities/turn-management/user-turn-strategies.mdx
+++ b/api-reference/server/utilities/turn-management/user-turn-strategies.mdx
@@ -71,13 +71,18 @@ Before any strategy can act, two things have to happen:
 Then the strategy's criteria run (the silence window, the turn model, or the LLM check) to finalize the turn.
 
 <Note>
-  Extra silence users notice usually isn't one tunable value — it's VAD silence
-  plus transcription latency plus the strategy's own window stacking up. If your
-  STT service is slow to return transcripts, that delay shows up in every turn
-  regardless of which strategy you use. Adjust responsiveness in the stop
-  strategy, and check the [STT
-  benchmark](https://github.com/pipecat-ai/stt-benchmark) if transcription is
-  the bottleneck.
+  These don't stack. The fallback timer is an absolute deadline — the end of the
+  user's speech plus the STT service's `ttfs_p99_latency` — so the VAD's
+  `stop_secs` and the time a turn model spends on inference both fall inside
+  that budget rather than extending it. What a user notices is the deadline
+  itself, or a finalized transcript arriving sooner.
+
+If your STT service is slow to return transcripts, that delay shows up in
+every turn regardless of which strategy you use. Adjust responsiveness in the
+stop strategy, and check the [STT
+benchmark](https://github.com/pipecat-ai/stt-benchmark) if transcription is
+the bottleneck.
+
 </Note>
 
 `user_turn_stop_timeout` (default `5.0s`, on `LLMUserAggregatorParams`) is a backstop, not part of normal timing: if a turn somehow never finalizes, it forces the turn to end so the bot isn't stuck waiting.
@@ -371,7 +376,7 @@ Signals the end of a user turn using two independent timers after VAD detects si
 - **user_speech_timeout**: Policy floor — the window in which the user may resume speaking after a pause. Always runs to completion.
 - **stt_timeout**: Safety net for STT latency — the P99 time for the STT service to return a final transcript after VAD stop. Short-circuited when the STT service emits a finalized transcript (`TranscriptionFrame.finalized=True`), since finalization means STT has nothing more to send.
 
-For STT services that support finalization (Speechmatics, Soniox, Deepgram Flux, AssemblyAI), user turns now end as soon as `user_speech_timeout` elapses after VAD stop, rather than waiting for both timers.
+For STT services that support finalization, user turns end as soon as `user_speech_timeout` elapses after VAD stop, rather than waiting for both timers. See [`TranscriptionFrame.finalized`](/api-reference/server/frames/data-frames#transcriptionframe) for which services report it.
 
 <ParamField path="user_speech_timeout" type="float" default="0.6">
   How long to wait (in seconds) after VAD detects silence before finalizing the

--- a/api-reference/server/utilities/turn-management/user-turn-strategies.mdx
+++ b/api-reference/server/utilities/turn-management/user-turn-strategies.mdx
@@ -376,7 +376,7 @@ Signals the end of a user turn using two independent timers after VAD detects si
 - **user_speech_timeout**: Policy floor — the window in which the user may resume speaking after a pause. Always runs to completion.
 - **stt_timeout**: Safety net for STT latency — the P99 time for the STT service to return a final transcript after VAD stop. Short-circuited when the STT service emits a finalized transcript (`TranscriptionFrame.finalized=True`), since finalization means STT has nothing more to send.
 
-For STT services that support finalization, user turns end as soon as `user_speech_timeout` elapses after VAD stop, rather than waiting for both timers. See [`TranscriptionFrame.finalized`](/api-reference/server/frames/data-frames#transcriptionframe) for which services report it.
+When a service finalizes, the turn ends as soon as `user_speech_timeout` elapses after VAD stop, rather than waiting for both timers. Support varies by service and can be conditional — see [`TranscriptionFrame.finalized`](/api-reference/server/frames/data-frames#transcriptionframe) for how a service reports it, and the service's own page for whether it does.
 
 <ParamField path="user_speech_timeout" type="float" default="0.6">
   How long to wait (in seconds) after VAD detects silence before finalizing the

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -74134,7 +74134,7 @@ Signals the end of a user turn using two independent timers after VAD detects si
 - **user_speech_timeout**: Policy floor — the window in which the user may resume speaking after a pause. Always runs to completion.
 - **stt_timeout**: Safety net for STT latency — the P99 time for the STT service to return a final transcript after VAD stop. Short-circuited when the STT service emits a finalized transcript (`TranscriptionFrame.finalized=True`), since finalization means STT has nothing more to send.
 
-For STT services that support finalization, user turns end as soon as `user_speech_timeout` elapses after VAD stop, rather than waiting for both timers. See [`TranscriptionFrame.finalized`](/api-reference/server/frames/data-frames#transcriptionframe) for which services report it.
+When a service finalizes, the turn ends as soon as `user_speech_timeout` elapses after VAD stop, rather than waiting for both timers. Support varies by service and can be conditional — see [`TranscriptionFrame.finalized`](/api-reference/server/frames/data-frames#transcriptionframe) for how a service reports it, and the service's own page for whether it does.
 
 <ParamField path="user_speech_timeout" type="float" default="0.6">
   How long to wait (in seconds) after VAD detects silence before finalizing the
@@ -77814,13 +77814,16 @@ A non-interim transcription result from an STT service: the service's best recog
 
 <ParamField path="finalized" type="bool" default="False">
   Whether the STT service has explicitly committed this transcription via a
-  finalize signal. Reported by AssemblyAI, Azure, Cartesia (Ink-2), Deepgram
-  Flux, Gemini Live, Google, NVIDIA (including SageMaker), Sarvam, Soniox, and
-  Speechmatics; other services leave it `False`. Turn detection strategies use
-  the flag to close a turn without waiting out the STT fallback timer.
+  finalize signal. Turn detection strategies use the flag to close a turn
+  without waiting out the STT fallback timer.
 
-Note that `DeepgramFluxSTTService` reports it and `DeepgramSTTService` does
-not.
+A service reports it in one of two ways: by marking the frame directly, when
+its provider's response is inherently final, or by calling
+`request_finalize()` and then `confirm_finalize()` once the provider
+acknowledges — in which case the flag is set for that requested finalization
+rather than for every final transcript. Whether a given service does either,
+and under what conditions, is documented on its own page. Services that do
+neither leave it `False`.
 
 </ParamField>
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3060,7 +3060,7 @@ async def bot(runner_args: RunnerArguments):
 
     elif isinstance(runner_args, SmallWebRTCRunnerArguments):
         from pipecat.transports.base_transport import TransportParams
-        from pipecat.transports.network.small_webrtc import SmallWebRTCTransport
+        from pipecat.transports.smallwebrtc.transport import SmallWebRTCTransport
 
         transport = SmallWebRTCTransport(
             params=TransportParams(
@@ -35229,7 +35229,7 @@ from the initial websocket `start` message Awaaz AI sends when a call connects.
 
 ```python
 from pipecat_awaazai import AwaazAIFrameSerializer
-from pipecat.transports.network.fastapi_websocket import (
+from pipecat.transports.websocket.fastapi import (
     FastAPIWebsocketTransport,
     FastAPIWebsocketParams,
 )
@@ -35539,15 +35539,19 @@ Before using ExotelFrameSerializer, you need:
 
 ```python
 from pipecat.serializers.exotel import ExotelFrameSerializer
-from pipecat.transports.network.websocket_server import WebSocketServerTransport
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
 
 serializer = ExotelFrameSerializer(
     stream_sid=stream_sid,
     call_sid=call_sid,
 )
 
-transport = WebSocketServerTransport(
-    params=WebSocketServerParams(
+transport = FastAPIWebsocketTransport(
+    websocket=websocket,
+    params=FastAPIWebsocketParams(
         audio_out_enabled=True,
         add_wav_header=False,
         serializer=serializer,
@@ -35645,7 +35649,7 @@ Before using GenesysAudioHookSerializer, you need:
 
 ```python
 from pipecat.serializers.genesys import GenesysAudioHookSerializer
-from pipecat.transports.network.fastapi_websocket import (
+from pipecat.transports.websocket.fastapi import (
     FastAPIWebsocketTransport,
     FastAPIWebsocketParams,
 )
@@ -35894,7 +35898,10 @@ Before using PlivoFrameSerializer, you need:
 
 ```python
 from pipecat.serializers.plivo import PlivoFrameSerializer
-from pipecat.transports.network.websocket_server import WebSocketServerTransport
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
 
 serializer = PlivoFrameSerializer(
     stream_id=stream_id,
@@ -35903,8 +35910,9 @@ serializer = PlivoFrameSerializer(
     auth_token=os.getenv("PLIVO_AUTH_TOKEN"),
 )
 
-transport = WebSocketServerTransport(
-    params=WebSocketServerParams(
+transport = FastAPIWebsocketTransport(
+    websocket=websocket,
+    params=FastAPIWebsocketParams(
         audio_out_enabled=True,
         add_wav_header=False,
         serializer=serializer,
@@ -36060,7 +36068,10 @@ Before using TwilioFrameSerializer, you need:
 
 ```python
 from pipecat.serializers.twilio import TwilioFrameSerializer
-from pipecat.transports.network.websocket_server import WebSocketServerTransport
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
 
 serializer = TwilioFrameSerializer(
     stream_sid=stream_sid,
@@ -36069,8 +36080,9 @@ serializer = TwilioFrameSerializer(
     auth_token=os.getenv("TWILIO_AUTH_TOKEN"),
 )
 
-transport = WebSocketServerTransport(
-    params=WebSocketServerParams(
+transport = FastAPIWebsocketTransport(
+    websocket=websocket,
+    params=FastAPIWebsocketParams(
         audio_out_enabled=True,
         add_wav_header=False,
         serializer=serializer,
@@ -36217,7 +36229,10 @@ Before using TelnyxFrameSerializer, you need:
 
 ```python
 from pipecat.serializers.telnyx import TelnyxFrameSerializer
-from pipecat.transports.network.websocket_server import WebSocketServerTransport
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
 
 serializer = TelnyxFrameSerializer(
     stream_id=stream_id,
@@ -36227,8 +36242,9 @@ serializer = TelnyxFrameSerializer(
     api_key=os.getenv("TELNYX_API_KEY"),
 )
 
-transport = WebSocketServerTransport(
-    params=WebSocketServerParams(
+transport = FastAPIWebsocketTransport(
+    websocket=websocket,
+    params=FastAPIWebsocketParams(
         audio_out_enabled=True,
         add_wav_header=False,
         serializer=serializer,
@@ -36354,12 +36370,16 @@ Before using VonageFrameSerializer, you need:
 
 ```python
 from pipecat.serializers.vonage import VonageFrameSerializer
-from pipecat.transports.network.websocket_server import WebSocketServerTransport
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
 
 serializer = VonageFrameSerializer()
 
-transport = WebSocketServerTransport(
-    params=WebSocketServerParams(
+transport = FastAPIWebsocketTransport(
+    websocket=websocket,
+    params=FastAPIWebsocketParams(
         audio_out_enabled=True,
         add_wav_header=False,
         serializer=serializer,
@@ -36489,7 +36509,7 @@ Wire the serializer into a `FastAPIWebsocketTransport`:
 
 ```python
 from pipecat_wavix import WavixFrameSerializer
-from pipecat.transports.network.fastapi_websocket import (
+from pipecat.transports.websocket.fastapi import (
     FastAPIWebsocketTransport,
     FastAPIWebsocketParams,
 )
@@ -69596,7 +69616,7 @@ Pipecat enriches spans with detailed attributes about service operations:
 
 ### TTS Service Spans
 
-- `gen_ai.system`: Service provider (e.g., "cartesia")
+- `gen_ai.provider.name`: Service provider (e.g., "cartesia")
 - `gen_ai.request.model`: Model ID/name
 - `voice_id`: Voice identifier
 - `text`: The text being synthesized
@@ -69606,7 +69626,7 @@ Pipecat enriches spans with detailed attributes about service operations:
 
 ### STT Service Spans
 
-- `gen_ai.system`: Service provider (e.g., "deepgram")
+- `gen_ai.provider.name`: Service provider (e.g., "deepgram")
 - `gen_ai.request.model`: Model ID/name
 - `transcript`: The transcribed text
 - `is_final`: Whether the transcription is final
@@ -69617,16 +69637,16 @@ Pipecat enriches spans with detailed attributes about service operations:
 
 ### LLM Service Spans
 
-- `gen_ai.system`: Service provider (e.g., "openai", "gcp.gemini")
+- `gen_ai.provider.name`: Service provider (e.g., "openai", "gcp.gemini")
 - `gen_ai.request.model`: Model ID/name
 - `gen_ai.operation.name`: Operation type (e.g., "chat")
 - `stream`: Whether streaming is enabled
 - `input`: JSON-serialized input messages
 - `output`: Complete response text
 - `tools`: JSON-serialized tools configuration
-- `tools.count`: Number of tools available
-- `tools.names`: Comma-separated tool names
-- `system`: System message content
+- `tool_count`: Number of tools available
+- `tool_choice`: The configured tool choice, when set
+- `gen_ai.system_instructions`: System instructions (truncated)
 - `gen_ai.usage.input_tokens`: Number of prompt tokens
 - `gen_ai.usage.output_tokens`: Number of completion tokens
 - `gen_ai.usage.cache_read.input_tokens`: Number of cached prompt tokens (when applicable)
@@ -69640,11 +69660,11 @@ Pipecat enriches spans with detailed attributes about service operations:
 
 #### Setup Spans
 
-- `gen_ai.system`: "gcp.gemini" or "openai"
+- `gen_ai.provider.name`: "gcp.gemini" or "openai"
 - `gen_ai.request.model`: Model identifier
 - `tools.count`: Number of available tools
 - `tools.definitions`: JSON-serialized tool schemas
-- `system_instruction`: System prompt (truncated)
+- `gen_ai.system_instructions`: System instructions (truncated). The OpenAI Realtime setup span reports this as `instructions`
 - `session.*`: Session configuration parameters
 
 #### Request Spans (OpenAI Realtime)
@@ -69663,7 +69683,8 @@ Pipecat enriches spans with detailed attributes about service operations:
 - `gen_ai.usage.audio.output_tokens`: Audio completion tokens (Gemini Live, OpenAI Realtime)
 - `gen_ai.usage.audio.cache_read.input_tokens`: Cached audio tokens (Gemini Live, OpenAI Realtime)
 - `function_calls.count`: Number of function calls made
-- `function_calls.names`: Comma-separated function names
+- `function_calls.first_name`: Name of the first function call
+- `function_calls.all_names`: Comma-separated names, when more than one call is made
 - `metrics.ttfb`: Time to first response in seconds
 
 #### Tool Call/Result Spans (Gemini Live)
@@ -69672,7 +69693,7 @@ Pipecat enriches spans with detailed attributes about service operations:
 - `tool.call_id`: Unique identifier for the call
 - `tool.arguments`: Function arguments (truncated)
 - `tool.result`: Function execution result (truncated)
-- `tool.result_status`: "completed", "error", or "parse_error"
+- `tool.result_status`: "completed", "success", or "error"
 
 ### Turn Spans
 
@@ -70933,7 +70954,7 @@ Here's the basic structure:
 # Your imports
 from pipecat.runner.types import RunnerArguments
 from pipecat.transports.base_transport import BaseTransport, TransportParams
-from pipecat.transports.network.small_webrtc import SmallWebRTCTransport
+from pipecat.transports.smallwebrtc.transport import SmallWebRTCTransport
 
 async def run_bot(transport: BaseTransport):
     """Your core bot logic here:
@@ -71008,7 +71029,7 @@ async def bot(runner_args: RunnerArguments):
 
     elif isinstance(runner_args, SmallWebRTCRunnerArguments):
         from pipecat.transports.base_transport import TransportParams
-        from pipecat.transports.network.small_webrtc import SmallWebRTCTransport
+        from pipecat.transports.smallwebrtc.transport import SmallWebRTCTransport
 
         transport = SmallWebRTCTransport(
             params=TransportParams(
@@ -73808,13 +73829,18 @@ Before any strategy can act, two things have to happen:
 Then the strategy's criteria run (the silence window, the turn model, or the LLM check) to finalize the turn.
 
 <Note>
-  Extra silence users notice usually isn't one tunable value — it's VAD silence
-  plus transcription latency plus the strategy's own window stacking up. If your
-  STT service is slow to return transcripts, that delay shows up in every turn
-  regardless of which strategy you use. Adjust responsiveness in the stop
-  strategy, and check the [STT
-  benchmark](https://github.com/pipecat-ai/stt-benchmark) if transcription is
-  the bottleneck.
+  These don't stack. The fallback timer is an absolute deadline — the end of the
+  user's speech plus the STT service's `ttfs_p99_latency` — so the VAD's
+  `stop_secs` and the time a turn model spends on inference both fall inside
+  that budget rather than extending it. What a user notices is the deadline
+  itself, or a finalized transcript arriving sooner.
+
+If your STT service is slow to return transcripts, that delay shows up in
+every turn regardless of which strategy you use. Adjust responsiveness in the
+stop strategy, and check the [STT
+benchmark](https://github.com/pipecat-ai/stt-benchmark) if transcription is
+the bottleneck.
+
 </Note>
 
 `user_turn_stop_timeout` (default `5.0s`, on `LLMUserAggregatorParams`) is a backstop, not part of normal timing: if a turn somehow never finalizes, it forces the turn to end so the bot isn't stuck waiting.
@@ -74108,7 +74134,7 @@ Signals the end of a user turn using two independent timers after VAD detects si
 - **user_speech_timeout**: Policy floor — the window in which the user may resume speaking after a pause. Always runs to completion.
 - **stt_timeout**: Safety net for STT latency — the P99 time for the STT service to return a final transcript after VAD stop. Short-circuited when the STT service emits a finalized transcript (`TranscriptionFrame.finalized=True`), since finalization means STT has nothing more to send.
 
-For STT services that support finalization (Speechmatics, Soniox, Deepgram Flux, AssemblyAI), user turns now end as soon as `user_speech_timeout` elapses after VAD stop, rather than waiting for both timers.
+For STT services that support finalization, user turns end as soon as `user_speech_timeout` elapses after VAD stop, rather than waiting for both timers. See [`TranscriptionFrame.finalized`](/api-reference/server/frames/data-frames#transcriptionframe) for which services report it.
 
 <ParamField path="user_speech_timeout" type="float" default="0.6">
   How long to wait (in seconds) after VAD detects silence before finalizing the
@@ -77788,10 +77814,14 @@ A non-interim transcription result from an STT service: the service's best recog
 
 <ParamField path="finalized" type="bool" default="False">
   Whether the STT service has explicitly committed this transcription via a
-  finalize signal. Some services (AssemblyAI, Deepgram, Soniox, Speechmatics)
-  support this; others don't, so it defaults to `False`. Turn detection
-  strategies can use this flag to trigger the bot's response immediately rather
-  than waiting for a timeout.
+  finalize signal. Reported by AssemblyAI, Azure, Cartesia (Ink-2), Deepgram
+  Flux, Gemini Live, Google, NVIDIA (including SageMaker), Sarvam, Soniox, and
+  Speechmatics; other services leave it `False`. Turn detection strategies use
+  the flag to close a turn without waiting out the STT fallback timer.
+
+Note that `DeepgramFluxSTTService` reports it and `DeepgramSTTService` does
+not.
+
 </ParamField>
 
 #### InterimTranscriptionFrame

--- a/pipecat/learn/transports.mdx
+++ b/pipecat/learn/transports.mdx
@@ -255,7 +255,7 @@ async def bot(runner_args: RunnerArguments):
 
     elif isinstance(runner_args, SmallWebRTCRunnerArguments):
         from pipecat.transports.base_transport import TransportParams
-        from pipecat.transports.network.small_webrtc import SmallWebRTCTransport
+        from pipecat.transports.smallwebrtc.transport import SmallWebRTCTransport
 
         transport = SmallWebRTCTransport(
             params=TransportParams(


### PR DESCRIPTION
Results of the targeted 1.6.0 / 1.7.0 sweep. Three agents, each hunting one failure mode: **docs that describe behavior a fix has since changed** — the class of error no structural check catches, and the one that produced the four confidently-wrong pages in the 1.8.0 audit.

It found more than I expected, including two problems that predate 1.6.0 entirely.

## 1. Tracing attributes that don't exist

`utilities/opentelemetry.mdx` named **seven attributes the code doesn't emit**. A Jaeger or Langfuse query written from that page returns zero rows.

| Documented | Actually emitted |
| --- | --- |
| `gen_ai.system` (×4 spans) | `gen_ai.provider.name` |
| `tools.count` (LLM span) | `tool_count` |
| `tools.names` (LLM span) | not emitted — exists only on setup spans, where the page already has it right |
| `system` | `gen_ai.system_instructions` |
| `system_instruction` | `gen_ai.system_instructions` (OpenAI Realtime reports it as `instructions`) |
| `function_calls.names` | `function_calls.first_name` + `function_calls.all_names` |
| `tool.result_status: parse_error` | removed; the set is `completed` / `success` / `error` |

`gen_ai.system` is the notable one: documented for TTS, STT, LLM **and** multimodal spans, absent from source entirely. It was renamed when tracing adopted the OpenTelemetry GenAI conventions in **0.0.107** — so this has been wrong across every release we've audited. The documented *values* were right the whole time; only the key was wrong, which is exactly why nobody noticed.

Also adds `tool_choice`, emitted but undocumented.

## 2. Turn-stop timing described as additive

`turn-management/user-turn-strategies.mdx` taught VAD silence, transcription latency and the strategy's own window as delays that stack: *"it's VAD silence plus transcription latency plus the strategy's own window stacking up."*

They don't stack. `TurnAnalyzerUserTurnStopStrategy` computes `stt_deadline = frame.timestamp - frame.stop_secs + self._stt_timeout` **before** running the analyzer (#5007), so `stop_secs` and turn-model inference fall *inside* the `ttfs_p99_latency` budget rather than extending it. The page also contradicted `stt-latency-tuning.mdx`, which had it right.

Two service lists were stale in the same area: both places enumerating STT services that report finalized transcripts listed four, where **eleven** do. `data-frames.mdx` also named "Deepgram" — but `DeepgramSTTService` never sets `finalized=True`; only `DeepgramFluxSTTService` does, so a reader picking from that list could pick the one that doesn't work. The strategies page now links to the frames reference instead of keeping a second copy to drift.

## 3. Imports naming a package that was removed in 1.0

Eight pages imported from `pipecat.transports.network`, removed in the 1.0 reorganisation — the docs' own migration table records the rename. **None of these snippets have run since 1.0.**

Five telephony serializer pages were worse still: alongside the dead path they constructed `WebSocketServerTransport` / `WebSocketServerParams` (capital S), which have **never existed under any name**. Those now use `FastAPIWebsocketTransport`, matching the telephony guides and what a serializer is actually paired with — renaming them to a single-client websocket server would have been importable but wrong for the use case.

## What the sweep found *nothing* for

Worth recording, since it bounds the remaining risk. All verified as no-coverage rather than stale: #4964 (websocket `EndFrame` close), #5164 (2s closing handshake), #4993 (trailing audio), #5112/#5115/#5126 (SmallWebRTC app messages, channels, Firefox PATCH), #5159, #4967, #4983, #5043, #5063. The docs never described the buggy behavior, so there was no workaround text to retract. #5113 (Deepgram retry limit) was already correct — we documented it in the error-handling PR.

Checks: `docs-meta-lint` 0 errors, `mint broken-links --check-anchors --check-redirects` clean, `llms.txt` / `llms-full.txt` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)