### PR TITLE
docs: document the React screen share bindings

### DIFF
--- a/api-reference/client/js/client-methods.mdx
+++ b/api-reference/client/js/client-methods.mdx
@@ -455,6 +455,8 @@ live_tracks_list = pcClient.tracks();
   local: {
     audio?: MediaStreamTrack;
     video?: MediaStreamTrack;
+    screenAudio?: MediaStreamTrack;
+    screenVideo?: MediaStreamTrack;
   },
   bot?: {
     audio?: MediaStreamTrack;

--- a/api-reference/client/react/components.mdx
+++ b/api-reference/client/react/components.mdx
@@ -54,6 +54,10 @@ Creates a new `<video>` element that renders either the bot or local participant
 <ParamField path="participant" type="('local' | 'bot')" required>
   Defines which participant's video track is rendered
 </ParamField>
+<ParamField path="trackType" type="('video' | 'screenVideo')">
+  Which of the participant's video tracks to render. Default: 'video'. Use
+  'screenVideo' to render a screen share
+</ParamField>
 <ParamField path="fit" type="('contain' | 'cover')">
   Defines whether the video should be fully contained or cover the box. Default:
   'contain'
@@ -124,6 +128,46 @@ A headless component to read and set the local participant's microphone state.
 <ParamField path="children" type="function">
   A render prop that provides state and handlers to the children
 </ParamField>
+
+## PipecatClientScreenShareToggle
+
+A headless component to read and set the local participant's screen share state.
+
+```jsx
+<PipecatClientScreenShareToggle
+  onScreenShareEnabledChanged={(enabled) =>
+    console.log("Screen share enabled:", enabled)
+  }
+>
+  {({ disabled, isScreenShareEnabled, onClick }) => (
+    <button disabled={disabled} onClick={onClick}>
+      {isScreenShareEnabled ? "Stop Sharing" : "Share Screen"}
+    </button>
+  )}
+</PipecatClientScreenShareToggle>
+```
+
+**Props**
+
+<ParamField
+  path="onScreenShareEnabledChanged(enabled: boolean)"
+  type="function"
+>
+  Triggered whenever the local participant's screen share state changes
+</ParamField>
+<ParamField path="disabled" type="boolean">
+  If true, the component will not allow toggling the screen share state.
+  Default: false
+</ParamField>
+<ParamField path="children" type="function">
+  A render prop that provides state and handlers to the children
+</ParamField>
+
+<Note>
+  Starting a screen share opens the browser's own picker, so it must run from a
+  user gesture — a click handler, as above. Render the shared surface with
+  [`PipecatClientVideo`](#pipecatclientvideo) using `trackType="screenVideo"`.
+</Note>
 
 ## VoiceVisualizer
 

--- a/api-reference/client/react/hooks.mdx
+++ b/api-reference/client/react/hooks.mdx
@@ -136,6 +136,27 @@ function MyTracks() {
 />
 <ParamField path="participantType" type="'bot' | 'local'" required />
 
+## usePipecatClientScreenShareControl
+
+Controls the local participant's screen share state.
+
+```jsx
+import { usePipecatClientScreenShareControl } from "@pipecat-ai/client-react";
+
+function ScreenShareToggle() {
+  const { enableScreenShare, isScreenShareEnabled } =
+    usePipecatClientScreenShareControl();
+
+  return (
+    <button onClick={() => enableScreenShare(!isScreenShareEnabled)}>
+      {isScreenShareEnabled ? "Stop Sharing" : "Share Screen"}
+    </button>
+  );
+}
+```
+
+Starting a share opens the browser's own picker, so call `enableScreenShare(true)` from a user gesture. Render the result with [`PipecatClientVideo`](/api-reference/client/react/components#pipecatclientvideo) using `trackType="screenVideo"`, or reach the raw track through [`tracks()`](/api-reference/client/js/client-methods#tracks).
+
 ## usePipecatClientTransportState
 
 Returns the current transport state.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -83594,6 +83594,8 @@ live_tracks_list = pcClient.tracks();
   local: {
     audio?: MediaStreamTrack;
     video?: MediaStreamTrack;
+    screenAudio?: MediaStreamTrack;
+    screenVideo?: MediaStreamTrack;
   },
   bot?: {
     audio?: MediaStreamTrack;
@@ -85618,6 +85620,10 @@ Creates a new `<video>` element that renders either the bot or local participant
 <ParamField path="participant" type="('local' | 'bot')" required>
   Defines which participant's video track is rendered
 </ParamField>
+<ParamField path="trackType" type="('video' | 'screenVideo')">
+  Which of the participant's video tracks to render. Default: 'video'. Use
+  'screenVideo' to render a screen share
+</ParamField>
 <ParamField path="fit" type="('contain' | 'cover')">
   Defines whether the video should be fully contained or cover the box. Default:
   'contain'
@@ -85688,6 +85694,46 @@ A headless component to read and set the local participant's microphone state.
 <ParamField path="children" type="function">
   A render prop that provides state and handlers to the children
 </ParamField>
+
+## PipecatClientScreenShareToggle
+
+A headless component to read and set the local participant's screen share state.
+
+```jsx
+<PipecatClientScreenShareToggle
+  onScreenShareEnabledChanged={(enabled) =>
+    console.log("Screen share enabled:", enabled)
+  }
+>
+  {({ disabled, isScreenShareEnabled, onClick }) => (
+    <button disabled={disabled} onClick={onClick}>
+      {isScreenShareEnabled ? "Stop Sharing" : "Share Screen"}
+    </button>
+  )}
+</PipecatClientScreenShareToggle>
+```
+
+**Props**
+
+<ParamField
+  path="onScreenShareEnabledChanged(enabled: boolean)"
+  type="function"
+>
+  Triggered whenever the local participant's screen share state changes
+</ParamField>
+<ParamField path="disabled" type="boolean">
+  If true, the component will not allow toggling the screen share state.
+  Default: false
+</ParamField>
+<ParamField path="children" type="function">
+  A render prop that provides state and handlers to the children
+</ParamField>
+
+<Note>
+  Starting a screen share opens the browser's own picker, so it must run from a
+  user gesture — a click handler, as above. Render the shared surface with
+  [`PipecatClientVideo`](#pipecatclientvideo) using `trackType="screenVideo"`.
+</Note>
 
 ## VoiceVisualizer
 
@@ -85864,6 +85910,27 @@ function MyTracks() {
   required
 />
 <ParamField path="participantType" type="'bot' | 'local'" required />
+
+## usePipecatClientScreenShareControl
+
+Controls the local participant's screen share state.
+
+```jsx
+import { usePipecatClientScreenShareControl } from "@pipecat-ai/client-react";
+
+function ScreenShareToggle() {
+  const { enableScreenShare, isScreenShareEnabled } =
+    usePipecatClientScreenShareControl();
+
+  return (
+    <button onClick={() => enableScreenShare(!isScreenShareEnabled)}>
+      {isScreenShareEnabled ? "Stop Sharing" : "Share Screen"}
+    </button>
+  );
+}
+```
+
+Starting a share opens the browser's own picker, so call `enableScreenShare(true)` from a user gesture. Render the result with [`PipecatClientVideo`](/api-reference/client/react/components#pipecatclientvideo) using `trackType="screenVideo"`, or reach the raw track through [`tracks()`](/api-reference/client/js/client-methods#tracks).
 
 ## usePipecatClientTransportState
 


### PR DESCRIPTION
Step 4 of the client SDK sweep. Screen share was documented on the JS side — `enableScreenShare()`, `isSharingScreen` — and **not at all** on the React side. An app using the React bindings had cam and mic covered and nothing for the third control.

## What's added

| | Page |
| --- | --- |
| `usePipecatClientScreenShareControl` | `react/hooks` |
| `PipecatClientScreenShareToggle` | `react/components` |
| `PipecatClientVideo trackType` prop | `react/components` |
| `Tracks` gains `screenAudio` / `screenVideo` | `js/client-methods` |

The hook and toggle are written to mirror the cam and mic ones they sit beside — the shapes are identical (`{ enableX, isXEnabled }` and the same render-prop payload), so a reader arriving from those finds what they expect rather than a differently-shaped API for the same job.

`trackType` was the notable omission: it's the **only** way to render a shared surface, and the props table didn't list it. Combined with `trackType` on `usePipecatClientMediaTrack` having omitted the screen values (fixed in #1169), screen-share tracks were unreachable through the documented API in both places.

## One constraint worth stating

Both entries note that starting a share opens the browser's own picker and so must run from a user gesture. That's the browser's rule rather than Pipecat's, but it decides how the control gets wired — and a `useEffect` that calls `enableScreenShare(true)` on mount will simply fail.

## Remaining

Omissions (callbacks, event-table rows, error classes, undocumented props, conversation extras), and the MoQ client transport.

Checks: `docs-meta-lint` 0 errors, `mint broken-links --check-anchors --check-redirects` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)