### PR TITLE
docs: fix Pipecat Cloud commands that fail when run

### DIFF
--- a/api-reference/cli/cloud/agent.mdx
+++ b/api-reference/cli/cloud/agent.mdx
@@ -74,7 +74,7 @@ Stop an active agent session and clean up its resources.
 **Usage:**
 
 ```shell
-pcc agent stop [ARGS] [OPTIONS]
+pipecat cloud agent stop [ARGS] [OPTIONS]
 ```
 
 **Arguments:**
@@ -152,9 +152,9 @@ pipecat cloud agent logs [ARGS] [OPTIONS]
 
 **Options:**
 
-<ParamField path="--level / -l" type="string" default="ALL">
-  Filter logs by severity: `ALL`, `DEBUG`, `INFO`, `WARNING`, `ERROR`,
-  `CRITICAL`.
+<ParamField path="--level / -l" type="string">
+  Filter logs by severity: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`.
+  Omit it to return every level.
 </ParamField>
 
 <ParamField path="--limit / -n" type="int" default="100">
@@ -248,6 +248,6 @@ pipecat cloud agent delete [ARGS] [OPTIONS]
 
 **Options:**
 
-<ParamField path="--force / -f" type="string">
+<ParamField path="--force / -f" type="boolean" default="false">
   Do not prompt for confirmation before deleting the agent.
 </ParamField>

--- a/api-reference/cli/cloud/auth.mdx
+++ b/api-reference/cli/cloud/auth.mdx
@@ -13,15 +13,8 @@ Begins an authorization flow to authenticate with Pipecat Cloud.
 **Usage:**
 
 ```shell
-pipecat cloud auth login [OPTIONS]
+pipecat cloud auth login
 ```
-
-**Options:**
-
-<ParamField path="--headless / -h" type="boolean" default="false">
-  Skip opening a browser window for authentication and print the URL instead.
-  Useful for remote or containerized environments.
-</ParamField>
 
 This command initiates the authentication process by:
 
@@ -30,7 +23,7 @@ This command initiates the authentication process by:
 3. Waiting for you to complete the sign-in process in the browser
 4. Retrieving and storing your access token locally
 
-If the browser doesn't open automatically, or if you use the `--headless` option, you can copy and paste the displayed URL into your browser manually.
+If the browser doesn't open automatically, you can copy and paste the displayed URL into your browser manually.
 
 On successful login, the CLI will store the access token in the local configuration file (defaults to `~/.config/pipecatcloud/pipecatcloud.toml`). This token will be used for all subsequent requests to the Pipecat Cloud API.
 
@@ -53,14 +46,12 @@ Authenticates with a [Personal Access Token](/pipecat-cloud/guides/personal-acce
 **Usage:**
 
 ```shell
-pipecat cloud auth use-pat <token>
+pipecat cloud auth use-pat
 ```
 
-**Arguments:**
-
-<ParamField path="token" type="string" required>
-  Personal Access Token (must start with `pcc_pat_`).
-</ParamField>
+The command prompts for the token without echoing it, so it takes no
+arguments and needs an interactive terminal. In CI, set `PIPECAT_TOKEN`
+instead.
 
 <Tip>
   You can also set the `PIPECAT_TOKEN` environment variable instead of storing

--- a/api-reference/cli/cloud/organizations.mdx
+++ b/api-reference/cli/cloud/organizations.mdx
@@ -79,20 +79,20 @@ pipecat cloud organizations keys create [OPTIONS]
   will be used.
 </ParamField>
 
-### keys delete
+### keys revoke
 
-Delete an API key from your organization. Command will prompt the user to select which key they wish to delete.
+Revoke an API key from your organization. Command will prompt the user to select which key they wish to revoke.
 
 **Usage:**
 
 ```shell
-pipecat cloud organizations keys delete [OPTIONS]
+pipecat cloud organizations keys revoke [OPTIONS]
 ```
 
 **Options:**
 
 <ParamField path="--organization / -o" type="string">
-  Organization ID to delete key for. If not provided, the default organization
+  Organization ID to revoke key for. If not provided, the default organization
   will be used.
 </ParamField>
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -24526,10 +24526,10 @@ pipecat cloud organizations select
 
 Switching organizations will target all CLI commands to the selected organization. For example, `pipecat cloud deploy` will issue the deployment request to your select organization.
 
-Alternatively, you issue commands with the optional `--org` flag, for example:
+Alternatively, you can target a single command with the `--organization` flag (`-o`), for example:
 
 ```bash
-pipecat cloud deploy my-agent image-name --org my-organization
+pipecat cloud deploy my-agent image-name --organization my-organization
 ```
 
 ## API keys
@@ -25141,10 +25141,10 @@ pipecat cloud agent start my-first-agent --api-key pk_...
 You can select and use a default API key for the agent start command:
 
 ```shell
-pipecat cloud organizations keys use my-default-key
+pipecat cloud organizations keys use
 ```
 
-See the [CLI reference](../cli-reference/agent#start) for more information.
+The command lists the organization's keys and prompts you to pick one, so it needs an interactive terminal. See the [CLI reference](/api-reference/cli/cloud/agent#start) for more information.
 
 ## Passing data
 
@@ -25158,7 +25158,7 @@ You pass a data blob through to the start request (please note that the data mus
 pipecat cloud agent start my-first-agent --data '{"room": "my-room"}'
 
 # or from a file
-pipecat cloud agent start my-first-agent --data-file data.json
+pipecat cloud agent start my-first-agent --data "$(cat data.json)"
 ```
 
 Data passed to your session can be accessed in your agent code via the `bot()` method, which receives session arguments:
@@ -25430,7 +25430,7 @@ Secrets can be managed via either the CLI or the [Dashboard <Icon icon="arrow-up
 ### Creating a secret set and adding secrets
 
 ```bash
-pipecat cloud secrets set my-secrets SECRET_NAME secret-value SECRET_NAME_2 secret-value-2
+pipecat cloud secrets set my-secrets SECRET_NAME=secret-value SECRET_NAME_2=secret-value-2
 ```
 
 This command will create or modify the secret set with the name `my-secrets`, and add or update the key-value pairs `SECRET_NAME` and `SECRET_NAME_2`.
@@ -25438,14 +25438,14 @@ This command will create or modify the secret set with the name `my-secrets`, an
 You can add additional secrets to the set by specifying more key-value pairs.
 
 ```bash
-pipecat cloud secrets set my-secrets SECRET_NAME_3 secret-value-3
+pipecat cloud secrets set my-secrets SECRET_NAME_3=secret-value-3
 ```
 
 <Info>
-  Whenever a secret is added or updated in an existing set, any deployments using
-  that set will need to be redeployed to access the new values. A plain
-  `pipecat cloud deploy` looks like no change here, so use
-  `pipecat cloud deploy --force`
+  Whenever a secret is added or updated in an existing set, any deployments
+  using that set will need to be redeployed to access the new values. A plain
+  `pipecat cloud deploy` looks like no change here, so use `pipecat cloud deploy
+  --force`
   ([why](/pipecat-cloud/fundamentals/deploy#when-a-deploy-does-not-replace-running-agents)).
 </Info>
 
@@ -25480,10 +25480,10 @@ when the agent starts.
 
 #### Regions
 
-Secret sets are created in a specific region. By default, secrets are created in `us-west` if no region is specified.
+Secret sets are created in a specific region. Without `--region`, a set is created in your organization's default region, which is `us-west` unless you've changed it with `pipecat cloud organizations default-region`.
 
 ```bash
-pipecat cloud secrets set my-secrets SECRET_NAME secret-value --region us-east
+pipecat cloud secrets set my-secrets SECRET_NAME=secret-value --region us-east
 ```
 
 <Warning>
@@ -25515,9 +25515,10 @@ There are several ways to specify key-value pairs:
 
    ```bash
    pipecat cloud secrets set my-secrets KEY1="value=with=equals"
-   # or
-   pipecat cloud secrets set my-secrets KEY1==value=with=equals
    ```
+
+   Only the first `=` separates the key from the value, so the rest of the
+   value is passed through untouched.
 
 4. **Values containing quotes**:
 
@@ -26367,8 +26368,10 @@ In CI/CD mode, the CLI will:
 - name: Deploy to Pipecat Cloud
   run: pipecat cloud deploy --yes
   env:
-    PIPECAT_CLOUD_API_KEY: ${{ secrets.PIPECAT_CLOUD_API_KEY }}
+    PIPECAT_TOKEN: ${{ secrets.PIPECAT_TOKEN }}
 ```
+
+The CLI reads settings from `PIPECAT_`-prefixed variables, so the token has to be `PIPECAT_TOKEN`. See [Personal access tokens](/pipecat-cloud/guides/personal-access-tokens) for minting one.
 
 <Note>
   For more comprehensive CI/CD setup including image tagging and monorepo
@@ -27036,7 +27039,7 @@ secret_set = "my-agent-secrets"
 image_credentials = "my-ecr-credentials"
 
 [scaling]
-    min_instances = 0
+    min_agents = 0
 ```
 
 ## Build and Push to ECR
@@ -27143,7 +27146,7 @@ secret_set = "my-agent-secrets"
 image_credentials = "my-gcp-credentials"
 
 [scaling]
-    min_instances = 0
+    min_agents = 0
 ```
 
 ## Build and Push to Artifact Registry
@@ -27428,8 +27431,10 @@ pipecat cloud agent list
 If you prefer not to set an environment variable each time, you can store a PAT in your local config file:
 
 ```shell
-pipecat cloud auth use-pat pcc_pat_...
+pipecat cloud auth use-pat
 ```
+
+The command prompts for the token rather than taking it as an argument, so it stays out of your shell history.
 
 This validates the token against the API and writes it to `~/.config/pipecatcloud/pipecatcloud.toml`. All subsequent commands will use it automatically, just like after `auth login`.
 
@@ -29991,7 +29996,7 @@ pipecat cloud secrets set my-agent-secrets \
   ANTHROPIC_API_KEY=sk_...
 
 # Reference in deployment
-pipecat cloud deploy my-agent my-image:latest --secret-set my-agent-secrets
+pipecat cloud deploy my-agent my-image:latest --secrets my-agent-secrets
 ```
 
 <Info>
@@ -91039,7 +91044,7 @@ Stop an active agent session and clean up its resources.
 **Usage:**
 
 ```shell
-pcc agent stop [ARGS] [OPTIONS]
+pipecat cloud agent stop [ARGS] [OPTIONS]
 ```
 
 **Arguments:**
@@ -91117,9 +91122,9 @@ pipecat cloud agent logs [ARGS] [OPTIONS]
 
 **Options:**
 
-<ParamField path="--level / -l" type="string" default="ALL">
-  Filter logs by severity: `ALL`, `DEBUG`, `INFO`, `WARNING`, `ERROR`,
-  `CRITICAL`.
+<ParamField path="--level / -l" type="string">
+  Filter logs by severity: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`.
+  Omit it to return every level.
 </ParamField>
 
 <ParamField path="--limit / -n" type="int" default="100">
@@ -91213,7 +91218,7 @@ pipecat cloud agent delete [ARGS] [OPTIONS]
 
 **Options:**
 
-<ParamField path="--force / -f" type="string">
+<ParamField path="--force / -f" type="boolean" default="false">
   Do not prompt for confirmation before deleting the agent.
 </ParamField>
 
@@ -91231,15 +91236,8 @@ Begins an authorization flow to authenticate with Pipecat Cloud.
 **Usage:**
 
 ```shell
-pipecat cloud auth login [OPTIONS]
+pipecat cloud auth login
 ```
-
-**Options:**
-
-<ParamField path="--headless / -h" type="boolean" default="false">
-  Skip opening a browser window for authentication and print the URL instead.
-  Useful for remote or containerized environments.
-</ParamField>
 
 This command initiates the authentication process by:
 
@@ -91248,7 +91246,7 @@ This command initiates the authentication process by:
 3. Waiting for you to complete the sign-in process in the browser
 4. Retrieving and storing your access token locally
 
-If the browser doesn't open automatically, or if you use the `--headless` option, you can copy and paste the displayed URL into your browser manually.
+If the browser doesn't open automatically, you can copy and paste the displayed URL into your browser manually.
 
 On successful login, the CLI will store the access token in the local configuration file (defaults to `~/.config/pipecatcloud/pipecatcloud.toml`). This token will be used for all subsequent requests to the Pipecat Cloud API.
 
@@ -91271,14 +91269,12 @@ Authenticates with a [Personal Access Token](/pipecat-cloud/guides/personal-acce
 **Usage:**
 
 ```shell
-pipecat cloud auth use-pat <token>
+pipecat cloud auth use-pat
 ```
 
-**Arguments:**
-
-<ParamField path="token" type="string" required>
-  Personal Access Token (must start with `pcc_pat_`).
-</ParamField>
+The command prompts for the token without echoing it, so it takes no
+arguments and needs an interactive terminal. In CI, set `PIPECAT_TOKEN`
+instead.
 
 <Tip>
   You can also set the `PIPECAT_TOKEN` environment variable instead of storing
@@ -92191,20 +92187,20 @@ pipecat cloud organizations keys create [OPTIONS]
   will be used.
 </ParamField>
 
-### keys delete
+### keys revoke
 
-Delete an API key from your organization. Command will prompt the user to select which key they wish to delete.
+Revoke an API key from your organization. Command will prompt the user to select which key they wish to revoke.
 
 **Usage:**
 
 ```shell
-pipecat cloud organizations keys delete [OPTIONS]
+pipecat cloud organizations keys revoke [OPTIONS]
 ```
 
 **Options:**
 
 <ParamField path="--organization / -o" type="string">
-  Organization ID to delete key for. If not provided, the default organization
+  Organization ID to revoke key for. If not provided, the default organization
   will be used.
 </ParamField>
 

--- a/pipecat-cloud/fundamentals/accounts-and-organizations.mdx
+++ b/pipecat-cloud/fundamentals/accounts-and-organizations.mdx
@@ -72,10 +72,10 @@ pipecat cloud organizations select
 
 Switching organizations will target all CLI commands to the selected organization. For example, `pipecat cloud deploy` will issue the deployment request to your select organization.
 
-Alternatively, you issue commands with the optional `--org` flag, for example:
+Alternatively, you can target a single command with the `--organization` flag (`-o`), for example:
 
 ```bash
-pipecat cloud deploy my-agent image-name --org my-organization
+pipecat cloud deploy my-agent image-name --organization my-organization
 ```
 
 ## API keys

--- a/pipecat-cloud/fundamentals/active-sessions.mdx
+++ b/pipecat-cloud/fundamentals/active-sessions.mdx
@@ -126,10 +126,10 @@ pipecat cloud agent start my-first-agent --api-key pk_...
 You can select and use a default API key for the agent start command:
 
 ```shell
-pipecat cloud organizations keys use my-default-key
+pipecat cloud organizations keys use
 ```
 
-See the [CLI reference](../cli-reference/agent#start) for more information.
+The command lists the organization's keys and prompts you to pick one, so it needs an interactive terminal. See the [CLI reference](/api-reference/cli/cloud/agent#start) for more information.
 
 ## Passing data
 
@@ -143,7 +143,7 @@ You pass a data blob through to the start request (please note that the data mus
 pipecat cloud agent start my-first-agent --data '{"room": "my-room"}'
 
 # or from a file
-pipecat cloud agent start my-first-agent --data-file data.json
+pipecat cloud agent start my-first-agent --data "$(cat data.json)"
 ```
 
 Data passed to your session can be accessed in your agent code via the `bot()` method, which receives session arguments:

--- a/pipecat-cloud/fundamentals/secrets.mdx
+++ b/pipecat-cloud/fundamentals/secrets.mdx
@@ -19,7 +19,7 @@ Secrets can be managed via either the CLI or the [Dashboard <Icon icon="arrow-up
 ### Creating a secret set and adding secrets
 
 ```bash
-pipecat cloud secrets set my-secrets SECRET_NAME secret-value SECRET_NAME_2 secret-value-2
+pipecat cloud secrets set my-secrets SECRET_NAME=secret-value SECRET_NAME_2=secret-value-2
 ```
 
 This command will create or modify the secret set with the name `my-secrets`, and add or update the key-value pairs `SECRET_NAME` and `SECRET_NAME_2`.
@@ -27,14 +27,14 @@ This command will create or modify the secret set with the name `my-secrets`, an
 You can add additional secrets to the set by specifying more key-value pairs.
 
 ```bash
-pipecat cloud secrets set my-secrets SECRET_NAME_3 secret-value-3
+pipecat cloud secrets set my-secrets SECRET_NAME_3=secret-value-3
 ```
 
 <Info>
-  Whenever a secret is added or updated in an existing set, any deployments using
-  that set will need to be redeployed to access the new values. A plain
-  `pipecat cloud deploy` looks like no change here, so use
-  `pipecat cloud deploy --force`
+  Whenever a secret is added or updated in an existing set, any deployments
+  using that set will need to be redeployed to access the new values. A plain
+  `pipecat cloud deploy` looks like no change here, so use `pipecat cloud deploy
+  --force`
   ([why](/pipecat-cloud/fundamentals/deploy#when-a-deploy-does-not-replace-running-agents)).
 </Info>
 
@@ -69,10 +69,10 @@ when the agent starts.
 
 #### Regions
 
-Secret sets are created in a specific region. By default, secrets are created in `us-west` if no region is specified.
+Secret sets are created in a specific region. Without `--region`, a set is created in your organization's default region, which is `us-west` unless you've changed it with `pipecat cloud organizations default-region`.
 
 ```bash
-pipecat cloud secrets set my-secrets SECRET_NAME secret-value --region us-east
+pipecat cloud secrets set my-secrets SECRET_NAME=secret-value --region us-east
 ```
 
 <Warning>
@@ -104,9 +104,10 @@ There are several ways to specify key-value pairs:
 
    ```bash
    pipecat cloud secrets set my-secrets KEY1="value=with=equals"
-   # or
-   pipecat cloud secrets set my-secrets KEY1==value=with=equals
    ```
+
+   Only the first `=` separates the key from the value, so the rest of the
+   value is passed through untouched.
 
 4. **Values containing quotes**:
 

--- a/pipecat-cloud/guides/cloud-builds.mdx
+++ b/pipecat-cloud/guides/cloud-builds.mdx
@@ -103,8 +103,10 @@ In CI/CD mode, the CLI will:
 - name: Deploy to Pipecat Cloud
   run: pipecat cloud deploy --yes
   env:
-    PIPECAT_CLOUD_API_KEY: ${{ secrets.PIPECAT_CLOUD_API_KEY }}
+    PIPECAT_TOKEN: ${{ secrets.PIPECAT_TOKEN }}
 ```
+
+The CLI reads settings from `PIPECAT_`-prefixed variables, so the token has to be `PIPECAT_TOKEN`. See [Personal access tokens](/pipecat-cloud/guides/personal-access-tokens) for minting one.
 
 <Note>
   For more comprehensive CI/CD setup including image tagging and monorepo

--- a/pipecat-cloud/guides/container-registries/aws-ecr.mdx
+++ b/pipecat-cloud/guides/container-registries/aws-ecr.mdx
@@ -51,7 +51,7 @@ secret_set = "my-agent-secrets"
 image_credentials = "my-ecr-credentials"
 
 [scaling]
-    min_instances = 0
+    min_agents = 0
 ```
 
 ## Build and Push to ECR

--- a/pipecat-cloud/guides/container-registries/gcp-artifact-registry.mdx
+++ b/pipecat-cloud/guides/container-registries/gcp-artifact-registry.mdx
@@ -39,7 +39,7 @@ secret_set = "my-agent-secrets"
 image_credentials = "my-gcp-credentials"
 
 [scaling]
-    min_instances = 0
+    min_agents = 0
 ```
 
 ## Build and Push to Artifact Registry

--- a/pipecat-cloud/guides/personal-access-tokens.mdx
+++ b/pipecat-cloud/guides/personal-access-tokens.mdx
@@ -73,8 +73,10 @@ pipecat cloud agent list
 If you prefer not to set an environment variable each time, you can store a PAT in your local config file:
 
 ```shell
-pipecat cloud auth use-pat pcc_pat_...
+pipecat cloud auth use-pat
 ```
+
+The command prompts for the token rather than taking it as an argument, so it stays out of your shell history.
 
 This validates the token against the API and writes it to `~/.config/pipecatcloud/pipecatcloud.toml`. All subsequent commands will use it automatically, just like after `auth login`.
 

--- a/pipecat-cloud/security/security-and-compliance.mdx
+++ b/pipecat-cloud/security/security-and-compliance.mdx
@@ -59,7 +59,7 @@ pipecat cloud secrets set my-agent-secrets \
   ANTHROPIC_API_KEY=sk_...
 
 # Reference in deployment
-pipecat cloud deploy my-agent my-image:latest --secret-set my-agent-secrets
+pipecat cloud deploy my-agent my-image:latest --secrets my-agent-secrets
 ```
 
 <Info>


### PR DESCRIPTION
Twelve invocations in the Pipecat Cloud docs name flags, arguments, or config keys that don't exist in `pipecatcloud`. Each was verified against `git show v1.2.0:<path>` in the pipecat-cloud repo — these are the commands a reader copies, and every one of them errors.

## The two that hurt most

**`min_instances` aborts the deploy.** The ECR and Artifact Registry guides both set it under `[scaling]`. The key was removed in 1.0.0; `ScalingParams` defines only `min_agents`/`max_agents` and is built with `ScalingParams(**scaling_data)`, so an unknown key raises `TypeError` and resurfaces as a `ConfigFileError`. The deploy stops before anything uploads.

**The CI example authenticates with a variable the CLI ignores.** `cloud-builds.mdx` set `PIPECAT_CLOUD_API_KEY`. Settings resolve as `"PIPECAT_" + key.upper()`, so that name maps to nothing — the job runs unauthenticated, hits `requires_login`, and since 1.1.0 exits 1. `personal-access-tokens.mdx` already used `PIPECAT_TOKEN`, so the two CI pages contradicted each other.

## The rest

| Written | Actual |
|---|---|
| `secrets set NAME value` (3 examples) | `NAME=value` — args without `=` exit 1 |
| `deploy --org` | `--organization` / `-o`; Click doesn't abbreviate |
| `deploy --secret-set` | `--secrets` / `-s` (that's the GitHub Action's input name) |
| `agent start --data-file` | `--data` / `-d`; read the file in the shell |
| `organizations keys use <name>` | no positional — it prompts |
| `organizations keys delete` | `keys revoke` (alias removed in 1.0.0) |
| `auth use-pat <token>` | no argument; reads via `getpass` |
| `auth login --headless` | removed with the OAuth2 PKCE rewrite |
| `agent logs --level ALL` | enum is DEBUG…CRITICAL; default is `None` |
| `pcc agent stop` | `pipecat cloud` (`pcc` removed in 1.0.0) |

## Also folded in

- `secrets.mdx` offered `KEY1==value=with=equals` as equivalent to the quoted form. The parser does `split("=", 1)`, so the value keeps a leading `=`.
- `secrets.mdx` claimed secret sets default to `us-west`. The API applies the organization's default region, which is `us-west` only until `organizations default-region` changes it — `fundamentals/deploy.mdx` already says it that way.
- `active-sessions.mdx` linked to `../cli-reference/agent#start`, a path that doesn't exist.
- `agent delete --force` was typed as a string; it's a boolean flag like every other `--force` on the page.

The region and separator fixes landed together because they're on the same page — splitting them across PRs would have meant a conflicting second touch.

## Verification

`mint broken-links --check-anchors --check-redirects` clean, `docs-meta-lint.mjs` 0 errors, `llms-full.txt` regenerated.

This is the first of five PRs from a sweep of the Pipecat Cloud docs against v1.2.0. Still to come: false statements (exceptions.mdx, pre-1.1.0 CLI output in four telephony pages), the `--output`/exit-code contract, the GitHub integration, and remaining reference gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)