### PR TITLE
docs: correct false statements in the Pipecat Cloud docs

### DIFF
--- a/api-reference/pipecat-cloud/sdk-reference/examples.mdx
+++ b/api-reference/pipecat-cloud/sdk-reference/examples.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Examples"
 "og:title": "Examples - Pipecat Cloud SDK"
-description: "Common Pipecat Cloud Python SDK patterns: starting agent sessions, handling session arguments, and managing deployments."
+description: "Common Pipecat Cloud Python SDK patterns: starting an agent session, and writing bot() entry points for Daily and WebSocket."
 ---
 
 This page provides examples of common tasks with the Pipecat Cloud Python SDK.

--- a/api-reference/pipecat-cloud/sdk-reference/exceptions.mdx
+++ b/api-reference/pipecat-cloud/sdk-reference/exceptions.mdx
@@ -10,7 +10,9 @@ The Pipecat Cloud SDK defines several exception classes to help you handle diffe
 
 ### Error
 
-Base class for all Pipecat Cloud exceptions.
+Base class for the SDK's exceptions, with one exception of its own:
+[`ConfigFileError`](#configfileerror) subclasses `Exception` directly, so
+catching `Error` will not catch it.
 
 ```python
 from pipecatcloud.exception import Error
@@ -34,45 +36,46 @@ try:
     response = await session.start()
 except AgentStartError as e:
     print(f"Failed to start agent: {e}")
-    if e.error_code == "429":
+    if e.error_code == "PCC-AGENT-AT-CAPACITY":
         print("Agent pool at capacity. Try again later.")
-    elif e.error_code == "404":
-        print("Agent not found.")
+    elif e.error_code == "PCC-1002":
+        print("No API key provided.")
 ```
+
+`Session.start()` raises this for every failure it can report — a missing
+API key, an agent that doesn't exist, an agent that isn't ready, and
+capacity limits — so `error_code` is how you tell them apart.
 
 #### Properties
 
 <ParamField path="message" type="string">
-  Error message with details about the failure.
+  Error message with details about the failure, prefixed with the error code.
 </ParamField>
 
-<ParamField path="error_code" type="string">
-  Error code that can be used for conditional handling of different error types.
+<ParamField path="error_code" type="string | None">
+  The API's error code, such as `PCC-1002` or `PCC-AGENT-AT-CAPACITY`. See
+  [Troubleshooting](/pipecat-cloud/fundamentals/error-codes) for what each one
+  means. `None` when the failure carried no structured error body.
 </ParamField>
 
 ### AgentNotHealthyError
 
-Raised when attempting to interact with an agent that is not in a ready state.
+Defined and exported by the package, but nothing in the SDK raises it. An
+agent that isn't in a ready state surfaces as an
+[`AgentStartError`](#agentstarterror) instead, so catch that:
 
 ```python
-from pipecatcloud.exception import AgentNotHealthyError
-
 try:
     response = await session.start()
-except AgentNotHealthyError as e:
-    print(f"Agent is not ready: {e}")
+except AgentStartError as e:
+    print(f"Failed to start agent: {e}")
     print("Check agent status with: pipecat cloud agent status my-agent")
 ```
 
-#### Properties
-
-<ParamField path="message" type="string">
-  Error message with details about the agent's status.
-</ParamField>
-
-<ParamField path="error_code" type="string">
-  Error code identifying the specific issue with the agent.
-</ParamField>
+<Note>
+  It appears in `pipecatcloud.__all__`, so it is importable and safe to
+  reference in an `except` clause — it just won't ever match.
+</Note>
 
 ## Authentication Errors
 
@@ -128,7 +131,9 @@ except ConfigError as e:
 
 ### ConfigFileError
 
-Raised when the configuration file is malformed.
+Raised when the configuration file is malformed. Unlike every other
+exception here it subclasses `Exception` rather than
+[`Error`](#error), so a broad `except Error` won't catch it.
 
 ```python
 from pipecatcloud.exception import ConfigFileError

--- a/api-reference/pipecat-cloud/sdk-reference/overview.mdx
+++ b/api-reference/pipecat-cloud/sdk-reference/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Pipecat Cloud SDK Overview"
 sidebarTitle: "Python SDK Overview"
-description: "The Pipecat Cloud Python SDK (pipecatcloud): programmatic agent deployment and session management from Python."
+description: "The Pipecat Cloud Python SDK (pipecatcloud): start and manage agent sessions, type bot() entry points, and handle SDK errors."
 ---
 
 The Pipecat Cloud Python SDK provides a programmatic interface for managing and interacting with your agents. It allows you to start and manage agent sessions, handle different session types, and respond to various error conditions.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -29210,10 +29210,13 @@ $ pipecat cloud organizations list
 This command will output a list of organizations associated with your account. For example:
 
 ```bash
-Organization        Name
-──────────────────────────────────────
-Default Workspace   three-random-words-randomnumber (active)
+Organization Name   Organization ID                  Active
+───────────────────────────────────────────────────────────
+Default Workspace   three-random-words-randomnumber  active
 ```
+
+The value you need is in the **Organization ID** column — that's the slug the
+rest of this guide calls your organization name.
 
 ### 2. Create a TwiML Bin
 
@@ -29314,10 +29317,13 @@ $ pipecat cloud organizations list
 This command will output a list of organizations associated with your account. For example:
 
 ```bash
-Organization        Name
-──────────────────────────────────────
-Default Workspace   three-random-words-randomnumber (active)
+Organization Name   Organization ID                  Active
+───────────────────────────────────────────────────────────
+Default Workspace   three-random-words-randomnumber  active
 ```
+
+The value you need is in the **Organization ID** column — that's the slug the
+rest of this guide calls your organization name.
 
 ### 2. Create a TeXML Application
 
@@ -29411,10 +29417,13 @@ $ pipecat cloud organizations list
 This command will output a list of organizations associated with your account. For example:
 
 ```bash
-Organization        Name
-──────────────────────────────────────
-Default Workspace   three-random-words-randomnumber (active)
+Organization Name   Organization ID                  Active
+───────────────────────────────────────────────────────────
+Default Workspace   three-random-words-randomnumber  active
 ```
+
+The value you need is in the **Organization ID** column — that's the slug the
+rest of this guide calls your organization name.
 
 ### 2. Set Up an XML Server
 
@@ -29580,10 +29589,13 @@ $ pipecat cloud organizations list
 This command will output a list of organizations associated with your account. For example:
 
 ```bash
-Organization        Name
-──────────────────────────────────────
-Default Workspace   three-random-words-randomnumber (active)
+Organization Name   Organization ID                  Active
+───────────────────────────────────────────────────────────
+Default Workspace   three-random-words-randomnumber  active
 ```
+
+The value you need is in the **Organization ID** column — that's the slug the
+rest of this guide calls your organization name.
 
 ### 4. Create App Bazaar Flow
 
@@ -89407,7 +89419,7 @@ OpenAPI operation: `PATCH /properties`
 # Pipecat Cloud SDK Overview
 Source: https://docs.pipecat.ai/api-reference/pipecat-cloud/sdk-reference/overview.md
 
-The Pipecat Cloud Python SDK (pipecatcloud): programmatic agent deployment and session management from Python.
+The Pipecat Cloud Python SDK (pipecatcloud): start and manage agent sessions, type bot() entry points, and handle SDK errors.
 
 The Pipecat Cloud Python SDK provides a programmatic interface for managing and interacting with your agents. It allows you to start and manage agent sessions, handle different session types, and respond to various error conditions.
 
@@ -89650,7 +89662,9 @@ The Pipecat Cloud SDK defines several exception classes to help you handle diffe
 
 ### Error
 
-Base class for all Pipecat Cloud exceptions.
+Base class for the SDK's exceptions, with one exception of its own:
+[`ConfigFileError`](#configfileerror) subclasses `Exception` directly, so
+catching `Error` will not catch it.
 
 ```python
 from pipecatcloud.exception import Error
@@ -89674,45 +89688,46 @@ try:
     response = await session.start()
 except AgentStartError as e:
     print(f"Failed to start agent: {e}")
-    if e.error_code == "429":
+    if e.error_code == "PCC-AGENT-AT-CAPACITY":
         print("Agent pool at capacity. Try again later.")
-    elif e.error_code == "404":
-        print("Agent not found.")
+    elif e.error_code == "PCC-1002":
+        print("No API key provided.")
 ```
+
+`Session.start()` raises this for every failure it can report — a missing
+API key, an agent that doesn't exist, an agent that isn't ready, and
+capacity limits — so `error_code` is how you tell them apart.
 
 #### Properties
 
 <ParamField path="message" type="string">
-  Error message with details about the failure.
+  Error message with details about the failure, prefixed with the error code.
 </ParamField>
 
-<ParamField path="error_code" type="string">
-  Error code that can be used for conditional handling of different error types.
+<ParamField path="error_code" type="string | None">
+  The API's error code, such as `PCC-1002` or `PCC-AGENT-AT-CAPACITY`. See
+  [Troubleshooting](/pipecat-cloud/fundamentals/error-codes) for what each one
+  means. `None` when the failure carried no structured error body.
 </ParamField>
 
 ### AgentNotHealthyError
 
-Raised when attempting to interact with an agent that is not in a ready state.
+Defined and exported by the package, but nothing in the SDK raises it. An
+agent that isn't in a ready state surfaces as an
+[`AgentStartError`](#agentstarterror) instead, so catch that:
 
 ```python
-from pipecatcloud.exception import AgentNotHealthyError
-
 try:
     response = await session.start()
-except AgentNotHealthyError as e:
-    print(f"Agent is not ready: {e}")
+except AgentStartError as e:
+    print(f"Failed to start agent: {e}")
     print("Check agent status with: pipecat cloud agent status my-agent")
 ```
 
-#### Properties
-
-<ParamField path="message" type="string">
-  Error message with details about the agent's status.
-</ParamField>
-
-<ParamField path="error_code" type="string">
-  Error code identifying the specific issue with the agent.
-</ParamField>
+<Note>
+  It appears in `pipecatcloud.__all__`, so it is importable and safe to
+  reference in an `except` clause — it just won't ever match.
+</Note>
 
 ## Authentication Errors
 
@@ -89768,7 +89783,9 @@ except ConfigError as e:
 
 ### ConfigFileError
 
-Raised when the configuration file is malformed.
+Raised when the configuration file is malformed. Unlike every other
+exception here it subclasses `Exception` rather than
+[`Error`](#error), so a broad `except Error` won't catch it.
 
 ```python
 from pipecatcloud.exception import ConfigFileError
@@ -89796,7 +89813,7 @@ except InvalidError as e:
 # Examples
 Source: https://docs.pipecat.ai/api-reference/pipecat-cloud/sdk-reference/examples.md
 
-Common Pipecat Cloud Python SDK patterns: starting agent sessions, handling session arguments, and managing deployments.
+Common Pipecat Cloud Python SDK patterns: starting an agent session, and writing bot() entry points for Daily and WebSocket.
 
 This page provides examples of common tasks with the Pipecat Cloud Python SDK.
 

--- a/llms.txt
+++ b/llms.txt
@@ -757,11 +757,11 @@ LLM, transports, serializers), pipelines, frames, workers, and utilities.
 
 #### SDK Reference
 
-- [Pipecat Cloud SDK Overview](https://docs.pipecat.ai/api-reference/pipecat-cloud/sdk-reference/overview.md): The Pipecat Cloud Python SDK (pipecatcloud): programmatic agent deployment and session management from Python.
+- [Pipecat Cloud SDK Overview](https://docs.pipecat.ai/api-reference/pipecat-cloud/sdk-reference/overview.md): The Pipecat Cloud Python SDK (pipecatcloud): start and manage agent sessions, type bot() entry points, and handle SDK errors.
 - [Session Management](https://docs.pipecat.ai/api-reference/pipecat-cloud/sdk-reference/sessions.md): Start and manage Pipecat Cloud agent sessions programmatically with the pipecatcloud Python SDK's session APIs.
 - [Session Arguments](https://docs.pipecat.ai/api-reference/pipecat-cloud/sdk-reference/session-arguments.md): Understand the session arguments Pipecat Cloud passes to your bot entry point at session start, from the Python SDK.
 - [Error Handling](https://docs.pipecat.ai/api-reference/pipecat-cloud/sdk-reference/exceptions.md): Handle errors from the Pipecat Cloud Python SDK: exception types raised by deployment and session operations, and how to catch them.
-- [Examples](https://docs.pipecat.ai/api-reference/pipecat-cloud/sdk-reference/examples.md): Common Pipecat Cloud Python SDK patterns: starting agent sessions, handling session arguments, and managing deployments.
+- [Examples](https://docs.pipecat.ai/api-reference/pipecat-cloud/sdk-reference/examples.md): Common Pipecat Cloud Python SDK patterns: starting an agent session, and writing bot() entry points for Daily and WebSocket.
 
 ### CLI
 

--- a/pipecat-cloud/guides/telephony/exotel-websocket.mdx
+++ b/pipecat-cloud/guides/telephony/exotel-websocket.mdx
@@ -56,10 +56,13 @@ $ pipecat cloud organizations list
 This command will output a list of organizations associated with your account. For example:
 
 ```bash
-Organization        Name
-──────────────────────────────────────
-Default Workspace   three-random-words-randomnumber (active)
+Organization Name   Organization ID                  Active
+───────────────────────────────────────────────────────────
+Default Workspace   three-random-words-randomnumber  active
 ```
+
+The value you need is in the **Organization ID** column — that's the slug the
+rest of this guide calls your organization name.
 
 ### 4. Create App Bazaar Flow
 

--- a/pipecat-cloud/guides/telephony/plivo-websocket.mdx
+++ b/pipecat-cloud/guides/telephony/plivo-websocket.mdx
@@ -42,10 +42,13 @@ $ pipecat cloud organizations list
 This command will output a list of organizations associated with your account. For example:
 
 ```bash
-Organization        Name
-──────────────────────────────────────
-Default Workspace   three-random-words-randomnumber (active)
+Organization Name   Organization ID                  Active
+───────────────────────────────────────────────────────────
+Default Workspace   three-random-words-randomnumber  active
 ```
+
+The value you need is in the **Organization ID** column — that's the slug the
+rest of this guide calls your organization name.
 
 ### 2. Set Up an XML Server
 

--- a/pipecat-cloud/guides/telephony/telnyx-websocket.mdx
+++ b/pipecat-cloud/guides/telephony/telnyx-websocket.mdx
@@ -45,10 +45,13 @@ $ pipecat cloud organizations list
 This command will output a list of organizations associated with your account. For example:
 
 ```bash
-Organization        Name
-──────────────────────────────────────
-Default Workspace   three-random-words-randomnumber (active)
+Organization Name   Organization ID                  Active
+───────────────────────────────────────────────────────────
+Default Workspace   three-random-words-randomnumber  active
 ```
+
+The value you need is in the **Organization ID** column — that's the slug the
+rest of this guide calls your organization name.
 
 ### 2. Create a TeXML Application
 

--- a/pipecat-cloud/guides/telephony/twilio-websocket.mdx
+++ b/pipecat-cloud/guides/telephony/twilio-websocket.mdx
@@ -45,10 +45,13 @@ $ pipecat cloud organizations list
 This command will output a list of organizations associated with your account. For example:
 
 ```bash
-Organization        Name
-──────────────────────────────────────
-Default Workspace   three-random-words-randomnumber (active)
+Organization Name   Organization ID                  Active
+───────────────────────────────────────────────────────────
+Default Workspace   three-random-words-randomnumber  active
 ```
+
+The value you need is in the **Organization ID** column — that's the slug the
+rest of this guide calls your organization name.
 
 ### 2. Create a TwiML Bin
 


### PR DESCRIPTION
Six statements in the Pipecat Cloud docs contradict the package. Unlike [#1175](https://github.com/pipecat-ai/docs/pull/1175), these don't fail loudly — they mislead a reader who follows them. Verified against `v1.2.0`.

## `exceptions.mdx` — three

**`Error` is not the base of everything.** The page opens by calling it "base class for all Pipecat Cloud exceptions" and demonstrates `except Error as e:`. But `ConfigFileError(Exception)` doesn't subclass it, so that pattern silently misses a malformed config file. Noted on both entries.

**The `error_code` example branches on HTTP statuses.** It compares to `"429"` and `"404"`. `error_code` is the `code` field of the API's error body — a PCC code like `PCC-1002` or `PCC-AGENT-AT-CAPACITY`, which this site already documents under Troubleshooting and which the CLI itself uses to build docs deep-links. HTTP statuses only ever reach `error_code` through the non-JSON fallback path. Now uses real codes and links to the reference. Also typed `string | None` — it's `None` when the failure carried no structured body.

**`AgentNotHealthyError` is never raised.** It was documented as raised around `session.start()`, with an example catching it. `git grep` finds three occurrences in the whole package: the class definition and two re-export lines. There is no raise site. `Session.start()` reports a not-ready agent as `AgentStartError` — its own docstring lists "Agent not ready" among that exception's causes. The entry now says the class is exported but inert, and shows the exception you can actually catch.

The third one is the reason this PR exists: a reader hardening a start path against unhealthy agents would write an `except` clause that never fires.

## Telephony guides — four pages, one changed column

All four websocket guides (Twilio, Telnyx, Plivo, Exotel) show pre-1.1.0 `organizations list` output:

```
Organization        Name
Default Workspace   three-random-words-randomnumber (active)
```

1.1.0 relabelled the columns and moved the active marker into its own:

```
Organization Name   Organization ID                  Active
Default Workspace   three-random-words-randomnumber  active
```

The slug each guide tells you to paste into `ORGANIZATION_NAME` moved from the column headed **Name** to the one headed **Organization ID**. A reader matching the old block against real output takes the display name and builds a `serviceHost` that doesn't resolve. Each page now names the column to read.

## SDK page descriptions — two

`overview.mdx` and `examples.mdx` both advertised "programmatic agent deployment". The SDK has no deployment surface: the HTTP client is `_API`, `config.py` exports only `_Setting`/`Config`/`config`, and `__all__` contains no deployment type. Both pages' own contents already reflected that — `overview.mdx`'s Key Components lists sessions, session arguments, and errors; `examples.mdx` has three sections, none about deployment. Only the descriptions oversold it, and those are what Kapa and the Context Hub cite. Both rewrites stay in the 110-140 char target.

## Verification

`mint broken-links --check-anchors --check-redirects` clean, `docs-meta-lint.mjs` 0 errors, `llms.txt` and `llms-full.txt` regenerated.

PR 2 of 5 from the v1.2.0 sweep. Next: the `--output`/exit-code contract, then the GitHub integration, then remaining reference gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)