### PR TITLE
docs: document DTMF

### DIFF
--- a/api-reference/client/js/client-methods.mdx
+++ b/api-reference/client/js/client-methods.mdx
@@ -425,6 +425,30 @@ A method to append text to the user's context. This is useful for providing text
   </Expandable>
 </ParamField>
 
+### sendDTMF()
+
+`sendDTMF(dtmf: DTMFButton | string): void`
+
+Sends DTMF keypresses to the bot — the digits a caller would press on a phone keypad, for navigating an IVR or entering an account number.
+
+<ParamField path="dtmf" type="DTMFButton | string" required>
+  A single key or a sequence of them, e.g. `"5"` or `"123#"`. Only `0`–`9`, `*`
+  and `#` are valid; anything else raises an `RTVIError` before a message is
+  sent.
+</ParamField>
+
+```typescript
+pcClient.sendDTMF("1"); // one key
+pcClient.sendDTMF("4085551234#"); // a sequence, in order
+```
+
+<Note>
+  DTMF requires a bot on RTVI protocol 2.0.0 or later; calling it against an
+  older bot raises an `UnsupportedFeatureError`. A sequence reaches a 2.1.0+ bot
+  as a single message, and a 2.0.x bot as one message per key — the difference
+  is handled for you.
+</Note>
+
 ### registerFunctionCallHandler()
 
 `registerFunctionCallHandler(functionName: string, callback: FunctionCallCallback): void`

--- a/api-reference/client/react/hooks.mdx
+++ b/api-reference/client/react/hooks.mdx
@@ -163,6 +163,32 @@ function MicToggle() {
 }
 ```
 
+## useDTMF
+
+Sends DTMF keypresses to the bot — the digits a caller would press on a phone keypad.
+
+```jsx
+import { useDTMF } from "@pipecat-ai/client-react";
+
+function Keypad() {
+  const { sendTone } = useDTMF();
+
+  return (
+    <div>
+      {["1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "0", "#"].map(
+        (key) => (
+          <button key={key} onClick={() => sendTone(key)}>
+            {key}
+          </button>
+        ),
+      )}
+    </div>
+  );
+}
+```
+
+`sendTone` takes a single key or a sequence (`"123#"`), and wraps [`sendDTMF()`](/api-reference/client/js/client-methods#senddtmf) — so the same validation and protocol requirements apply. It is a no-op until a client is available from `PipecatClientProvider`.
+
 ## usePipecatConversation
 
 The primary hook for accessing the conversation message stream. Returns the current list of messages (ordered for display) and a function to inject messages programmatically.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -83564,6 +83564,30 @@ A method to append text to the user's context. This is useful for providing text
   </Expandable>
 </ParamField>
 
+### sendDTMF()
+
+`sendDTMF(dtmf: DTMFButton | string): void`
+
+Sends DTMF keypresses to the bot — the digits a caller would press on a phone keypad, for navigating an IVR or entering an account number.
+
+<ParamField path="dtmf" type="DTMFButton | string" required>
+  A single key or a sequence of them, e.g. `"5"` or `"123#"`. Only `0`–`9`, `*`
+  and `#` are valid; anything else raises an `RTVIError` before a message is
+  sent.
+</ParamField>
+
+```typescript
+pcClient.sendDTMF("1"); // one key
+pcClient.sendDTMF("4085551234#"); // a sequence, in order
+```
+
+<Note>
+  DTMF requires a bot on RTVI protocol 2.0.0 or later; calling it against an
+  older bot raises an `UnsupportedFeatureError`. A sequence reaches a 2.1.0+ bot
+  as a single message, and a 2.0.x bot as one message per key — the difference
+  is handled for you.
+</Note>
+
 ### registerFunctionCallHandler()
 
 `registerFunctionCallHandler(functionName: string, callback: FunctionCallCallback): void`
@@ -85794,6 +85818,32 @@ function MicToggle() {
   );
 }
 ```
+
+## useDTMF
+
+Sends DTMF keypresses to the bot — the digits a caller would press on a phone keypad.
+
+```jsx
+import { useDTMF } from "@pipecat-ai/client-react";
+
+function Keypad() {
+  const { sendTone } = useDTMF();
+
+  return (
+    <div>
+      {["1", "2", "3", "4", "5", "6", "7", "8", "9", "*", "0", "#"].map(
+        (key) => (
+          <button key={key} onClick={() => sendTone(key)}>
+            {key}
+          </button>
+        ),
+      )}
+    </div>
+  );
+}
+```
+
+`sendTone` takes a single key or a sequence (`"123#"`), and wraps [`sendDTMF()`](/api-reference/client/js/client-methods#senddtmf) — so the same validation and protocol requirements apply. It is a no-op until a client is available from `PipecatClientProvider`.
 
 ## usePipecatConversation
 


### PR DESCRIPTION
Step 2 of the client SDK sweep. DTMF shipped in **client-js 1.13.0** (both feature commits of that release) and **client-react 1.8.0**, and appeared nowhere in the docs — so keypad input, which is what a telephony bot needs for IVR navigation or account entry, looked unsupported.

## `sendDTMF()` — `js/client-methods`

Placed next to `sendText()`, since both are non-audio user input.

Two behaviors documented because they're the ones that bite:

- **Validation is strict and eager.** Only `0`–`9`, `*`, `#`; anything else raises `RTVIError` *before* a message is sent.
- **It needs a bot on RTVI protocol 2.0.0+**, otherwise `UnsupportedFeatureError`.

The 2.1.0-vs-2.0.x split — a sequence arrives as one message on the newer protocol, one message per key on the older — is stated as reassurance rather than something to code against, since the client handles it.

## `useDTMF` — `react/hooks`

Documented as what it is: a thin wrapper over `sendDTMF`, linked rather than restated, with a keypad example. Notes that it's a no-op until a client is available from `PipecatClientProvider`.

## One deliberate omission

`snippets/js-transport-support.jsx` maps each method to the transport version that added support for it. I did **not** add a `sendDTMF` row — I have no sourced per-transport versions for it, and a fabricated row in a compatibility table is worse than an absent one. Worth adding by whoever has that data.

Checks: `docs-meta-lint` 0 errors, `mint broken-links --check-anchors --check-redirects` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)