### PR TITLE
docs: document the Pipecat Cloud GitHub integration

### DIFF
--- a/api-reference/cli/cloud/agent.mdx
+++ b/api-reference/cli/cloud/agent.mdx
@@ -118,6 +118,23 @@ pipecat cloud agent status [ARGS]
   Unique string identifier for the agent deployment. Must not contain spaces.
 </ParamField>
 
+For a [GitHub-linked agent](#link), the output also carries the linked
+repository and branch, the Dockerfile path and build subdirectory, whether
+pushes auto-deploy, the commit actually running, and the latest deploy attempt
+with its failure reason if it has one.
+
+The running commit and the linked branch can legitimately differ — right after
+you link a repository, after you re-point an agent, or when auto-deploy is off
+and there are unshipped commits. When the running commit didn't come from the
+current link, `status` says so and names the repository and branch it did come
+from.
+
+<Tip>
+  Nothing live from the current link shows as `— (nothing from this link is live
+  yet)`, which is what you'll see between `agent link` and the first [`agent
+  deploy --github`](#deploy).
+</Tip>
+
 ## deployments
 
 Lists deployment history for an agent, including image versions and timestamps.
@@ -171,9 +188,166 @@ pipecat cloud agent logs [ARGS] [OPTIONS]
   sessions [agent-name]`).
 </ParamField>
 
+## link
+
+Link an agent to a GitHub repository and branch, or re-point an existing link. Requires the organization to be [connected to GitHub](/api-reference/cli/cloud/github#connect).
+
+**Usage:**
+
+```shell
+pipecat cloud agent link [ARGS] [OPTIONS]
+```
+
+**Arguments:**
+
+<ParamField path="agent-name" type="string" required>
+  Name of the agent to link.
+</ParamField>
+
+**Options:**
+
+<ParamField path="--repo" type="string" required>
+  Repository as `owner/repo`.
+</ParamField>
+
+<ParamField path="--branch" type="string" required>
+  Branch to build and deploy from.
+</ParamField>
+
+<ParamField path="--dockerfile-path" type="string" default="Dockerfile">
+  Path to the Dockerfile within the repository.
+</ParamField>
+
+<ParamField path="--subdirectory" type="string">
+  Build context subdirectory within the repository.
+</ParamField>
+
+<ParamField
+  path="--auto-deploy / --no-auto-deploy"
+  type="boolean"
+  default="--auto-deploy"
+>
+  Whether a push to the branch deploys the agent.
+</ParamField>
+
+<ParamField path="--organization / -o" type="string">
+  Organization the agent belongs to. If not provided, uses the current
+  organization from your configuration.
+</ParamField>
+
+```shell
+pipecat cloud agent link my-agent --repo my-org/my-bot --branch main
+```
+
+<Note>
+  Linking never changes what is running. It sets where the *next* deploy comes
+  from — use [`agent deploy --github`](#deploy) to ship the branch now.
+</Note>
+
+Re-running `link` on an already-linked agent re-points it. Options you leave out keep their stored values, so changing only the branch won't reset a Dockerfile path you set earlier.
+
+The repository and branch are validated locally against the same rules the API applies, so a typo fails immediately rather than after a round trip.
+
+## unlink
+
+Remove an agent's GitHub repository link.
+
+**Usage:**
+
+```shell
+pipecat cloud agent unlink [ARGS] [OPTIONS]
+```
+
+**Arguments:**
+
+<ParamField path="agent-name" type="string" required>
+  Name of the agent to unlink.
+</ParamField>
+
+**Options:**
+
+<ParamField path="--organization / -o" type="string">
+  Organization the agent belongs to. If not provided, uses the current
+  organization from your configuration.
+</ParamField>
+
+<ParamField path="--force / -f" type="boolean" default="false">
+  Skip the confirmation prompt.
+</ParamField>
+
+Pushes stop deploying the agent. The running agent is not touched and its current deployment stays live.
+
+## deploy
+
+Build and deploy a GitHub-linked agent from its branch's current HEAD, without waiting for a push.
+
+**Usage:**
+
+```shell
+pipecat cloud agent deploy [ARGS] [OPTIONS]
+```
+
+**Arguments:**
+
+<ParamField path="agent-name" type="string" required>
+  Name of the agent to deploy.
+</ParamField>
+
+**Options:**
+
+<ParamField path="--github" type="boolean" default="false">
+  Deploy the agent's linked GitHub branch. Currently the only mode this command
+  supports, so it has to be passed — without it the command exits 1 and points
+  you at `pipecat cloud deploy`.
+</ParamField>
+
+<ParamField path="--wait" type="boolean" default="false">
+  Follow the deploy rather than returning as soon as it is queued.
+</ParamField>
+
+<ParamField path="--organization / -o" type="string">
+  Organization the agent belongs to. If not provided, uses the current
+  organization from your configuration.
+</ParamField>
+
+```shell
+pipecat cloud agent deploy my-agent --github --wait
+```
+
+<Note>
+  `--github` is explicit rather than implied so that adding image-based deploys
+  to this command later can't change what an existing script does. To deploy an
+  image or a cloud build, use [`pipecat cloud
+  deploy`](/api-reference/cli/cloud/deploy).
+</Note>
+
+### What `--wait` reports
+
+Without `--wait`, the command returns once the deploy is queued, printing the branch and commit it will build.
+
+With `--wait`, it follows the deploy and reports one of these:
+
+| Outcome        | Meaning                                                                          | Exit |
+| -------------- | -------------------------------------------------------------------------------- | ---- |
+| Succeeded      | The deploy reached a terminal state and succeeded.                               | 0    |
+| Failed         | The deploy reached a terminal state and failed. The reason is printed.           | 1    |
+| Superseded     | A newer push took over as the latest attempt, so this one is no longer reported. | 0    |
+| Still building | Observed and still moving when the wait ran out. It continues server-side.       | 0    |
+| Never observed | The wait never saw the attempt at all.                                           | 1    |
+
+<Warning>
+  A zero exit from `--wait` means the deploy was observed and did not fail — not
+  that it finished. A deploy still building, or superseded by a newer push, also
+  exits 0. Check the outcome itself if you need to gate on completion; in
+  `--output json` it is reported as `waitOutcome`.
+</Warning>
+
+"Never observed" exits non-zero on purpose: a wait that saw nothing can't tell a healthy build from an API that was down the whole time, and calling that success is what would make `--wait` unsafe as a deploy gate.
+
 ## list
 
-Lists all agents in an organization with their details.
+Lists all agents in an organization with their details, including a GitHub
+column for agents built from a repository.
 
 **Usage:**
 

--- a/api-reference/cli/cloud/build.mdx
+++ b/api-reference/cli/cloud/build.mdx
@@ -67,6 +67,9 @@ The status command displays detailed build information including:
 - Build duration and context/image sizes
 - Error messages (if the build failed)
 
+For a build triggered from a [GitHub-linked agent](/api-reference/cli/cloud/agent#link),
+it also reports the repository, the ref, and the commit the build came from.
+
 ## list
 
 List recent cloud builds.
@@ -96,6 +99,10 @@ pipecat cloud build list [OPTIONS]
   Organization to use. If not provided, uses the current organization from your
   configuration.
 </ParamField>
+
+The listing carries a **Source** column. GitHub-triggered builds show
+`owner/repo@commit`; a build from a local context has no commit provenance and
+shows nothing there.
 
 ## Examples
 

--- a/api-reference/cli/cloud/deploy.mdx
+++ b/api-reference/cli/cloud/deploy.mdx
@@ -131,6 +131,41 @@ See [Agent Profiles](/pipecat-cloud/fundamentals/deploy#agent-profiles) for more
   context directory.
 </ParamField>
 
+### GitHub source
+
+Create an agent that builds from a GitHub repository instead of an image. The
+organization must be [connected to GitHub](/api-reference/cli/cloud/github#connect)
+first.
+
+<ParamField path="--repo" type="string">
+  Repository as `owner/repo`. Skips the image build and push entirely — Pipecat
+  Cloud builds from the repository.
+</ParamField>
+
+<ParamField path="--branch" type="string">
+  Branch to build and deploy from.
+</ParamField>
+
+<ParamField path="--dockerfile-path" type="string" default="Dockerfile">
+  Path to the Dockerfile within the repository. Distinct from `--dockerfile`,
+  which applies to cloud builds from a local context.
+</ParamField>
+
+<ParamField path="--subdirectory" type="string">
+  Build context subdirectory within the repository.
+</ParamField>
+
+<Warning>
+  `--repo` only applies when **creating** an agent. The API accepts a GitHub
+  source on create and ignores it on update, so re-pointing an existing agent
+  goes through [`agent link`](/api-reference/cli/cloud/agent#link) instead.
+</Warning>
+
+A GitHub source can't be combined with `--image` or `--build-id` — a deploy is
+built from a repository or from an image, not both. The first deploy is followed
+through its build, so the command reports whether it succeeded rather than
+returning as soon as it's queued.
+
 ## Examples
 
 **Deploy a new agent:**
@@ -203,6 +238,12 @@ pipecat cloud deploy --yes
 
 ```shell
 pipecat cloud deploy --build-id abc12345-6789-0abc-def0-123456789abc
+```
+
+**Create an agent that builds from a GitHub repository:**
+
+```shell
+pipecat cloud deploy my-agent --repo my-org/my-bot --branch main
 ```
 
 **Deploy using an alternate config file:**
@@ -400,6 +441,56 @@ patterns = ["*.md", "tests/", "docs/"]
 ```
 
 </ParamField>
+
+#### GitHub Source Configuration
+
+Build from a repository instead of an image, in a `[git]` section. Command-line
+flags take precedence over these values.
+
+<ParamField path="git.repo" type="string">
+Repository as `owner/repo`.
+
+```toml
+[git]
+repo = "my-org/my-bot"
+```
+
+</ParamField>
+
+<ParamField path="git.branch" type="string">
+Branch to build and deploy from.
+
+```toml
+[git]
+branch = "main"
+```
+
+</ParamField>
+
+<ParamField path="git.dockerfile_path" type="string" default="Dockerfile">
+Path to the Dockerfile within the repository.
+
+```toml
+[git]
+dockerfile_path = "docker/Dockerfile"
+```
+
+</ParamField>
+
+<ParamField path="git.subdirectory" type="string">
+Build context subdirectory within the repository.
+
+```toml
+[git]
+subdirectory = "bot"
+```
+
+</ParamField>
+
+<Note>
+  Like `--repo`, a `[git]` section only takes effect when the agent is created.
+  It is ignored on an update.
+</Note>
 
 ### Complete Example
 

--- a/api-reference/cli/cloud/github.mdx
+++ b/api-reference/cli/cloud/github.mdx
@@ -1,0 +1,160 @@
+---
+title: "pipecat cloud github"
+sidebarTitle: "github"
+description: "pipecat cloud github connects an organization to GitHub, inspects the App installation, and lists visible repositories and branches."
+---
+
+The `github` command group connects a Pipecat Cloud organization to GitHub by installing the Pipecat Cloud GitHub App. Once connected, agents can be built from a repository instead of an image — see [`agent link`](/api-reference/cli/cloud/agent#link) and [`deploy --repo`](/api-reference/cli/cloud/deploy).
+
+The connection is per organization, not per agent. One installation covers every agent in the organization.
+
+<Card
+  title="Deploy from GitHub"
+  icon="github"
+  href="/pipecat-cloud/guides/deploy-from-github"
+>
+  The full walkthrough, from connecting an account to deploying on push
+</Card>
+
+## connect
+
+Install the Pipecat Cloud GitHub App on a GitHub account and link it to your organization.
+
+**Usage:**
+
+```shell
+pipecat cloud github connect [OPTIONS]
+```
+
+**Options:**
+
+<ParamField path="--organization / -o" type="string">
+  Organization to connect. If not provided, uses the current organization from
+  your configuration.
+</ParamField>
+
+The command opens the GitHub App install page in your browser and then waits, polling until the installation lands — there is nothing to copy back into the terminal. GitHub redirects to the API's own setup callback, which completes the link server-side, so the flow works the same as the dashboard's.
+
+If the browser can't be opened, the URL is printed for you to open manually. The command gives up after 15 minutes; if you completed the install after that, `github status` will show it.
+
+Connecting an organization that's already connected is not an error — the command reports the existing installation and leaves it alone. To connect a different GitHub account, run [`github disconnect`](#disconnect) first.
+
+## status
+
+Show the organization's GitHub connection.
+
+**Usage:**
+
+```shell
+pipecat cloud github status [OPTIONS]
+```
+
+**Options:**
+
+<ParamField path="--organization / -o" type="string">
+  Organization to inspect. If not provided, uses the current organization from
+  your configuration.
+</ParamField>
+
+Reports the connected GitHub account and type, the installation ID, whether the App is active or suspended, and a link to manage it on GitHub. If the organization isn't connected, it says so and points at `github connect`.
+
+<Warning>
+  A suspended installation stops deploys. `status` flags it; reinstate the App
+  from GitHub to resume.
+</Warning>
+
+## disconnect
+
+Disconnect the organization from GitHub.
+
+**Usage:**
+
+```shell
+pipecat cloud github disconnect [OPTIONS]
+```
+
+**Options:**
+
+<ParamField path="--organization / -o" type="string">
+  Organization to disconnect. If not provided, uses the current organization
+  from your configuration.
+</ParamField>
+
+<ParamField path="--yes / -y" type="boolean" default="false">
+  Skip the confirmation prompt.
+</ParamField>
+
+This removes the installation and **every repository link in the organization**, so linked agents stop auto-deploying. What is already running is not touched.
+
+The App itself stays installed on GitHub. Uninstall it there to revoke access entirely.
+
+## repos
+
+List the repositories the GitHub App can access.
+
+**Usage:**
+
+```shell
+pipecat cloud github repos [OPTIONS]
+```
+
+**Options:**
+
+<ParamField path="--organization / -o" type="string">
+  Organization to list repositories for. If not provided, uses the current
+  organization from your configuration.
+</ParamField>
+
+Shows each repository's full name, default branch, and visibility. The list reflects what you granted the App on GitHub — if a repository is missing, widen the App's repository access from GitHub rather than from here.
+
+## branches
+
+List branches for a repository.
+
+**Usage:**
+
+```shell
+pipecat cloud github branches [ARGS] [OPTIONS]
+```
+
+**Arguments:**
+
+<ParamField path="repo" type="string" required>
+  Repository as `owner/repo`. Any other form is rejected before the request is
+  made.
+</ParamField>
+
+**Options:**
+
+<ParamField path="--query / -q" type="string">
+  Prefix to search for. Runs a server-side search, which reaches branches past
+  the plain list's cap — use it on repositories with many branches.
+</ParamField>
+
+<ParamField path="--organization / -o" type="string">
+  Organization to list branches for. If not provided, uses the current
+  organization from your configuration.
+</ParamField>
+
+```shell
+pipecat cloud github branches my-org/my-bot --query release/
+```
+
+## More Information
+
+<CardGroup cols={2}>
+  <Card
+    title="Link an agent"
+    icon="link"
+    href="/api-reference/cli/cloud/agent#link"
+  >
+    Point an existing agent at a repository and branch
+  </Card>
+  <Card
+    title="Create from a repository"
+    icon="rocket"
+    href="/api-reference/cli/cloud/deploy"
+  >
+    `deploy --repo` builds a new agent from GitHub
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -947,6 +947,7 @@
                       "api-reference/cli/cloud/auth",
                       "api-reference/cli/cloud/build",
                       "api-reference/cli/cloud/docker",
+                      "api-reference/cli/cloud/github",
                       "api-reference/cli/cloud/deploy",
                       "api-reference/cli/cloud/organizations",
                       "api-reference/cli/cloud/secrets",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -26474,7 +26474,7 @@ Connect a GitHub repository to an agent and Pipecat Cloud builds and deploys it 
 
 {/* prettier-ignore */}
 <Info>
-  This guide sets the integration up in the [Pipecat Cloud dashboard <Icon icon="arrow-up-right-from-square" iconType="solid" />](https://pipecat.daily.co). Deploys use [cloud builds](/pipecat-cloud/guides/cloud-builds) under the hood, so your project needs a `Dockerfile`.
+  Everything here works from the [Pipecat Cloud dashboard <Icon icon="arrow-up-right-from-square" iconType="solid" />](https://pipecat.daily.co) or the CLI — each section shows both. Deploys use [cloud builds](/pipecat-cloud/guides/cloud-builds) under the hood, so your project needs a `Dockerfile`.
 </Info>
 
 <Note>
@@ -26494,20 +26494,40 @@ Connect a GitHub repository to an agent and Pipecat Cloud builds and deploys it 
 
 The GitHub App is installed once per Pipecat Cloud organization, and every agent in that organization shares it.
 
-<Steps>
-  <Step title="Open GitHub settings">
-    In the dashboard, go to **Settings → GitHub**.
-  </Step>
-  <Step title="Install the app">
-    Click **Connect GitHub**. A new tab opens GitHub's installation screen,
-    where you choose the account or organization to install into and which
-    repositories to grant access to — all of them, or a hand-picked list.
-  </Step>
-  <Step title="Return to the dashboard">
-    Once you approve the install, the dashboard picks up the connection
-    automatically and shows the connected account.
-  </Step>
-</Steps>
+<Tabs>
+  <Tab title="Dashboard">
+    <Steps>
+      <Step title="Open GitHub settings">
+        Go to **Settings → GitHub**.
+      </Step>
+      <Step title="Install the app">
+        Click **Connect GitHub**. A new tab opens GitHub's installation screen,
+        where you choose the account or organization to install into and which
+        repositories to grant access to — all of them, or a hand-picked list.
+      </Step>
+      <Step title="Return to the dashboard">
+        Once you approve the install, the dashboard picks up the connection
+        automatically and shows the connected account.
+      </Step>
+    </Steps>
+  </Tab>
+  <Tab title="CLI">
+    ```shell
+    pipecat cloud github connect
+    ```
+
+    This opens the same GitHub installation screen and then waits, polling until
+    the install lands — there's nothing to paste back into the terminal. Approve
+    it in the browser and the command reports the connected account.
+
+    Check it any time:
+
+    ```shell
+    pipecat cloud github status
+    ```
+
+  </Tab>
+</Tabs>
 
 <Tip>
   Granting access to only the repositories you deploy from is the safer default.
@@ -26517,30 +26537,79 @@ The GitHub App is installed once per Pipecat Cloud organization, and every agent
 
 ## Deploy a new agent from a repository
 
-When you create an agent, choose **GitHub** as the source:
+<Tabs>
+  <Tab title="Dashboard">
+    When you create an agent, choose **GitHub** as the source:
 
-<Steps>
-  <Step title="Pick the repository">
-    Select any repository the installation can see. Private repositories are
-    supported.
-  </Step>
-  <Step title="Pick the branch">
-    The repository's default branch is preselected. Search to find any other
-    branch.
-  </Step>
-  <Step title="Set the Dockerfile path (optional)">
-    Defaults to `Dockerfile` at the repository root. Set a path such as
-    `docker/Dockerfile` if yours lives elsewhere.
-  </Step>
-</Steps>
+    <Steps>
+      <Step title="Pick the repository">
+        Select any repository the installation can see. Private repositories are
+        supported.
+      </Step>
+      <Step title="Pick the branch">
+        The repository's default branch is preselected. Search to find any other
+        branch.
+      </Step>
+      <Step title="Set the Dockerfile path (optional)">
+        Defaults to `Dockerfile` at the repository root. Set a path such as
+        `docker/Dockerfile` if yours lives elsewhere.
+      </Step>
+    </Steps>
 
-Creating the agent builds the branch's current commit and deploys it.
+  </Tab>
+  <Tab title="CLI">
+    ```shell
+    pipecat cloud deploy my-agent --repo my-org/my-bot --branch main
+    ```
+
+    No image argument: passing `--repo` skips the image build and push entirely.
+    Add `--dockerfile-path` if your `Dockerfile` isn't at the repository root, and
+    `--subdirectory` to build from a subdirectory.
+
+    The same thing in `pcc-deploy.toml`, where flags win over file values:
+
+    ```toml
+    agent_name = "my-agent"
+
+    [git]
+    repo = "my-org/my-bot"
+    branch = "main"
+    ```
+
+    Not sure what the App can see?
+
+    ```shell
+    pipecat cloud github repos
+    pipecat cloud github branches my-org/my-bot
+    ```
+
+  </Tab>
+</Tabs>
+
+Creating the agent builds the branch's current commit and deploys it. `--repo`
+applies only at creation — to re-point an agent that already exists, use
+`agent link` below.
 
 ## Connect an existing agent
 
 Agents that already run a Docker image can be moved onto GitHub deploys at any time.
 
-Go to your agent's **Settings → GitHub** tab and pick a repository, branch, and Dockerfile path.
+<Tabs>
+  <Tab title="Dashboard">
+    Go to your agent's **Settings → GitHub** tab and pick a repository, branch,
+    and Dockerfile path.
+  </Tab>
+  <Tab title="CLI">
+    ```shell
+    pipecat cloud agent link my-agent --repo my-org/my-bot --branch main
+    ```
+
+    Re-run it to re-point an agent at a different repository or branch. Options
+    you leave out keep their stored values, so changing the branch won't reset a
+    Dockerfile path you set earlier.
+
+  </Tab>
+</Tabs>
 
 <Note>
   Linking a repository does not deploy anything. The agent keeps serving its
@@ -26554,37 +26623,89 @@ Go to your agent's **Settings → GitHub** tab and pick a repository, branch, an
 
 Pushes to any other branch are ignored — only the branch you connected triggers a deploy.
 
-Turn it off from the agent's **Settings → GitHub** tab when you want to control the timing yourself, for example while you're stabilizing a branch.
+Turn it off when you want to control the timing yourself, for example while you're stabilizing a branch.
+
+<Tabs>
+  <Tab title="Dashboard">
+    Toggle it on the agent's **Settings → GitHub** tab.
+  </Tab>
+  <Tab title="CLI">
+    ```shell
+    pipecat cloud agent link my-agent --repo my-org/my-bot --branch main --no-auto-deploy
+    ```
+
+    Pass `--auto-deploy` to turn it back on.
+
+  </Tab>
+</Tabs>
 
 ## Deploy manually
 
-The **Deploy** button on the agent's GitHub settings builds and deploys the connected branch's current `HEAD`. It works whether or not deploy on push is enabled, and it's the way to ship a change when it's off.
+Deploying manually builds the connected branch's current `HEAD`. It works whether or not deploy on push is enabled, and it's the way to ship a change when it's off.
 
-Deploys are queued: the button returns as soon as the build is accepted, and progress shows up in the agent's deployment history and on the [Builds](/pipecat-cloud/guides/cloud-builds) page.
+<Tabs>
+  <Tab title="Dashboard">
+    Use the **Deploy** button on the agent's GitHub settings. Deploys are queued:
+    the button returns as soon as the build is accepted, and progress shows up in
+    the agent's deployment history and on the
+    [Builds](/pipecat-cloud/guides/cloud-builds) page.
+  </Tab>
+  <Tab title="CLI">
+    ```shell
+    pipecat cloud agent deploy my-agent --github
+    ```
+
+    Returns as soon as the deploy is queued, printing the branch and commit it
+    will build. To follow it instead:
+
+    ```shell
+    pipecat cloud agent deploy my-agent --github --wait
+    ```
+
+    <Warning>
+      A zero exit from `--wait` means the deploy was observed and did not fail —
+      not that it finished. A deploy still building, or superseded by a newer
+      push, also exits 0. See [what `--wait`
+      reports](/api-reference/cli/cloud/agent#what-wait-reports) before gating a
+      pipeline on it.
+    </Warning>
+
+  </Tab>
+</Tabs>
 
 ## See what's running
 
 An agent deployed from GitHub shows its source and the exact commit it is running — on the agent overview and in the agents list — linked back to that commit on GitHub.
 
-The commit that's running and the branch that's connected can legitimately differ: right after you link a repository, after you re-point an agent at a different repository or branch, or when deploy on push is off and there are unshipped commits. The dashboard says so and offers a deploy when that's the case.
+The commit that's running and the branch that's connected can legitimately differ: right after you link a repository, after you re-point an agent at a different repository or branch, or when deploy on push is off and there are unshipped commits. Both the dashboard and the CLI say so rather than leaving you to compare them — the dashboard offers a deploy, and `agent status` names the repository and branch the running commit actually came from.
+
+From the CLI:
+
+```shell
+pipecat cloud agent status my-agent
+```
+
+It reports the linked repository and branch, the Dockerfile path, whether pushes auto-deploy, the running commit, and the latest deploy attempt with its failure reason. `pipecat cloud agent list` carries a GitHub column for agents built from a repository.
 
 ## Change or remove a connection
 
 <AccordionGroup>
   <Accordion title="Switch branch or repository">
     Edit the repository, branch, or Dockerfile path on the agent's **Settings →
-    GitHub** tab and save. The running deployment is untouched until the next
-    deploy.
+    GitHub** tab and save, or run `pipecat cloud agent link` again with the new
+    values. The running deployment is untouched until the next deploy.
   </Accordion>
   <Accordion title="Unlink one agent">
-    **Unlink** removes the agent's connection to the repository. Pushes stop
-    deploying it, and its current deployment stays live.
+    **Unlink**, or `pipecat cloud agent unlink my-agent`, removes the agent's
+    connection to the repository. Pushes stop deploying it, and its current
+    deployment stays live.
   </Accordion>
   <Accordion title="Disconnect the organization">
-    **Disconnect** on **Settings → GitHub** removes the installation and every
-    repository link in the organization. Connected agents stop auto-deploying
-    and keep running what they last deployed. This does not uninstall the app on
-    GitHub — do that from GitHub if you want to revoke access entirely.
+    **Disconnect** on **Settings → GitHub**, or `pipecat cloud github
+    disconnect`, removes the installation and every repository link in the
+    organization. Connected agents stop auto-deploying and keep running what
+    they last deployed. This does not uninstall the app on GitHub — do that from
+    GitHub if you want to revoke access entirely.
   </Accordion>
 </AccordionGroup>
 
@@ -26594,7 +26715,7 @@ The commit that's running and the branch that's connected can legitimately diffe
 - **Each agent connects to one branch.** To run staging and production from one repository, create two agents and connect each to its own branch.
 - **A `Dockerfile` is required.** The build follows the same path as [cloud builds](/pipecat-cloud/guides/cloud-builds). Run `pipecat init` to scaffold a project that already has one.
 - **Secrets are configured in Pipecat Cloud**, not in your repository. See [Secrets](/pipecat-cloud/fundamentals/secrets).
-- **A suspended installation stops deploys.** If the app is suspended on GitHub, the dashboard flags it; reinstate it from GitHub to resume.
+- **A suspended installation stops deploys.** If the app is suspended on GitHub, the dashboard and `pipecat cloud github status` both flag it; reinstate it from GitHub to resume.
 
 ## Troubleshooting
 
@@ -26602,11 +26723,15 @@ The commit that's running and the branch that's connected can legitimately diffe
   <Accordion title="A repository is missing from the picker">
     The installation can only see repositories you granted it. Open **Settings →
     GitHub → Manage on GitHub** and add the repository to the installation's
-    access list.
+    access list. `pipecat cloud github repos` lists exactly what the App can
+    currently see.
   </Accordion>
   <Accordion title="A push didn't deploy">
     Check that the push went to the connected branch, that **Deploy on push** is
     enabled on the agent, and that the installation isn't suspended on GitHub.
+    `pipecat cloud agent status my-agent` shows the connected branch and
+    auto-deploy setting; `pipecat cloud github status` flags a suspended
+    installation.
   </Accordion>
   <Accordion title="The build failed">
     Build logs are on the agent's deployment history. The most common causes are
@@ -91237,6 +91362,23 @@ pipecat cloud agent status [ARGS]
   Unique string identifier for the agent deployment. Must not contain spaces.
 </ParamField>
 
+For a [GitHub-linked agent](#link), the output also carries the linked
+repository and branch, the Dockerfile path and build subdirectory, whether
+pushes auto-deploy, the commit actually running, and the latest deploy attempt
+with its failure reason if it has one.
+
+The running commit and the linked branch can legitimately differ — right after
+you link a repository, after you re-point an agent, or when auto-deploy is off
+and there are unshipped commits. When the running commit didn't come from the
+current link, `status` says so and names the repository and branch it did come
+from.
+
+<Tip>
+  Nothing live from the current link shows as `— (nothing from this link is live
+  yet)`, which is what you'll see between `agent link` and the first [`agent
+  deploy --github`](#deploy).
+</Tip>
+
 ## deployments
 
 Lists deployment history for an agent, including image versions and timestamps.
@@ -91290,9 +91432,166 @@ pipecat cloud agent logs [ARGS] [OPTIONS]
   sessions [agent-name]`).
 </ParamField>
 
+## link
+
+Link an agent to a GitHub repository and branch, or re-point an existing link. Requires the organization to be [connected to GitHub](/api-reference/cli/cloud/github#connect).
+
+**Usage:**
+
+```shell
+pipecat cloud agent link [ARGS] [OPTIONS]
+```
+
+**Arguments:**
+
+<ParamField path="agent-name" type="string" required>
+  Name of the agent to link.
+</ParamField>
+
+**Options:**
+
+<ParamField path="--repo" type="string" required>
+  Repository as `owner/repo`.
+</ParamField>
+
+<ParamField path="--branch" type="string" required>
+  Branch to build and deploy from.
+</ParamField>
+
+<ParamField path="--dockerfile-path" type="string" default="Dockerfile">
+  Path to the Dockerfile within the repository.
+</ParamField>
+
+<ParamField path="--subdirectory" type="string">
+  Build context subdirectory within the repository.
+</ParamField>
+
+<ParamField
+  path="--auto-deploy / --no-auto-deploy"
+  type="boolean"
+  default="--auto-deploy"
+>
+  Whether a push to the branch deploys the agent.
+</ParamField>
+
+<ParamField path="--organization / -o" type="string">
+  Organization the agent belongs to. If not provided, uses the current
+  organization from your configuration.
+</ParamField>
+
+```shell
+pipecat cloud agent link my-agent --repo my-org/my-bot --branch main
+```
+
+<Note>
+  Linking never changes what is running. It sets where the *next* deploy comes
+  from — use [`agent deploy --github`](#deploy) to ship the branch now.
+</Note>
+
+Re-running `link` on an already-linked agent re-points it. Options you leave out keep their stored values, so changing only the branch won't reset a Dockerfile path you set earlier.
+
+The repository and branch are validated locally against the same rules the API applies, so a typo fails immediately rather than after a round trip.
+
+## unlink
+
+Remove an agent's GitHub repository link.
+
+**Usage:**
+
+```shell
+pipecat cloud agent unlink [ARGS] [OPTIONS]
+```
+
+**Arguments:**
+
+<ParamField path="agent-name" type="string" required>
+  Name of the agent to unlink.
+</ParamField>
+
+**Options:**
+
+<ParamField path="--organization / -o" type="string">
+  Organization the agent belongs to. If not provided, uses the current
+  organization from your configuration.
+</ParamField>
+
+<ParamField path="--force / -f" type="boolean" default="false">
+  Skip the confirmation prompt.
+</ParamField>
+
+Pushes stop deploying the agent. The running agent is not touched and its current deployment stays live.
+
+## deploy
+
+Build and deploy a GitHub-linked agent from its branch's current HEAD, without waiting for a push.
+
+**Usage:**
+
+```shell
+pipecat cloud agent deploy [ARGS] [OPTIONS]
+```
+
+**Arguments:**
+
+<ParamField path="agent-name" type="string" required>
+  Name of the agent to deploy.
+</ParamField>
+
+**Options:**
+
+<ParamField path="--github" type="boolean" default="false">
+  Deploy the agent's linked GitHub branch. Currently the only mode this command
+  supports, so it has to be passed — without it the command exits 1 and points
+  you at `pipecat cloud deploy`.
+</ParamField>
+
+<ParamField path="--wait" type="boolean" default="false">
+  Follow the deploy rather than returning as soon as it is queued.
+</ParamField>
+
+<ParamField path="--organization / -o" type="string">
+  Organization the agent belongs to. If not provided, uses the current
+  organization from your configuration.
+</ParamField>
+
+```shell
+pipecat cloud agent deploy my-agent --github --wait
+```
+
+<Note>
+  `--github` is explicit rather than implied so that adding image-based deploys
+  to this command later can't change what an existing script does. To deploy an
+  image or a cloud build, use [`pipecat cloud
+  deploy`](/api-reference/cli/cloud/deploy).
+</Note>
+
+### What `--wait` reports
+
+Without `--wait`, the command returns once the deploy is queued, printing the branch and commit it will build.
+
+With `--wait`, it follows the deploy and reports one of these:
+
+| Outcome        | Meaning                                                                          | Exit |
+| -------------- | -------------------------------------------------------------------------------- | ---- |
+| Succeeded      | The deploy reached a terminal state and succeeded.                               | 0    |
+| Failed         | The deploy reached a terminal state and failed. The reason is printed.           | 1    |
+| Superseded     | A newer push took over as the latest attempt, so this one is no longer reported. | 0    |
+| Still building | Observed and still moving when the wait ran out. It continues server-side.       | 0    |
+| Never observed | The wait never saw the attempt at all.                                           | 1    |
+
+<Warning>
+  A zero exit from `--wait` means the deploy was observed and did not fail — not
+  that it finished. A deploy still building, or superseded by a newer push, also
+  exits 0. Check the outcome itself if you need to gate on completion; in
+  `--output json` it is reported as `waitOutcome`.
+</Warning>
+
+"Never observed" exits non-zero on purpose: a wait that saw nothing can't tell a healthy build from an API that was down the whole time, and calling that success is what would make `--wait` unsafe as a deploy gate.
+
 ## list
 
-Lists all agents in an organization with their details.
+Lists all agents in an organization with their details, including a GitHub
+column for agents built from a repository.
 
 **Usage:**
 
@@ -91548,6 +91847,9 @@ The status command displays detailed build information including:
 - Build duration and context/image sizes
 - Error messages (if the build failed)
 
+For a build triggered from a [GitHub-linked agent](/api-reference/cli/cloud/agent#link),
+it also reports the repository, the ref, and the commit the build came from.
+
 ## list
 
 List recent cloud builds.
@@ -91577,6 +91879,10 @@ pipecat cloud build list [OPTIONS]
   Organization to use. If not provided, uses the current organization from your
   configuration.
 </ParamField>
+
+The listing carries a **Source** column. GitHub-triggered builds show
+`owner/repo@commit`; a build from a local context has no commit provenance and
+shows nothing there.
 
 ## Examples
 
@@ -91779,6 +92085,166 @@ The command provides helpful error messages for common issues:
 - **Missing Dockerfile**: Indicates that a Dockerfile must be present in the current directory
 - **Registry access issues**: Provides guidance on checking permissions and authentication
 
+# pipecat cloud github
+Source: https://docs.pipecat.ai/api-reference/cli/cloud/github.md
+
+pipecat cloud github connects an organization to GitHub, inspects the App installation, and lists visible repositories and branches.
+
+The `github` command group connects a Pipecat Cloud organization to GitHub by installing the Pipecat Cloud GitHub App. Once connected, agents can be built from a repository instead of an image — see [`agent link`](/api-reference/cli/cloud/agent#link) and [`deploy --repo`](/api-reference/cli/cloud/deploy).
+
+The connection is per organization, not per agent. One installation covers every agent in the organization.
+
+<Card
+  title="Deploy from GitHub"
+  icon="github"
+  href="/pipecat-cloud/guides/deploy-from-github"
+>
+  The full walkthrough, from connecting an account to deploying on push
+</Card>
+
+## connect
+
+Install the Pipecat Cloud GitHub App on a GitHub account and link it to your organization.
+
+**Usage:**
+
+```shell
+pipecat cloud github connect [OPTIONS]
+```
+
+**Options:**
+
+<ParamField path="--organization / -o" type="string">
+  Organization to connect. If not provided, uses the current organization from
+  your configuration.
+</ParamField>
+
+The command opens the GitHub App install page in your browser and then waits, polling until the installation lands — there is nothing to copy back into the terminal. GitHub redirects to the API's own setup callback, which completes the link server-side, so the flow works the same as the dashboard's.
+
+If the browser can't be opened, the URL is printed for you to open manually. The command gives up after 15 minutes; if you completed the install after that, `github status` will show it.
+
+Connecting an organization that's already connected is not an error — the command reports the existing installation and leaves it alone. To connect a different GitHub account, run [`github disconnect`](#disconnect) first.
+
+## status
+
+Show the organization's GitHub connection.
+
+**Usage:**
+
+```shell
+pipecat cloud github status [OPTIONS]
+```
+
+**Options:**
+
+<ParamField path="--organization / -o" type="string">
+  Organization to inspect. If not provided, uses the current organization from
+  your configuration.
+</ParamField>
+
+Reports the connected GitHub account and type, the installation ID, whether the App is active or suspended, and a link to manage it on GitHub. If the organization isn't connected, it says so and points at `github connect`.
+
+<Warning>
+  A suspended installation stops deploys. `status` flags it; reinstate the App
+  from GitHub to resume.
+</Warning>
+
+## disconnect
+
+Disconnect the organization from GitHub.
+
+**Usage:**
+
+```shell
+pipecat cloud github disconnect [OPTIONS]
+```
+
+**Options:**
+
+<ParamField path="--organization / -o" type="string">
+  Organization to disconnect. If not provided, uses the current organization
+  from your configuration.
+</ParamField>
+
+<ParamField path="--yes / -y" type="boolean" default="false">
+  Skip the confirmation prompt.
+</ParamField>
+
+This removes the installation and **every repository link in the organization**, so linked agents stop auto-deploying. What is already running is not touched.
+
+The App itself stays installed on GitHub. Uninstall it there to revoke access entirely.
+
+## repos
+
+List the repositories the GitHub App can access.
+
+**Usage:**
+
+```shell
+pipecat cloud github repos [OPTIONS]
+```
+
+**Options:**
+
+<ParamField path="--organization / -o" type="string">
+  Organization to list repositories for. If not provided, uses the current
+  organization from your configuration.
+</ParamField>
+
+Shows each repository's full name, default branch, and visibility. The list reflects what you granted the App on GitHub — if a repository is missing, widen the App's repository access from GitHub rather than from here.
+
+## branches
+
+List branches for a repository.
+
+**Usage:**
+
+```shell
+pipecat cloud github branches [ARGS] [OPTIONS]
+```
+
+**Arguments:**
+
+<ParamField path="repo" type="string" required>
+  Repository as `owner/repo`. Any other form is rejected before the request is
+  made.
+</ParamField>
+
+**Options:**
+
+<ParamField path="--query / -q" type="string">
+  Prefix to search for. Runs a server-side search, which reaches branches past
+  the plain list's cap — use it on repositories with many branches.
+</ParamField>
+
+<ParamField path="--organization / -o" type="string">
+  Organization to list branches for. If not provided, uses the current
+  organization from your configuration.
+</ParamField>
+
+```shell
+pipecat cloud github branches my-org/my-bot --query release/
+```
+
+## More Information
+
+<CardGroup cols={2}>
+  <Card
+    title="Link an agent"
+    icon="link"
+    href="/api-reference/cli/cloud/agent#link"
+  >
+    Point an existing agent at a repository and branch
+  </Card>
+  <Card
+    title="Create from a repository"
+    icon="rocket"
+    href="/api-reference/cli/cloud/deploy"
+  >
+    `deploy --repo` builds a new agent from GitHub
+  </Card>
+</CardGroup>
+
 # pipecat cloud deploy
 Source: https://docs.pipecat.ai/api-reference/cli/cloud/deploy.md
 
@@ -91911,6 +92377,41 @@ See [Agent Profiles](/pipecat-cloud/fundamentals/deploy#agent-profiles) for more
   context directory.
 </ParamField>
 
+### GitHub source
+
+Create an agent that builds from a GitHub repository instead of an image. The
+organization must be [connected to GitHub](/api-reference/cli/cloud/github#connect)
+first.
+
+<ParamField path="--repo" type="string">
+  Repository as `owner/repo`. Skips the image build and push entirely — Pipecat
+  Cloud builds from the repository.
+</ParamField>
+
+<ParamField path="--branch" type="string">
+  Branch to build and deploy from.
+</ParamField>
+
+<ParamField path="--dockerfile-path" type="string" default="Dockerfile">
+  Path to the Dockerfile within the repository. Distinct from `--dockerfile`,
+  which applies to cloud builds from a local context.
+</ParamField>
+
+<ParamField path="--subdirectory" type="string">
+  Build context subdirectory within the repository.
+</ParamField>
+
+<Warning>
+  `--repo` only applies when **creating** an agent. The API accepts a GitHub
+  source on create and ignores it on update, so re-pointing an existing agent
+  goes through [`agent link`](/api-reference/cli/cloud/agent#link) instead.
+</Warning>
+
+A GitHub source can't be combined with `--image` or `--build-id` — a deploy is
+built from a repository or from an image, not both. The first deploy is followed
+through its build, so the command reports whether it succeeded rather than
+returning as soon as it's queued.
+
 ## Examples
 
 **Deploy a new agent:**
@@ -91983,6 +92484,12 @@ pipecat cloud deploy --yes
 
 ```shell
 pipecat cloud deploy --build-id abc12345-6789-0abc-def0-123456789abc
+```
+
+**Create an agent that builds from a GitHub repository:**
+
+```shell
+pipecat cloud deploy my-agent --repo my-org/my-bot --branch main
 ```
 
 **Deploy using an alternate config file:**
@@ -92180,6 +92687,56 @@ patterns = ["*.md", "tests/", "docs/"]
 ```
 
 </ParamField>
+
+#### GitHub Source Configuration
+
+Build from a repository instead of an image, in a `[git]` section. Command-line
+flags take precedence over these values.
+
+<ParamField path="git.repo" type="string">
+Repository as `owner/repo`.
+
+```toml
+[git]
+repo = "my-org/my-bot"
+```
+
+</ParamField>
+
+<ParamField path="git.branch" type="string">
+Branch to build and deploy from.
+
+```toml
+[git]
+branch = "main"
+```
+
+</ParamField>
+
+<ParamField path="git.dockerfile_path" type="string" default="Dockerfile">
+Path to the Dockerfile within the repository.
+
+```toml
+[git]
+dockerfile_path = "docker/Dockerfile"
+```
+
+</ParamField>
+
+<ParamField path="git.subdirectory" type="string">
+Build context subdirectory within the repository.
+
+```toml
+[git]
+subdirectory = "bot"
+```
+
+</ParamField>
+
+<Note>
+  Like `--repo`, a `[git]` section only takes effect when the agent is created.
+  It is ignored on an update.
+</Note>
 
 ### Complete Example
 

--- a/llms.txt
+++ b/llms.txt
@@ -780,6 +780,7 @@ LLM, transports, serializers), pipelines, frames, workers, and utilities.
 - [pipecat cloud auth](https://docs.pipecat.ai/api-reference/cli/cloud/auth.md): pipecat cloud auth manages authentication with Pipecat Cloud: login, logout, and checking your current credentials.
 - [pipecat cloud build](https://docs.pipecat.ai/api-reference/cli/cloud/build.md): pipecat cloud build manages Pipecat Cloud builds: view build logs, check build status, and inspect builds from the CLI.
 - [pipecat cloud docker](https://docs.pipecat.ai/api-reference/cli/cloud/docker.md): pipecat cloud docker builds, tags, and pushes agent Docker images to container registries for Pipecat Cloud deployments.
+- [pipecat cloud github](https://docs.pipecat.ai/api-reference/cli/cloud/github.md): pipecat cloud github connects an organization to GitHub, inspects the App installation, and lists visible repositories and branches.
 - [pipecat cloud deploy](https://docs.pipecat.ai/api-reference/cli/cloud/deploy.md): pipecat cloud deploy creates or updates a Pipecat Cloud agent deployment, building a deployment manifest from your options.
 - [pipecat cloud organizations](https://docs.pipecat.ai/api-reference/cli/cloud/organizations.md): pipecat cloud organizations manages Pipecat Cloud organizations and API keys: list, select, and manage from the CLI.
 - [pipecat cloud secrets](https://docs.pipecat.ai/api-reference/cli/cloud/secrets.md): pipecat cloud secrets manages secret sets for agent deployments: create, update, list, and delete sensitive configuration.

--- a/pipecat-cloud/guides/deploy-from-github.mdx
+++ b/pipecat-cloud/guides/deploy-from-github.mdx
@@ -7,7 +7,7 @@ Connect a GitHub repository to an agent and Pipecat Cloud builds and deploys it 
 
 {/* prettier-ignore */}
 <Info>
-  This guide sets the integration up in the [Pipecat Cloud dashboard <Icon icon="arrow-up-right-from-square" iconType="solid" />](https://pipecat.daily.co). Deploys use [cloud builds](/pipecat-cloud/guides/cloud-builds) under the hood, so your project needs a `Dockerfile`.
+  Everything here works from the [Pipecat Cloud dashboard <Icon icon="arrow-up-right-from-square" iconType="solid" />](https://pipecat.daily.co) or the CLI — each section shows both. Deploys use [cloud builds](/pipecat-cloud/guides/cloud-builds) under the hood, so your project needs a `Dockerfile`.
 </Info>
 
 <Note>
@@ -27,20 +27,40 @@ Connect a GitHub repository to an agent and Pipecat Cloud builds and deploys it 
 
 The GitHub App is installed once per Pipecat Cloud organization, and every agent in that organization shares it.
 
-<Steps>
-  <Step title="Open GitHub settings">
-    In the dashboard, go to **Settings → GitHub**.
-  </Step>
-  <Step title="Install the app">
-    Click **Connect GitHub**. A new tab opens GitHub's installation screen,
-    where you choose the account or organization to install into and which
-    repositories to grant access to — all of them, or a hand-picked list.
-  </Step>
-  <Step title="Return to the dashboard">
-    Once you approve the install, the dashboard picks up the connection
-    automatically and shows the connected account.
-  </Step>
-</Steps>
+<Tabs>
+  <Tab title="Dashboard">
+    <Steps>
+      <Step title="Open GitHub settings">
+        Go to **Settings → GitHub**.
+      </Step>
+      <Step title="Install the app">
+        Click **Connect GitHub**. A new tab opens GitHub's installation screen,
+        where you choose the account or organization to install into and which
+        repositories to grant access to — all of them, or a hand-picked list.
+      </Step>
+      <Step title="Return to the dashboard">
+        Once you approve the install, the dashboard picks up the connection
+        automatically and shows the connected account.
+      </Step>
+    </Steps>
+  </Tab>
+  <Tab title="CLI">
+    ```shell
+    pipecat cloud github connect
+    ```
+
+    This opens the same GitHub installation screen and then waits, polling until
+    the install lands — there's nothing to paste back into the terminal. Approve
+    it in the browser and the command reports the connected account.
+
+    Check it any time:
+
+    ```shell
+    pipecat cloud github status
+    ```
+
+  </Tab>
+</Tabs>
 
 <Tip>
   Granting access to only the repositories you deploy from is the safer default.
@@ -50,30 +70,79 @@ The GitHub App is installed once per Pipecat Cloud organization, and every agent
 
 ## Deploy a new agent from a repository
 
-When you create an agent, choose **GitHub** as the source:
+<Tabs>
+  <Tab title="Dashboard">
+    When you create an agent, choose **GitHub** as the source:
 
-<Steps>
-  <Step title="Pick the repository">
-    Select any repository the installation can see. Private repositories are
-    supported.
-  </Step>
-  <Step title="Pick the branch">
-    The repository's default branch is preselected. Search to find any other
-    branch.
-  </Step>
-  <Step title="Set the Dockerfile path (optional)">
-    Defaults to `Dockerfile` at the repository root. Set a path such as
-    `docker/Dockerfile` if yours lives elsewhere.
-  </Step>
-</Steps>
+    <Steps>
+      <Step title="Pick the repository">
+        Select any repository the installation can see. Private repositories are
+        supported.
+      </Step>
+      <Step title="Pick the branch">
+        The repository's default branch is preselected. Search to find any other
+        branch.
+      </Step>
+      <Step title="Set the Dockerfile path (optional)">
+        Defaults to `Dockerfile` at the repository root. Set a path such as
+        `docker/Dockerfile` if yours lives elsewhere.
+      </Step>
+    </Steps>
 
-Creating the agent builds the branch's current commit and deploys it.
+  </Tab>
+  <Tab title="CLI">
+    ```shell
+    pipecat cloud deploy my-agent --repo my-org/my-bot --branch main
+    ```
+
+    No image argument: passing `--repo` skips the image build and push entirely.
+    Add `--dockerfile-path` if your `Dockerfile` isn't at the repository root, and
+    `--subdirectory` to build from a subdirectory.
+
+    The same thing in `pcc-deploy.toml`, where flags win over file values:
+
+    ```toml
+    agent_name = "my-agent"
+
+    [git]
+    repo = "my-org/my-bot"
+    branch = "main"
+    ```
+
+    Not sure what the App can see?
+
+    ```shell
+    pipecat cloud github repos
+    pipecat cloud github branches my-org/my-bot
+    ```
+
+  </Tab>
+</Tabs>
+
+Creating the agent builds the branch's current commit and deploys it. `--repo`
+applies only at creation — to re-point an agent that already exists, use
+`agent link` below.
 
 ## Connect an existing agent
 
 Agents that already run a Docker image can be moved onto GitHub deploys at any time.
 
-Go to your agent's **Settings → GitHub** tab and pick a repository, branch, and Dockerfile path.
+<Tabs>
+  <Tab title="Dashboard">
+    Go to your agent's **Settings → GitHub** tab and pick a repository, branch,
+    and Dockerfile path.
+  </Tab>
+  <Tab title="CLI">
+    ```shell
+    pipecat cloud agent link my-agent --repo my-org/my-bot --branch main
+    ```
+
+    Re-run it to re-point an agent at a different repository or branch. Options
+    you leave out keep their stored values, so changing the branch won't reset a
+    Dockerfile path you set earlier.
+
+  </Tab>
+</Tabs>
 
 <Note>
   Linking a repository does not deploy anything. The agent keeps serving its
@@ -87,37 +156,89 @@ Go to your agent's **Settings → GitHub** tab and pick a repository, branch, an
 
 Pushes to any other branch are ignored — only the branch you connected triggers a deploy.
 
-Turn it off from the agent's **Settings → GitHub** tab when you want to control the timing yourself, for example while you're stabilizing a branch.
+Turn it off when you want to control the timing yourself, for example while you're stabilizing a branch.
+
+<Tabs>
+  <Tab title="Dashboard">
+    Toggle it on the agent's **Settings → GitHub** tab.
+  </Tab>
+  <Tab title="CLI">
+    ```shell
+    pipecat cloud agent link my-agent --repo my-org/my-bot --branch main --no-auto-deploy
+    ```
+
+    Pass `--auto-deploy` to turn it back on.
+
+  </Tab>
+</Tabs>
 
 ## Deploy manually
 
-The **Deploy** button on the agent's GitHub settings builds and deploys the connected branch's current `HEAD`. It works whether or not deploy on push is enabled, and it's the way to ship a change when it's off.
+Deploying manually builds the connected branch's current `HEAD`. It works whether or not deploy on push is enabled, and it's the way to ship a change when it's off.
 
-Deploys are queued: the button returns as soon as the build is accepted, and progress shows up in the agent's deployment history and on the [Builds](/pipecat-cloud/guides/cloud-builds) page.
+<Tabs>
+  <Tab title="Dashboard">
+    Use the **Deploy** button on the agent's GitHub settings. Deploys are queued:
+    the button returns as soon as the build is accepted, and progress shows up in
+    the agent's deployment history and on the
+    [Builds](/pipecat-cloud/guides/cloud-builds) page.
+  </Tab>
+  <Tab title="CLI">
+    ```shell
+    pipecat cloud agent deploy my-agent --github
+    ```
+
+    Returns as soon as the deploy is queued, printing the branch and commit it
+    will build. To follow it instead:
+
+    ```shell
+    pipecat cloud agent deploy my-agent --github --wait
+    ```
+
+    <Warning>
+      A zero exit from `--wait` means the deploy was observed and did not fail —
+      not that it finished. A deploy still building, or superseded by a newer
+      push, also exits 0. See [what `--wait`
+      reports](/api-reference/cli/cloud/agent#what-wait-reports) before gating a
+      pipeline on it.
+    </Warning>
+
+  </Tab>
+</Tabs>
 
 ## See what's running
 
 An agent deployed from GitHub shows its source and the exact commit it is running — on the agent overview and in the agents list — linked back to that commit on GitHub.
 
-The commit that's running and the branch that's connected can legitimately differ: right after you link a repository, after you re-point an agent at a different repository or branch, or when deploy on push is off and there are unshipped commits. The dashboard says so and offers a deploy when that's the case.
+The commit that's running and the branch that's connected can legitimately differ: right after you link a repository, after you re-point an agent at a different repository or branch, or when deploy on push is off and there are unshipped commits. Both the dashboard and the CLI say so rather than leaving you to compare them — the dashboard offers a deploy, and `agent status` names the repository and branch the running commit actually came from.
+
+From the CLI:
+
+```shell
+pipecat cloud agent status my-agent
+```
+
+It reports the linked repository and branch, the Dockerfile path, whether pushes auto-deploy, the running commit, and the latest deploy attempt with its failure reason. `pipecat cloud agent list` carries a GitHub column for agents built from a repository.
 
 ## Change or remove a connection
 
 <AccordionGroup>
   <Accordion title="Switch branch or repository">
     Edit the repository, branch, or Dockerfile path on the agent's **Settings →
-    GitHub** tab and save. The running deployment is untouched until the next
-    deploy.
+    GitHub** tab and save, or run `pipecat cloud agent link` again with the new
+    values. The running deployment is untouched until the next deploy.
   </Accordion>
   <Accordion title="Unlink one agent">
-    **Unlink** removes the agent's connection to the repository. Pushes stop
-    deploying it, and its current deployment stays live.
+    **Unlink**, or `pipecat cloud agent unlink my-agent`, removes the agent's
+    connection to the repository. Pushes stop deploying it, and its current
+    deployment stays live.
   </Accordion>
   <Accordion title="Disconnect the organization">
-    **Disconnect** on **Settings → GitHub** removes the installation and every
-    repository link in the organization. Connected agents stop auto-deploying
-    and keep running what they last deployed. This does not uninstall the app on
-    GitHub — do that from GitHub if you want to revoke access entirely.
+    **Disconnect** on **Settings → GitHub**, or `pipecat cloud github
+    disconnect`, removes the installation and every repository link in the
+    organization. Connected agents stop auto-deploying and keep running what
+    they last deployed. This does not uninstall the app on GitHub — do that from
+    GitHub if you want to revoke access entirely.
   </Accordion>
 </AccordionGroup>
 
@@ -127,7 +248,7 @@ The commit that's running and the branch that's connected can legitimately diffe
 - **Each agent connects to one branch.** To run staging and production from one repository, create two agents and connect each to its own branch.
 - **A `Dockerfile` is required.** The build follows the same path as [cloud builds](/pipecat-cloud/guides/cloud-builds). Run `pipecat init` to scaffold a project that already has one.
 - **Secrets are configured in Pipecat Cloud**, not in your repository. See [Secrets](/pipecat-cloud/fundamentals/secrets).
-- **A suspended installation stops deploys.** If the app is suspended on GitHub, the dashboard flags it; reinstate it from GitHub to resume.
+- **A suspended installation stops deploys.** If the app is suspended on GitHub, the dashboard and `pipecat cloud github status` both flag it; reinstate it from GitHub to resume.
 
 ## Troubleshooting
 
@@ -135,11 +256,15 @@ The commit that's running and the branch that's connected can legitimately diffe
   <Accordion title="A repository is missing from the picker">
     The installation can only see repositories you granted it. Open **Settings →
     GitHub → Manage on GitHub** and add the repository to the installation's
-    access list.
+    access list. `pipecat cloud github repos` lists exactly what the App can
+    currently see.
   </Accordion>
   <Accordion title="A push didn't deploy">
     Check that the push went to the connected branch, that **Deploy on push** is
     enabled on the agent, and that the installation isn't suspended on GitHub.
+    `pipecat cloud agent status my-agent` shows the connected branch and
+    auto-deploy setting; `pipecat cloud github status` flags a suspended
+    installation.
   </Accordion>
   <Accordion title="The build failed">
     Build logs are on the agent's deployment history. The most common causes are


### PR DESCRIPTION
The GitHub App integration shipped in `pipecatcloud` 1.2.0 with the CLI at parity with the dashboard. None of it was documented — `grep` across all MDX for `github connect`, `agent link`, `agent unlink`, `--repo`, or `[git]` returned nothing.

Verified against `v1.2.0`.

## New: `api-reference/cli/cloud/github`

`connect`, `status`, `disconnect`, `repos`, `branches`. The behaviors worth writing down aren't guessable from `--help`: the installation is **per organization**, not per agent; `connect` opens the browser and then polls for up to 15 minutes with nothing to paste back; connecting an already-connected org is a no-op rather than an error; `disconnect` removes **every repository link in the organization** while leaving running agents alone; and `branches --query` runs a server-side search that reaches past the plain list's cap.

## `agent.mdx`: `link`, `unlink`, `deploy --github`

The `--wait` contract gets its own section, because it reads backwards from what you'd assume:

| Outcome | Exit |
|---|---|
| Succeeded | 0 |
| Failed | 1 |
| Superseded by a newer push | 0 |
| Still building when the wait ran out | 0 |
| Never observed | 1 |

**A zero exit means the deploy was observed and did not fail — not that it finished.** Anyone gating a pipeline on `--wait` needs that, plus `waitOutcome` in `--output json` as the machine-readable half. "Never observed" exiting non-zero is deliberate: a wait that saw nothing can't distinguish a healthy build from an API that was down throughout.

Two more non-obvious behaviors: `link` never changes what's running — it sets where the *next* deploy comes from — and re-linking preserves options you omit, so a branch-only change won't silently reset a stored Dockerfile path. `status` and `list` also gained GitHub fields, including the case where the running commit didn't come from the current link, which `status` reports by naming where it *did* come from.

## `deploy.mdx`: `--repo` and `[git]`

Flags plus the `pcc-deploy.toml` section. Two constraints stated outright because neither fails somewhere obvious: a GitHub source **only applies when creating an agent** (the API accepts `git` on create and ignores it on update, so re-pointing goes through `agent link`), and it can't combine with `--image` or `--build-id`.

Also distinguishes `--dockerfile-path` from the existing `--dockerfile` — adjacent flags, different sources: one is a path inside the repository, the other applies to cloud builds from a local context.

## `build.mdx`

`build status` now reports repository, ref, and commit; `build list` has a **Source** column showing `owner/repo@commit`. Builds from a local context carry no commit provenance and leave it blank.

## `deploy-from-github.mdx`

The guide opened with "This guide sets the integration up in the Pipecat Cloud dashboard." With the CLI at parity that framing is wrong rather than just incomplete.

Its seven sections already mapped one-to-one onto commands, so each operational section now has **Dashboard / CLI** tabs instead of a forked second page — a reader picks their tool once and follows the same walkthrough, with shared prose outside the tabs. The existing dashboard content is unchanged; I can't verify it against the CLI repo, so I only added alongside it.

## Verification

`mint broken-links --check-anchors --check-redirects` clean (including the new `#what-wait-reports` cross-page anchor), `docs-meta-lint.mjs` 0 errors, `llms.txt`/`llms-full.txt` regenerated, `docs.json` valid.

## One thing to decide

The projected auto-generated `llms.txt` is now at **99,862 of the 100,000 cap** — 138 characters of headroom. PR 5 adds a `spend-limit` page and will cross it. It's a warning, not an error, and it concerns the fallback Mintlify would generate if we didn't ship our own (ours is already 103k), so I don't believe it blocks anything. Worth a decision before I add another page.

PR 4 of 5. Remaining: `spend-limit`, the `pipecatcloud[pipecat]` extra, three undocumented exports, and eight missing flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)