### PR TITLE
docs: add the MoQ client transport

### DIFF
--- a/api-reference/client/js/transports/moq.mdx
+++ b/api-reference/client/js/transports/moq.mdx
@@ -1,0 +1,158 @@
+---
+title: "MoQ Transport"
+"og:title": "MoQ Transport - JavaScript SDK"
+sidebarTitle: "MoQ"
+description: "MoqTransport for the JavaScript SDK: Media over QUIC audio and RTVI messaging to a Pipecat bot, over WebTransport."
+---
+
+`MoqTransport` connects a `PipecatClient` to a Pipecat bot over [Media over QUIC](https://quic.video) — either through a relay both sides dial, or directly to a bot serving its own socket.
+
+It publishes the microphone as an Opus broadcast and consumes the bot's, discovering codec and sample rate from the bot's catalog at connect time rather than pinning them in code. RTVI messages travel in both directions over a dedicated JSON stream track, so this is a full RTVI transport rather than an audio-only path.
+
+Connection uses WebTransport, with `@moq/net` racing a WebSocket fallback if WebTransport can't be reached.
+
+## Installation
+
+```bash
+npm install @pipecat-ai/client-js @pipecat-ai/moq-transport
+```
+
+## Usage
+
+### Basic Setup
+
+```javascript
+import { PipecatClient } from "@pipecat-ai/client-js";
+import { MoqTransport } from "@pipecat-ai/moq-transport";
+
+const transport = new MoqTransport({
+  relayUrl: "https://relay.example.com:4080/moq",
+  clientId: "request",
+  botId: "response",
+});
+
+const pcClient = new PipecatClient({ transport });
+
+await pcClient.connect();
+```
+
+### With the development runner
+
+The Pipecat development runner returns everything the transport needs from `POST /start`, under a `moq` key — the relay URL, the certificate hash in serve mode, the namespace, and the participant ids. Pass it straight through:
+
+```javascript
+const { moq } = await fetch("/start", { method: "POST" }).then((r) => r.json());
+
+const transport = new MoqTransport({
+  relayUrl: moq.relayUrl,
+  namespace: moq.namespace,
+  clientId: moq.clientId,
+  botId: moq.botId,
+  serverCertificateHashes: moq.certHash
+    ? [{ algorithm: "sha-256", value: moq.certHash }]
+    : undefined,
+});
+```
+
+<Warning>
+  Constructing the transport by hand, take care with `clientId` and `botId`. The
+  defaults here are `client0` and `bot0`, while a Pipecat bot publishes under
+  `response` and listens on `request`. With defaults on both sides the two never
+  find each other — so set `clientId: "request"` and `botId: "response"`, or
+  take the values from `/start` as above.
+</Warning>
+
+### Self-signed development relay
+
+A bot in serve mode mints its own certificate and reports the fingerprint. Pin it rather than disabling verification:
+
+```javascript
+const transport = new MoqTransport({
+  relayUrl: "https://localhost:4080/moq",
+  serverCertificateHashes: [{ algorithm: "sha-256", value: certHashBytes }],
+});
+```
+
+## API Reference
+
+### Constructor Options
+
+<ParamField path="relayUrl" type="string" required>
+  Full URL of the MoQ peer, e.g. `https://relay.example.com:4080/moq`.
+</ParamField>
+
+<ParamField path="clientId" type="string" default="client0">
+  This client's participant id. The client publishes under
+  `<namespace>/<clientId>`.
+</ParamField>
+
+<ParamField path="botId" type="string" default="bot0">
+  The bot's participant id. The client subscribes to `<namespace>/<botId>`.
+</ParamField>
+
+<ParamField path="namespace" type="string" default="pipecat">
+  Top-level namespace, analogous to a room name.
+</ParamField>
+
+<ParamField path="serverCertificateHashes" type="WebTransportHash[]">
+  Certificate hashes to pin, for a self-signed development relay. Same shape as
+  WebTransport's own `serverCertificateHashes`.
+</ParamField>
+
+<ParamField path="transcriptTrack" type="string" default="transcript.json.z">
+  Track name for the bidirectional RTVI message channel. Discovered by
+  convention rather than through the catalog, so it has to match the bot's.
+</ParamField>
+
+<ParamField path="audioLatencyMs" type="number" default="80">
+  Jitter buffer floor, in milliseconds. Lower is more interactive and drops more
+  on a poor network; higher is smoother at the cost of delay.
+</ParamField>
+
+<ParamField path="audioBufferMaxMs" type="number | 'real-time'" default="30000">
+  Ceiling for buffered playback. A bot writes TTS audio faster than real time
+  with future-dated timestamps, and the player buffers it rather than skipping
+  ahead — this caps how much may build up. An interruption flushes it early.
+  Pass `"real-time"` to collapse to the floor instead, which only makes sense
+  against a genuinely live publisher.
+</ParamField>
+
+<ParamField path="audioSampleRate" type="number" default="48000">
+  Rate the client publishes its microphone at. One of Opus's supported rates:
+  8000, 12000, 16000, 24000, or 48000. The bot reads this from the catalog and
+  resamples, so exact agreement isn't required.
+</ParamField>
+
+### Broadcast paths
+
+Each side publishes on one path and subscribes to the other's:
+
+```
+client publishes   <namespace>/<clientId>
+client subscribes  <namespace>/<botId>
+```
+
+Audio track names within a broadcast come from the bot's catalog, so they aren't configured here. The transcript track is the exception — it's a JSON stream rather than a media rendition, so the catalog doesn't describe it and both sides agree on the name by convention.
+
+## Events
+
+`MoqTransport` reports connection state through the standard [`PipecatClient` callbacks](/api-reference/client/js/callbacks) — there are no MoQ-specific events.
+
+## More Information
+
+<CardGroup cols={2}>
+  <Card
+    title="Server-side MoQ transport"
+    icon="server"
+    href="/api-reference/server/services/transport/moq"
+  >
+    The bot half of the pair, including serve and relay modes
+  </Card>
+  <Card
+    title="Choosing a transport"
+    icon="shuffle"
+    href="/client/concepts/choosing-a-transport"
+  >
+    How MoQ compares to the other client transports
+  </Card>
+</CardGroup>

--- a/client/concepts/choosing-a-transport.mdx
+++ b/client/concepts/choosing-a-transport.mdx
@@ -31,6 +31,9 @@ The choice of transport has one important constraint: **the client transport and
   >
     Direct WebSocket connection. For server-to-server setups only.
   </Card>
+  <Card title="MoQ" icon="bolt" href="/api-reference/client/js/transports/moq">
+    Audio and RTVI over Media over QUIC, through a relay or straight to the bot.
+  </Card>
   <Card
     title="Gemini Live"
     icon="google"
@@ -193,10 +196,11 @@ The Pipecat CLI scaffolds a `config.ts` that selects the transport based on an e
 
 ## Summary
 
-| Transport     | Best for                      | Requires       |
-| ------------- | ----------------------------- | -------------- |
-| SmallWebRTC   | Local dev, self-hosted        | Nothing        |
-| Daily         | Production apps, global users | Daily account  |
-| WebSocket     | Text-only, server-to-server   | Custom server  |
-| Gemini Live   | Gemini prototypes             | Gemini API key |
-| OpenAI WebRTC | OpenAI prototypes             | OpenAI API key |
+| Transport     | Best for                      | Requires                      |
+| ------------- | ----------------------------- | ----------------------------- |
+| SmallWebRTC   | Local dev, self-hosted        | Nothing                       |
+| Daily         | Production apps, global users | Daily account                 |
+| WebSocket     | Text-only, server-to-server   | Custom server                 |
+| MoQ           | QUIC transport, NAT traversal | Relay, or a bot in serve mode |
+| Gemini Live   | Gemini prototypes             | Gemini API key                |
+| OpenAI WebRTC | OpenAI prototypes             | OpenAI API key                |

--- a/docs.json
+++ b/docs.json
@@ -778,6 +778,7 @@
                     "pages": [
                       "api-reference/client/js/transports/transport",
                       "api-reference/client/js/transports/daily",
+                      "api-reference/client/js/transports/moq",
                       "api-reference/client/js/transports/small-webrtc",
                       "api-reference/client/js/transports/websocket",
                       "api-reference/client/js/transports/gemini",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -20068,6 +20068,9 @@ The choice of transport has one important constraint: **the client transport and
   >
     Direct WebSocket connection. For server-to-server setups only.
   </Card>
+  <Card title="MoQ" icon="bolt" href="/api-reference/client/js/transports/moq">
+    Audio and RTVI over Media over QUIC, through a relay or straight to the bot.
+  </Card>
   <Card
     title="Gemini Live"
     icon="google"
@@ -20230,13 +20233,14 @@ The Pipecat CLI scaffolds a `config.ts` that selects the transport based on an e
 
 ## Summary
 
-| Transport     | Best for                      | Requires       |
-| ------------- | ----------------------------- | -------------- |
-| SmallWebRTC   | Local dev, self-hosted        | Nothing        |
-| Daily         | Production apps, global users | Daily account  |
-| WebSocket     | Text-only, server-to-server   | Custom server  |
-| Gemini Live   | Gemini prototypes             | Gemini API key |
-| OpenAI WebRTC | OpenAI prototypes             | OpenAI API key |
+| Transport     | Best for                      | Requires                      |
+| ------------- | ----------------------------- | ----------------------------- |
+| SmallWebRTC   | Local dev, self-hosted        | Nothing                       |
+| Daily         | Production apps, global users | Daily account                 |
+| WebSocket     | Text-only, server-to-server   | Custom server                 |
+| MoQ           | QUIC transport, NAT traversal | Relay, or a bot in serve mode |
+| Gemini Live   | Gemini prototypes             | Gemini API key                |
+| OpenAI WebRTC | OpenAI prototypes             | OpenAI API key                |
 
 # Session Lifecycle
 Source: https://docs.pipecat.ai/client/concepts/session-lifecycle.md
@@ -84759,6 +84763,163 @@ const dailyCall = pcClient.transport.dailyCallClient;
 >
   `@pipecat-ai/daily-transport`
 </Card>
+
+# MoQ Transport
+Source: https://docs.pipecat.ai/api-reference/client/js/transports/moq.md
+
+MoqTransport for the JavaScript SDK: Media over QUIC audio and RTVI messaging to a Pipecat bot, over WebTransport.
+
+`MoqTransport` connects a `PipecatClient` to a Pipecat bot over [Media over QUIC](https://quic.video) — either through a relay both sides dial, or directly to a bot serving its own socket.
+
+It publishes the microphone as an Opus broadcast and consumes the bot's, discovering codec and sample rate from the bot's catalog at connect time rather than pinning them in code. RTVI messages travel in both directions over a dedicated JSON stream track, so this is a full RTVI transport rather than an audio-only path.
+
+Connection uses WebTransport, with `@moq/net` racing a WebSocket fallback if WebTransport can't be reached.
+
+## Installation
+
+```bash
+npm install @pipecat-ai/client-js @pipecat-ai/moq-transport
+```
+
+## Usage
+
+### Basic Setup
+
+```javascript
+import { PipecatClient } from "@pipecat-ai/client-js";
+import { MoqTransport } from "@pipecat-ai/moq-transport";
+
+const transport = new MoqTransport({
+  relayUrl: "https://relay.example.com:4080/moq",
+  clientId: "request",
+  botId: "response",
+});
+
+const pcClient = new PipecatClient({ transport });
+
+await pcClient.connect();
+```
+
+### With the development runner
+
+The Pipecat development runner returns everything the transport needs from `POST /start`, under a `moq` key — the relay URL, the certificate hash in serve mode, the namespace, and the participant ids. Pass it straight through:
+
+```javascript
+const { moq } = await fetch("/start", { method: "POST" }).then((r) => r.json());
+
+const transport = new MoqTransport({
+  relayUrl: moq.relayUrl,
+  namespace: moq.namespace,
+  clientId: moq.clientId,
+  botId: moq.botId,
+  serverCertificateHashes: moq.certHash
+    ? [{ algorithm: "sha-256", value: moq.certHash }]
+    : undefined,
+});
+```
+
+<Warning>
+  Constructing the transport by hand, take care with `clientId` and `botId`. The
+  defaults here are `client0` and `bot0`, while a Pipecat bot publishes under
+  `response` and listens on `request`. With defaults on both sides the two never
+  find each other — so set `clientId: "request"` and `botId: "response"`, or
+  take the values from `/start` as above.
+</Warning>
+
+### Self-signed development relay
+
+A bot in serve mode mints its own certificate and reports the fingerprint. Pin it rather than disabling verification:
+
+```javascript
+const transport = new MoqTransport({
+  relayUrl: "https://localhost:4080/moq",
+  serverCertificateHashes: [{ algorithm: "sha-256", value: certHashBytes }],
+});
+```
+
+## API Reference
+
+### Constructor Options
+
+<ParamField path="relayUrl" type="string" required>
+  Full URL of the MoQ peer, e.g. `https://relay.example.com:4080/moq`.
+</ParamField>
+
+<ParamField path="clientId" type="string" default="client0">
+  This client's participant id. The client publishes under
+  `<namespace>/<clientId>`.
+</ParamField>
+
+<ParamField path="botId" type="string" default="bot0">
+  The bot's participant id. The client subscribes to `<namespace>/<botId>`.
+</ParamField>
+
+<ParamField path="namespace" type="string" default="pipecat">
+  Top-level namespace, analogous to a room name.
+</ParamField>
+
+<ParamField path="serverCertificateHashes" type="WebTransportHash[]">
+  Certificate hashes to pin, for a self-signed development relay. Same shape as
+  WebTransport's own `serverCertificateHashes`.
+</ParamField>
+
+<ParamField path="transcriptTrack" type="string" default="transcript.json.z">
+  Track name for the bidirectional RTVI message channel. Discovered by
+  convention rather than through the catalog, so it has to match the bot's.
+</ParamField>
+
+<ParamField path="audioLatencyMs" type="number" default="80">
+  Jitter buffer floor, in milliseconds. Lower is more interactive and drops more
+  on a poor network; higher is smoother at the cost of delay.
+</ParamField>
+
+<ParamField path="audioBufferMaxMs" type="number | 'real-time'" default="30000">
+  Ceiling for buffered playback. A bot writes TTS audio faster than real time
+  with future-dated timestamps, and the player buffers it rather than skipping
+  ahead — this caps how much may build up. An interruption flushes it early.
+  Pass `"real-time"` to collapse to the floor instead, which only makes sense
+  against a genuinely live publisher.
+</ParamField>
+
+<ParamField path="audioSampleRate" type="number" default="48000">
+  Rate the client publishes its microphone at. One of Opus's supported rates:
+  8000, 12000, 16000, 24000, or 48000. The bot reads this from the catalog and
+  resamples, so exact agreement isn't required.
+</ParamField>
+
+### Broadcast paths
+
+Each side publishes on one path and subscribes to the other's:
+
+```
+client publishes   <namespace>/<clientId>
+client subscribes  <namespace>/<botId>
+```
+
+Audio track names within a broadcast come from the bot's catalog, so they aren't configured here. The transcript track is the exception — it's a JSON stream rather than a media rendition, so the catalog doesn't describe it and both sides agree on the name by convention.
+
+## Events
+
+`MoqTransport` reports connection state through the standard [`PipecatClient` callbacks](/api-reference/client/js/callbacks) — there are no MoQ-specific events.
+
+## More Information
+
+<CardGroup cols={2}>
+  <Card
+    title="Server-side MoQ transport"
+    icon="server"
+    href="/api-reference/server/services/transport/moq"
+  >
+    The bot half of the pair, including serve and relay modes
+  </Card>
+  <Card
+    title="Choosing a transport"
+    icon="shuffle"
+    href="/client/concepts/choosing-a-transport"
+  >
+    How MoQ compares to the other client transports
+  </Card>
+</CardGroup>
 
 # Small WebRTC Transport
 Source: https://docs.pipecat.ai/api-reference/client/js/transports/small-webrtc.md

--- a/llms.txt
+++ b/llms.txt
@@ -652,6 +652,7 @@ LLM, transports, serializers), pipelines, frames, workers, and utilities.
 
 - [Transport Overview](https://docs.pipecat.ai/api-reference/client/js/transports/transport.md): The Transport base class in the Pipecat JavaScript SDK: device management, connectivity, and messaging every transport implements.
 - [Daily WebRTC Transport](https://docs.pipecat.ai/api-reference/client/js/transports/daily.md): DailyTransport for the Pipecat JavaScript SDK: WebRTC audio and video on Daily's infrastructure, wrapping a Daily-JS call client.
+- [MoQ Transport](https://docs.pipecat.ai/api-reference/client/js/transports/moq.md): MoqTransport for the JavaScript SDK: Media over QUIC audio and RTVI messaging to a Pipecat bot, over WebTransport.
 - [Small WebRTC Transport](https://docs.pipecat.ai/api-reference/client/js/transports/small-webrtc.md): SmallWebRTCTransport for the JavaScript SDK: peer-to-peer WebRTC to a Pipecat bot with no third-party WebRTC provider.
 - [WebSocket Transport](https://docs.pipecat.ai/api-reference/client/js/transports/websocket.md): WebSocketTransport for the JavaScript SDK: a lightweight, purely WebSocket-based connection between clients and a Pipecat bot.
 - [Gemini Live WebSocket Transport](https://docs.pipecat.ai/api-reference/client/js/transports/gemini.md): GeminiLiveWebsocketTransport for the JavaScript SDK: connect directly to Google's Gemini Live service over WebSocket.


### PR DESCRIPTION
`@pipecat-ai/moq-transport` is published on npm at 0.1.1 and had no documentation. Three things pointed at a page that didn't exist:

- the package's **own README** links to `docs.pipecat.ai/client/js/transports` for documentation
- the **server-side MoQ page** (#1154) describes the browser dialling the bot and pinning its certificate
- **`choosing-a-transport`** presented five transports as the complete set, while also stating that client and server transports must be a matching pair

So a reader following the server page had nowhere to land, and the selection page told them the option didn't exist.

## A warning the source made necessary

The client defaults `clientId` to `client0` and `botId` to `bot0`. A Pipecat bot publishes under **`response`** and listens on **`request`** — renamed server-side in 1.8.0 (#5158). With defaults on both sides, **the two never find each other.**

The development runner papers over this: `/start` returns both ids from `--moq-client-id` / `--moq-bot-id`, and the browser pipes them straight in. So the runner path works and the mismatch only bites someone wiring the transport by hand — which is exactly why it's worth stating.

The page shows both routes: explicit ids in the basic example, and the `/start` passthrough for runner-driven apps.

<sub>Worth flagging separately: the client package's defaults look stale relative to pipecat 1.8.0. Aligning them upstream would remove the trap rather than document it.</sub>

## `audioBufferMaxMs` gets a real explanation

Not a restated type. A bot writes TTS audio *faster than real time* with future-dated timestamps, and the player buffers it rather than skipping ahead — so this option caps how much may accumulate, and an interruption flushes it early. `"real-time"` collapses to the floor, which suits a genuinely live publisher and not a bot. None of that is guessable from the signature.

## Also

- Card and summary-table row in `choosing-a-transport`
- Registered in `docs.json`, between `daily` and `small-webrtc`
- Noted that the transcript track is agreed by convention rather than through the catalog, since the catalog only describes media renditions

Checks: `docs-meta-lint` 0 errors, `mint broken-links --check-anchors --check-redirects` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)