### PR TITLE
docs: document the per-device media state

### DIFF
--- a/api-reference/client/js/callbacks.mdx
+++ b/api-reference/client/js/callbacks.mdx
@@ -145,6 +145,13 @@ pcClient.on(RTVIEvent.BotReady, () => console.log("Bot ready via event"));
   User selected a new camera as their selected/active device.
 </ParamField>
 
+<ParamField path="onMediaStateChanged" type="mediaState:MediaState">
+  Per-device mic/cam state changed — a permission granted or denied, a device
+  that couldn't be acquired. See
+  [`mediaState`](/api-reference/client/js/client-methods#mediastate) for the
+  shape and what each state means.
+</ParamField>
+
 <ParamField path="onSpeakerUpdated" type="speaker:MediaDeviceInfo">
   User selected a new speaker as their selected/active device.
 </ParamField>
@@ -497,6 +504,7 @@ Here's the complete reference mapping events to their corresponding callbacks:
 | `MicUpdated`           | `onMicUpdated`           | `MediaDeviceInfo`               |
 | `CamUpdated`           | `onCamUpdated`           | `MediaDeviceInfo`               |
 | `SpeakerUpdated`       | `onSpeakerUpdated`       | `MediaDeviceInfo`               |
+| `MediaStateUpdated`    | `onMediaStateChanged`    | `MediaState`                    |
 | `DeviceError`          | `onDeviceError`          | `DeviceError`                   |
 
 ### Audio Activity Events

--- a/api-reference/client/js/client-methods.mdx
+++ b/api-reference/client/js/client-methods.mdx
@@ -196,6 +196,14 @@ Initializes the media device selection machinery, based on `enableCam`/`enableMi
 await pcClient.initDevices();
 ```
 
+It drives [`mediaState`](#mediastate): both devices move to `initializing` on entry, then to `granted` for each device the transport reports as acquired. A device that isn't acquired falls back to `uninitialized`. On failure the underlying error classifies the affected devices and is re-thrown, so callers still see it.
+
+<Note>
+  Calling `initDevices()` again after a failure is the recovery path — a second
+  call re-enters `initializing` and reclassifies. There is no separate retry
+  method.
+</Note>
+
 ### getAllMics()
 
 `async getAllMics(): Promise<MediaDeviceInfo[]>`
@@ -370,6 +378,63 @@ An accessor to determine if the client is sharing their screen.
 ```typescript
 screen_sharing = pcClient.isSharingScreen;
 ```
+
+### mediaState
+
+`get mediaState(): MediaState`
+
+Per-device state for the mic and cam, independent of the transport's connection state. Use it to render permission UI — whether to show a "grant access" prompt, an error, or the device picker.
+
+```typescript
+const { mic, cam } = pcClient.mediaState;
+
+if (mic.state === "error" && mic.reason === "blocked") {
+  // the user denied microphone permission
+}
+```
+
+Returns a snapshot. To track changes, subscribe to `RTVIEvent.MediaStateUpdated` or pass an [`onMediaStateChanged`](/api-reference/client/js/callbacks) callback to the constructor. In React, use [`useMediaState`](/api-reference/client/react/hooks#usemediastate).
+
+<Expandable title="MediaState" defaultOpen="true">
+  <ParamField path="mic" type="DeviceStatus">
+    Status of the microphone.
+  </ParamField>
+  <ParamField path="cam" type="DeviceStatus">
+    Status of the camera.
+  </ParamField>
+</Expandable>
+
+A `DeviceStatus` is `{ state }`, plus `reason` and optional `details` when `state` is `"error"`:
+
+| `state`         | Meaning                                          |
+| --------------- | ------------------------------------------------ |
+| `uninitialized` | `initDevices()` hasn't run for this device       |
+| `initializing`  | Enumeration or a permission request is in flight |
+| `granted`       | Enumerated and ready to use                      |
+| `error`         | Could not be acquired; see `reason`              |
+
+| `reason`              | Meaning                                                            |
+| --------------------- | ------------------------------------------------------------------ |
+| `blocked`             | The user denied permission                                         |
+| `already-in-use`      | The hardware is busy in another application                        |
+| `not-found`           | No matching hardware                                               |
+| `invalid-constraints` | The requested constraints couldn't be satisfied                    |
+| `not-supported`       | Browser API unavailable — a legacy browser, or an insecure context |
+| `unknown`             | Couldn't be classified                                             |
+
+<Note>
+  Speakers aren't tracked here. Output devices have no permission or in-use
+  failure mode, only enumeration, so `getAllSpeakers()` and `updateSpeaker()`
+  are the whole story for them.
+</Note>
+
+### needsInit()
+
+`needsInit(): boolean`
+
+Whether `initDevices()` still has work to do — true while any device you opted into with `enableMic` / `enableCam` is still `uninitialized`. Devices you opted out of stay `uninitialized` by design and don't count.
+
+`connect()` and `startBot()` use this internally to decide whether to run an implicit `initDevices()`; it's public so your own code can branch on the same rule.
 
 ## Tracks (audio and video)
 

--- a/api-reference/client/react/hooks.mdx
+++ b/api-reference/client/react/hooks.mdx
@@ -95,6 +95,25 @@ function DeviceSelector() {
 }
 ```
 
+## useMediaState
+
+Subscribes to the per-device mic and cam state, re-rendering when either transitions. Use it to drive permission UI.
+
+```jsx
+import { useMediaState } from "@pipecat-ai/client-react";
+
+function MicStatus() {
+  const { mic } = useMediaState();
+
+  if (mic.state === "error") {
+    return <p>Microphone unavailable: {mic.reason}</p>;
+  }
+  return <p>Microphone {mic.state}</p>;
+}
+```
+
+Returns a [`MediaState`](/api-reference/client/js/client-methods#mediastate) snapshot. Safe to call from any component inside `PipecatClientProvider` — the subscription is mounted for you.
+
 ## usePipecatClientMediaTrack
 
 Access audio and video tracks.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -83335,6 +83335,14 @@ Initializes the media device selection machinery, based on `enableCam`/`enableMi
 await pcClient.initDevices();
 ```
 
+It drives [`mediaState`](#mediastate): both devices move to `initializing` on entry, then to `granted` for each device the transport reports as acquired. A device that isn't acquired falls back to `uninitialized`. On failure the underlying error classifies the affected devices and is re-thrown, so callers still see it.
+
+<Note>
+  Calling `initDevices()` again after a failure is the recovery path — a second
+  call re-enters `initializing` and reclassifies. There is no separate retry
+  method.
+</Note>
+
 ### getAllMics()
 
 `async getAllMics(): Promise<MediaDeviceInfo[]>`
@@ -83509,6 +83517,63 @@ An accessor to determine if the client is sharing their screen.
 ```typescript
 screen_sharing = pcClient.isSharingScreen;
 ```
+
+### mediaState
+
+`get mediaState(): MediaState`
+
+Per-device state for the mic and cam, independent of the transport's connection state. Use it to render permission UI — whether to show a "grant access" prompt, an error, or the device picker.
+
+```typescript
+const { mic, cam } = pcClient.mediaState;
+
+if (mic.state === "error" && mic.reason === "blocked") {
+  // the user denied microphone permission
+}
+```
+
+Returns a snapshot. To track changes, subscribe to `RTVIEvent.MediaStateUpdated` or pass an [`onMediaStateChanged`](/api-reference/client/js/callbacks) callback to the constructor. In React, use [`useMediaState`](/api-reference/client/react/hooks#usemediastate).
+
+<Expandable title="MediaState" defaultOpen="true">
+  <ParamField path="mic" type="DeviceStatus">
+    Status of the microphone.
+  </ParamField>
+  <ParamField path="cam" type="DeviceStatus">
+    Status of the camera.
+  </ParamField>
+</Expandable>
+
+A `DeviceStatus` is `{ state }`, plus `reason` and optional `details` when `state` is `"error"`:
+
+| `state`         | Meaning                                          |
+| --------------- | ------------------------------------------------ |
+| `uninitialized` | `initDevices()` hasn't run for this device       |
+| `initializing`  | Enumeration or a permission request is in flight |
+| `granted`       | Enumerated and ready to use                      |
+| `error`         | Could not be acquired; see `reason`              |
+
+| `reason`              | Meaning                                                            |
+| --------------------- | ------------------------------------------------------------------ |
+| `blocked`             | The user denied permission                                         |
+| `already-in-use`      | The hardware is busy in another application                        |
+| `not-found`           | No matching hardware                                               |
+| `invalid-constraints` | The requested constraints couldn't be satisfied                    |
+| `not-supported`       | Browser API unavailable — a legacy browser, or an insecure context |
+| `unknown`             | Couldn't be classified                                             |
+
+<Note>
+  Speakers aren't tracked here. Output devices have no permission or in-use
+  failure mode, only enumeration, so `getAllSpeakers()` and `updateSpeaker()`
+  are the whole story for them.
+</Note>
+
+### needsInit()
+
+`needsInit(): boolean`
+
+Whether `initDevices()` still has work to do — true while any device you opted into with `enableMic` / `enableCam` is still `uninitialized`. Devices you opted out of stay `uninitialized` by design and don't count.
+
+`connect()` and `startBot()` use this internally to decide whether to run an implicit `initDevices()`; it's public so your own code can branch on the same rule.
 
 ## Tracks (audio and video)
 
@@ -83858,6 +83923,13 @@ pcClient.on(RTVIEvent.BotReady, () => console.log("Bot ready via event"));
 
 <ParamField path="onCamUpdated" type="cam:MediaDeviceInfo">
   User selected a new camera as their selected/active device.
+</ParamField>
+
+<ParamField path="onMediaStateChanged" type="mediaState:MediaState">
+  Per-device mic/cam state changed — a permission granted or denied, a device
+  that couldn't be acquired. See
+  [`mediaState`](/api-reference/client/js/client-methods#mediastate) for the
+  shape and what each state means.
 </ParamField>
 
 <ParamField path="onSpeakerUpdated" type="speaker:MediaDeviceInfo">
@@ -84212,6 +84284,7 @@ Here's the complete reference mapping events to their corresponding callbacks:
 | `MicUpdated`           | `onMicUpdated`           | `MediaDeviceInfo`               |
 | `CamUpdated`           | `onCamUpdated`           | `MediaDeviceInfo`               |
 | `SpeakerUpdated`       | `onSpeakerUpdated`       | `MediaDeviceInfo`               |
+| `MediaStateUpdated`    | `onMediaStateChanged`    | `MediaState`                    |
 | `DeviceError`          | `onDeviceError`          | `DeviceError`                   |
 
 ### Audio Activity Events
@@ -85750,6 +85823,25 @@ function DeviceSelector() {
   );
 }
 ```
+
+## useMediaState
+
+Subscribes to the per-device mic and cam state, re-rendering when either transitions. Use it to drive permission UI.
+
+```jsx
+import { useMediaState } from "@pipecat-ai/client-react";
+
+function MicStatus() {
+  const { mic } = useMediaState();
+
+  if (mic.state === "error") {
+    return <p>Microphone unavailable: {mic.reason}</p>;
+  }
+  return <p>Microphone {mic.state}</p>;
+}
+```
+
+Returns a [`MediaState`](/api-reference/client/js/client-methods#mediastate) snapshot. Safe to call from any component inside `PipecatClientProvider` — the subscription is mounted for you.
 
 ## usePipecatClientMediaTrack
 


### PR DESCRIPTION
Step 3 of the client SDK sweep. The MediaState surface shipped in **client-js 1.8.0** and **client-react 1.8.0** and was documented nowhere.

It's the intended way to render permission UI. Without it, the only signal the docs offered was the boolean `isMicEnabled` — which can't distinguish *"we haven't asked yet"* from *"the user said no"* from *"another app has the mic"*, and those want three different interfaces.

## What's added

| | Page |
| --- | --- |
| `mediaState` getter, with the `MediaState` / `DeviceStatus` shape | `js/client-methods` |
| `needsInit()` | `js/client-methods` |
| `onMediaStateChanged` callback + the `MediaStateUpdated` event row | `js/callbacks` |
| `useMediaState` | `react/hooks` |

Two tables carry the vocabulary, because branching on it is the whole point:

- **states** — `uninitialized` / `initializing` / `granted` / `error`
- **error reasons** — `blocked`, `already-in-use`, `not-found`, `invalid-constraints`, `not-supported`, `unknown`

`blocked` and `already-in-use` are the pair that matters: one is a permissions problem the user can fix in the browser, the other is another application holding the hardware. Same boolean, different remedy.

Also noted that **speakers are deliberately absent** from `MediaState` — an output device has no permission or in-use failure mode, only enumeration, so `getAllSpeakers()` / `updateSpeaker()` are the whole story there. Worth stating so nobody hunts for `mediaState.speaker`.

## `initDevices()` was already documented — in pre-1.8.0 terms

It now says which state transitions it drives, and this:

> Calling `initDevices()` again after a failure is the recovery path — a second call re-enters `initializing` and reclassifies. There is no separate retry method.

Straight from the source docstring, and worth surfacing because a reader hitting a device error would otherwise go looking for a `retryDevices()` that doesn't exist.

Checks: `docs-meta-lint` 0 errors, `mint broken-links --check-anchors --check-redirects` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)