### PR TITLE
docs: correct two frames the reference described wrongly

### DIFF
--- a/api-reference/server/frames/data-frames.mdx
+++ b/api-reference/server/frames/data-frames.mdx
@@ -244,8 +244,8 @@ Sends text to the pipeline's TTS service as a standalone utterance, independent 
   The text to be spoken.
 </ParamField>
 
-<ParamField path="append_to_context" type="bool | None" default="None">
-  Whether to append the spoken text to the LLM context.
+<ParamField path="append_to_context" type="bool" default="True">
+  Whether the spoken text is appended to the LLM context.
 </ParamField>
 
 ## Transport Message Frames

--- a/api-reference/server/frames/system-frames.mdx
+++ b/api-reference/server/frames/system-frames.mdx
@@ -391,6 +391,16 @@ Base metadata frame broadcast by services at startup, providing information abou
   Name of the service that emitted this metadata.
 </ParamField>
 
+<ParamField
+  path="user_turn_strategies"
+  type="UserTurnStrategies | None"
+  default="None"
+>
+  The turn strategies the service recommends, when it has an opinion — a service
+  with its own turn detection uses this to ask for
+  [`ExternalUserTurnStrategies`](/api-reference/server/utilities/turn-management/external-turn-management).
+</ParamField>
+
 ### STTMetadataFrame
 
 Metadata from an STT service, including latency characteristics used for turn detection tuning.
@@ -402,19 +412,14 @@ Inherits from `ServiceMetadataFrame`.
   calibrate wait times.
 </ParamField>
 
-### RealtimeServiceMetadataFrame
+### LLMServiceMetadataFrame
 
-Broadcast at pipeline start by realtime (speech-to-speech) LLM services (OpenAI Realtime, Azure Realtime, Inworld, Grok/xAI Realtime, Gemini Live, AWS Nova Sonic, Ultravox). Its presence lets downstream processors — notably `LLMContextAggregatorPair` — detect that a realtime service is in the pipeline and configure themselves accordingly. See [Realtime (Speech-to-Speech) Services](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services).
+Broadcast at pipeline start by an LLM service. Downstream processors — notably `LLMContextAggregatorPair` — read `is_realtime_service` to tell whether a realtime (speech-to-speech) service is in the pipeline and configure themselves accordingly. See [Realtime (Speech-to-Speech) Services](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services).
 
 Inherits from `ServiceMetadataFrame`.
 
-<ParamField path="emits_user_turn_frames" type="bool" default="True">
-  Whether the service is currently configured to emit `UserStartedSpeakingFrame`
-  / `UserStoppedSpeakingFrame` from server-side turn signals. `False` for
-  services with no server-side turn signals (e.g. Gemini Live, AWS Nova Sonic,
-  Ultravox), and also `False` when a service's server-side turn detection has
-  been disabled by configuration (e.g. OpenAI Realtime with
-  `turn_detection=False`).
+<ParamField path="is_realtime_service" type="bool" default="False">
+  Whether the broadcasting service is a realtime (speech-to-speech) LLM service.
 </ParamField>
 
 ## RTVI

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -78017,8 +78017,8 @@ Sends text to the pipeline's TTS service as a standalone utterance, independent 
   The text to be spoken.
 </ParamField>
 
-<ParamField path="append_to_context" type="bool | None" default="None">
-  Whether to append the spoken text to the LLM context.
+<ParamField path="append_to_context" type="bool" default="True">
+  Whether the spoken text is appended to the LLM context.
 </ParamField>
 
 ## Transport Message Frames
@@ -78967,6 +78967,16 @@ Base metadata frame broadcast by services at startup, providing information abou
   Name of the service that emitted this metadata.
 </ParamField>
 
+<ParamField
+  path="user_turn_strategies"
+  type="UserTurnStrategies | None"
+  default="None"
+>
+  The turn strategies the service recommends, when it has an opinion — a service
+  with its own turn detection uses this to ask for
+  [`ExternalUserTurnStrategies`](/api-reference/server/utilities/turn-management/external-turn-management).
+</ParamField>
+
 ### STTMetadataFrame
 
 Metadata from an STT service, including latency characteristics used for turn detection tuning.
@@ -78978,19 +78988,14 @@ Inherits from `ServiceMetadataFrame`.
   calibrate wait times.
 </ParamField>
 
-### RealtimeServiceMetadataFrame
+### LLMServiceMetadataFrame
 
-Broadcast at pipeline start by realtime (speech-to-speech) LLM services (OpenAI Realtime, Azure Realtime, Inworld, Grok/xAI Realtime, Gemini Live, AWS Nova Sonic, Ultravox). Its presence lets downstream processors — notably `LLMContextAggregatorPair` — detect that a realtime service is in the pipeline and configure themselves accordingly. See [Realtime (Speech-to-Speech) Services](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services).
+Broadcast at pipeline start by an LLM service. Downstream processors — notably `LLMContextAggregatorPair` — read `is_realtime_service` to tell whether a realtime (speech-to-speech) service is in the pipeline and configure themselves accordingly. See [Realtime (Speech-to-Speech) Services](/api-reference/server/utilities/turn-management/external-turn-management#realtime-speech-to-speech-services).
 
 Inherits from `ServiceMetadataFrame`.
 
-<ParamField path="emits_user_turn_frames" type="bool" default="True">
-  Whether the service is currently configured to emit `UserStartedSpeakingFrame`
-  / `UserStoppedSpeakingFrame` from server-side turn signals. `False` for
-  services with no server-side turn signals (e.g. Gemini Live, AWS Nova Sonic,
-  Ultravox), and also `False` when a service's server-side turn detection has
-  been disabled by configuration (e.g. OpenAI Realtime with
-  `turn_detection=False`).
+<ParamField path="is_realtime_service" type="bool" default="False">
+  Whether the broadcasting service is a realtime (speech-to-speech) LLM service.
 </ParamField>
 
 ## RTVI


### PR DESCRIPTION
Two findings that fell out of prototyping automated drift checks. Both are cases where the reference describes something that isn't in the source.

## `RealtimeServiceMetadataFrame` doesn't exist

The page documented it as its own frame type, with its own field, and explained that *its presence* is how downstream processors detect a realtime service. None of that is real:

| Documented | Actual |
| --- | --- |
| `RealtimeServiceMetadataFrame` | `LLMServiceMetadataFrame` |
| `emits_user_turn_frames: bool = True` | `is_realtime_service: bool = False` |
| detection by frame *type* | detection by *field value* |

So a reader implementing against this page would look for a frame class that doesn't exist, then a field that doesn't exist, and would have the mechanism backwards — every LLM service broadcasts the same frame, and the boolean distinguishes them.

`ServiceMetadataFrame` was also missing `user_turn_strategies`, which is how a service with its own turn detection asks for external turn strategies.

## `TTSSpeakFrame.append_to_context`

Documented as `bool | None` defaulting to `None`. The source is `bool = True` — and `None` is *deprecated*, with a runtime warning on `__post_init__`. So the page advertised a deprecated value as the default.

## How they were found

Prototypes for two checks, neither of which I'm proposing to ship as-is:

- **Frame placement/existence** — resolve each `### XFrame` against its base class. Caught the phantom frame. Would also have caught the two frame misplacements from the 1.6/1.7 sweep. Worth building; low false-positive risk since frames resolve by name.
- **Documented default vs source default** — caught `append_to_context`. Measured at 0 false positives on 170 comparisons, **but** it only covers 11% of ParamFields, and coverage depends on a page using a `### ClassName` heading, which 108 of 183 service pages don't. It would not have caught the Moondream default that motivated it. Not worth gating on until attribution uses the real page→class mapping.

Checks: `check-imports` clean, `docs-meta-lint` 0 errors, `mint broken-links --check-anchors --check-redirects` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)