### PR TITLE
docs: document pipecat cloud output modes and exit codes

### DIFF
--- a/api-reference/cli/cloud/output.mdx
+++ b/api-reference/cli/cloud/output.mdx
@@ -1,0 +1,119 @@
+---
+title: "Output Modes and Exit Codes"
+"og:title": "Output Modes and Exit Codes - Pipecat Cloud CLI"
+sidebarTitle: "Output & exit codes"
+description: "Render pipecat cloud output as rich, plain, or json, read its exit codes, and run it non-interactively in CI."
+---
+
+Every `pipecat cloud` command shares one output contract and one set of exit codes. Both matter most in CI, where there's no terminal to read and the exit status is the only signal your pipeline gets.
+
+## Output modes
+
+`--output` is a global option, so it goes before the subcommand:
+
+```bash
+pipecat cloud --output json agent list
+```
+
+| Mode    | What you get                                                                                                                                                                     |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rich`  | Panels, spinners, and tables. The default on a terminal.                                                                                                                         |
+| `plain` | Line-oriented: no boxes, no spinners, no truncation. The default when output is piped or redirected. Listings are tab-separated, and long values are never wrapped or shortened. |
+| `json`  | One machine-parseable JSON object on stdout.                                                                                                                                     |
+
+In `json` mode, stdout carries nothing but the JSON payload — every
+human-facing message, including errors and progress, moves to stderr. That
+means you can pipe stdout straight into a parser without filtering:
+
+```bash
+pipecat cloud --output json agent list | jq -r '.agents[].name'
+```
+
+<Tip>
+  Piping already gets you `plain`, so scripts that just need stable, untruncated
+  text don't have to pass anything. Reach for `json` when you want to read
+  specific fields.
+</Tip>
+
+### Setting it once
+
+The mode resolves in this order, first match winning:
+
+1. The `--output` flag
+2. The `PIPECAT_OUTPUT` environment variable, or the `output` key in your CLI config file
+3. Auto-detection: `rich` on a terminal, `plain` otherwise
+
+So a CI job can set it once for every step:
+
+```yaml
+env:
+  PIPECAT_OUTPUT: json
+```
+
+An unrecognized mode is a usage error — the CLI names the valid modes and exits 2.
+
+## Exit codes
+
+| Code | Meaning                                                                                                                                                                                                         |
+| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | The command completed.                                                                                                                                                                                          |
+| `1`  | The command ran and failed: an API error, a validation failure, a missing agent, or a confirmation you declined.                                                                                                |
+| `2`  | The command was called wrong, or it needed to prompt and couldn't. Unknown flags, invalid option values, and an unrecognized `--output` mode land here, as does any prompt reached without a terminal on stdin. |
+
+Declining a confirmation exits 1 rather than 0 — an aborted deploy is a failed
+step, not a successful no-op.
+
+## Running non-interactively
+
+Rather than let a prompt hang or misread a closed stdin, a command that would
+prompt checks for an interactive terminal first and exits 2 with the flag that
+skips the prompt:
+
+```
+Confirmation required but input is not a terminal.
+Pass --yes to run non-interactively.
+```
+
+This applies to every prompt, so the rule to script by is: if running a command
+by hand asks you a question, the CI version of that command needs the
+corresponding flag.
+
+| Command                            | Flag                               |
+| ---------------------------------- | ---------------------------------- |
+| `deploy`                           | `--yes` (or `--force`, implies it) |
+| `agent start` / `stop` / `delete`  | `--force`                          |
+| `secrets set` / `unset` / `delete` | `--skip`                           |
+| `secrets image-pull-secret`        | `--skip`                           |
+| `docker build-push`                | `--yes`                            |
+| `spend-limit set` / `clear`        | `--yes`                            |
+| `organizations keys create`        | `--name`                           |
+
+A few commands exist only to ask you something — `organizations select` and
+`organizations keys use` present a picker and have nothing to bypass. Use
+`--organization` on the individual command instead of selecting one first, and
+set `PIPECAT_TOKEN` rather than authenticating interactively.
+
+<Note>
+  These flags skip the *prompt*, not the *check*. `agent delete --force` still
+  refuses to delete an agent that doesn't exist, and `deploy --yes` still fails
+  on an invalid config.
+</Note>
+
+## More Information
+
+<CardGroup cols={2}>
+  <Card
+    title="Personal access tokens"
+    icon="key"
+    href="/pipecat-cloud/guides/personal-access-tokens"
+  >
+    Authenticate a CI job with PIPECAT_TOKEN
+  </Card>
+  <Card
+    title="CI with GitHub Actions"
+    icon="github"
+    href="/pipecat-cloud/guides/ci-with-github-actions"
+  >
+    A full deployment pipeline
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -942,6 +942,7 @@
                   {
                     "group": "cloud",
                     "pages": [
+                      "api-reference/cli/cloud/output",
                       "api-reference/cli/cloud/agent",
                       "api-reference/cli/cloud/auth",
                       "api-reference/cli/cloud/build",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -26362,6 +26362,11 @@ In CI/CD mode, the CLI will:
 - Automatically trigger a cloud build if no image is specified
 - Fail with an error if no Dockerfile is found in the build context
 
+Without `--yes`, the deploy prompts for confirmation, finds no terminal, and
+exits 2 before doing anything. See [Output modes and exit
+codes](/api-reference/cli/cloud/output) for the full contract, including how to
+get machine-readable output with `--output json`.
+
 ### GitHub Actions example
 
 ```yaml
@@ -26624,6 +26629,12 @@ This guide shows you how to automate Pipecat Cloud deployments from GitHub Actio
   workflow file and no API key to manage. Reach for a GitHub Actions workflow
   when a deploy has to run tests, wait on an approval, or do custom steps.
 </Note>
+
+<Tip>
+  Whether you use the action or call the CLI directly, [Output modes and exit
+  codes](/api-reference/cli/cloud/output) covers what each exit status means and
+  which flag each command needs to run without a terminal.
+</Tip>
 
 ## Prerequisites
 
@@ -27467,7 +27478,10 @@ jobs:
   For deployments specifically, the [Deploy to Pipecat Cloud GitHub
   Action](./ci-with-github-actions) uses an API key instead. PATs are useful
   when you need to run arbitrary CLI commands in CI (e.g. managing secrets,
-  listing agents, or scripting multi-step workflows).
+  listing agents, or scripting multi-step workflows). For scripting, see [Output
+  modes and exit codes](/api-reference/cli/cloud/output) — `--output json` gives
+  you parseable output on stdout, and each command has a flag that skips its
+  prompt.
 </Tip>
 
 ### GitLab CI
@@ -90985,6 +90999,124 @@ pipecat context-hub status
   What the hub indexes, the MCP tool list, custom sources, and setup without the
   Pipecat CLI
 </Card>
+
+# Output Modes and Exit Codes
+Source: https://docs.pipecat.ai/api-reference/cli/cloud/output.md
+
+Render pipecat cloud output as rich, plain, or json, read its exit codes, and run it non-interactively in CI.
+
+Every `pipecat cloud` command shares one output contract and one set of exit codes. Both matter most in CI, where there's no terminal to read and the exit status is the only signal your pipeline gets.
+
+## Output modes
+
+`--output` is a global option, so it goes before the subcommand:
+
+```bash
+pipecat cloud --output json agent list
+```
+
+| Mode    | What you get                                                                                                                                                                     |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rich`  | Panels, spinners, and tables. The default on a terminal.                                                                                                                         |
+| `plain` | Line-oriented: no boxes, no spinners, no truncation. The default when output is piped or redirected. Listings are tab-separated, and long values are never wrapped or shortened. |
+| `json`  | One machine-parseable JSON object on stdout.                                                                                                                                     |
+
+In `json` mode, stdout carries nothing but the JSON payload — every
+human-facing message, including errors and progress, moves to stderr. That
+means you can pipe stdout straight into a parser without filtering:
+
+```bash
+pipecat cloud --output json agent list | jq -r '.agents[].name'
+```
+
+<Tip>
+  Piping already gets you `plain`, so scripts that just need stable, untruncated
+  text don't have to pass anything. Reach for `json` when you want to read
+  specific fields.
+</Tip>
+
+### Setting it once
+
+The mode resolves in this order, first match winning:
+
+1. The `--output` flag
+2. The `PIPECAT_OUTPUT` environment variable, or the `output` key in your CLI config file
+3. Auto-detection: `rich` on a terminal, `plain` otherwise
+
+So a CI job can set it once for every step:
+
+```yaml
+env:
+  PIPECAT_OUTPUT: json
+```
+
+An unrecognized mode is a usage error — the CLI names the valid modes and exits 2.
+
+## Exit codes
+
+| Code | Meaning                                                                                                                                                                                                         |
+| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | The command completed.                                                                                                                                                                                          |
+| `1`  | The command ran and failed: an API error, a validation failure, a missing agent, or a confirmation you declined.                                                                                                |
+| `2`  | The command was called wrong, or it needed to prompt and couldn't. Unknown flags, invalid option values, and an unrecognized `--output` mode land here, as does any prompt reached without a terminal on stdin. |
+
+Declining a confirmation exits 1 rather than 0 — an aborted deploy is a failed
+step, not a successful no-op.
+
+## Running non-interactively
+
+Rather than let a prompt hang or misread a closed stdin, a command that would
+prompt checks for an interactive terminal first and exits 2 with the flag that
+skips the prompt:
+
+```
+Confirmation required but input is not a terminal.
+Pass --yes to run non-interactively.
+```
+
+This applies to every prompt, so the rule to script by is: if running a command
+by hand asks you a question, the CI version of that command needs the
+corresponding flag.
+
+| Command                            | Flag                               |
+| ---------------------------------- | ---------------------------------- |
+| `deploy`                           | `--yes` (or `--force`, implies it) |
+| `agent start` / `stop` / `delete`  | `--force`                          |
+| `secrets set` / `unset` / `delete` | `--skip`                           |
+| `secrets image-pull-secret`        | `--skip`                           |
+| `docker build-push`                | `--yes`                            |
+| `spend-limit set` / `clear`        | `--yes`                            |
+| `organizations keys create`        | `--name`                           |
+
+A few commands exist only to ask you something — `organizations select` and
+`organizations keys use` present a picker and have nothing to bypass. Use
+`--organization` on the individual command instead of selecting one first, and
+set `PIPECAT_TOKEN` rather than authenticating interactively.
+
+<Note>
+  These flags skip the *prompt*, not the *check*. `agent delete --force` still
+  refuses to delete an agent that doesn't exist, and `deploy --yes` still fails
+  on an invalid config.
+</Note>
+
+## More Information
+
+<CardGroup cols={2}>
+  <Card
+    title="Personal access tokens"
+    icon="key"
+    href="/pipecat-cloud/guides/personal-access-tokens"
+  >
+    Authenticate a CI job with PIPECAT_TOKEN
+  </Card>
+  <Card
+    title="CI with GitHub Actions"
+    icon="github"
+    href="/pipecat-cloud/guides/ci-with-github-actions"
+  >
+    A full deployment pipeline
+  </Card>
+</CardGroup>
 
 # pipecat cloud agent
 Source: https://docs.pipecat.ai/api-reference/cli/cloud/agent.md

--- a/llms.txt
+++ b/llms.txt
@@ -775,6 +775,7 @@ LLM, transports, serializers), pipelines, frames, workers, and utilities.
 
 ##### cloud
 
+- [Output Modes and Exit Codes](https://docs.pipecat.ai/api-reference/cli/cloud/output.md): Render pipecat cloud output as rich, plain, or json, read its exit codes, and run it non-interactively in CI.
 - [pipecat cloud agent](https://docs.pipecat.ai/api-reference/cli/cloud/agent.md): pipecat cloud agent subcommands manage deployed Pipecat Cloud agents: view status and control agent lifecycle from the CLI.
 - [pipecat cloud auth](https://docs.pipecat.ai/api-reference/cli/cloud/auth.md): pipecat cloud auth manages authentication with Pipecat Cloud: login, logout, and checking your current credentials.
 - [pipecat cloud build](https://docs.pipecat.ai/api-reference/cli/cloud/build.md): pipecat cloud build manages Pipecat Cloud builds: view build logs, check build status, and inspect builds from the CLI.

--- a/pipecat-cloud/guides/ci-with-github-actions.mdx
+++ b/pipecat-cloud/guides/ci-with-github-actions.mdx
@@ -13,6 +13,12 @@ This guide shows you how to automate Pipecat Cloud deployments from GitHub Actio
   when a deploy has to run tests, wait on an approval, or do custom steps.
 </Note>
 
+<Tip>
+  Whether you use the action or call the CLI directly, [Output modes and exit
+  codes](/api-reference/cli/cloud/output) covers what each exit status means and
+  which flag each command needs to run without a terminal.
+</Tip>
+
 ## Prerequisites
 
 Before setting up your workflow, ensure you have:

--- a/pipecat-cloud/guides/cloud-builds.mdx
+++ b/pipecat-cloud/guides/cloud-builds.mdx
@@ -97,6 +97,11 @@ In CI/CD mode, the CLI will:
 - Automatically trigger a cloud build if no image is specified
 - Fail with an error if no Dockerfile is found in the build context
 
+Without `--yes`, the deploy prompts for confirmation, finds no terminal, and
+exits 2 before doing anything. See [Output modes and exit
+codes](/api-reference/cli/cloud/output) for the full contract, including how to
+get machine-readable output with `--output json`.
+
 ### GitHub Actions example
 
 ```yaml

--- a/pipecat-cloud/guides/personal-access-tokens.mdx
+++ b/pipecat-cloud/guides/personal-access-tokens.mdx
@@ -109,7 +109,10 @@ jobs:
   For deployments specifically, the [Deploy to Pipecat Cloud GitHub
   Action](./ci-with-github-actions) uses an API key instead. PATs are useful
   when you need to run arbitrary CLI commands in CI (e.g. managing secrets,
-  listing agents, or scripting multi-step workflows).
+  listing agents, or scripting multi-step workflows). For scripting, see [Output
+  modes and exit codes](/api-reference/cli/cloud/output) — `--output json` gives
+  you parseable output on stdout, and each command has a flag that skips its
+  prompt.
 </Tip>
 
 ### GitLab CI


### PR DESCRIPTION
Two things shipped in `pipecatcloud` 1.1.0 that the docs never mentioned: the global `--output {rich,plain,json}` option, and a real exit-code contract. `grep` for `--output` or `PIPECAT_OUTPUT` across the whole site returned nothing, and the only exit-status guidance anywhere was `deploy.mdx` saying a failure "will exit with an error".

Both matter most in CI, where there's no terminal to read and the exit status is the only signal the pipeline gets. The exit-code change in particular is breaking for existing pipelines — errors and refused prompts now exit non-zero where they used to exit 0.

## New page

`api-reference/cli/cloud/output` covers:

- **The three modes** and how they resolve — flag, then `PIPECAT_OUTPUT` / the `output` config key, then auto-detection (`rich` on a terminal, `plain` when piped). `--output` is global, so it goes *before* the subcommand.
- **What `json` mode guarantees**: stdout carries nothing but the payload; every human-facing message, errors and progress included, moves to stderr. That's the part that makes `| jq` safe, and it isn't guessable.
- **The three exit codes** — 0, 1 for a command that ran and failed, 2 for a usage error or a prompt reached without a TTY. Including that declining a confirmation exits 1, not 0.
- **Prompt bypasses per command.** Rather than hang, a command that would prompt checks for a terminal and exits 2 naming the flag that skips it. The table lists which flag each command takes, with the general rule stated first: if running a command by hand asks you a question, the CI version needs a flag.

Verified against `v1.2.0` — the mode enum and resolution order from the entry point, `require_interactive`'s exit-2 behavior and its per-call-site flag hints, and the decline-exits-1 path.

## Placement

I'd planned to put this on `api-reference/cli/overview.mdx`, and changed my mind after reading it: that page covers the whole `pipecat` CLI, and `init`, `eval`, and `context-hub` have no `--output` — I confirmed neither name appears in the framework CLI source. The flag comes from `pipecatcloud`'s entry point and is cloud-only, so scoping it to the shared overview would have overclaimed.

Linked from the three pages a CI author actually reads: `cloud-builds`, `ci-with-github-actions`, and `personal-access-tokens`.

## Note

The `spend-limit` row in the bypass table names a command that has no page yet — it's added in the next PR. The row is accurate and a CI author needs it; omitting real commands because their reference page doesn't exist yet would make the table wrong by omission.

## Verification

`mint broken-links --check-anchors --check-redirects` clean, `docs-meta-lint.mjs` 0 errors, `llms.txt` and `llms-full.txt` regenerated, `docs.json` nav updated and valid.

PR 3 of 5 from the v1.2.0 sweep. Next: the GitHub integration, then remaining reference gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)