### PR TITLE
docs: state image architecture as region-dependent, not absolute

### DIFF
--- a/api-reference/cli/cloud/docker.mdx
+++ b/api-reference/cli/cloud/docker.mdx
@@ -169,7 +169,9 @@ pipecat cloud docker build-push --no-latest
 
 ## Platform Support
 
-All images are built for the `linux/arm64` platform, which is required for Pipecat Cloud deployments. This is automatically configured and cannot be changed.
+`build-push` always builds for `linux/arm64`. This is automatically configured and cannot be changed.
+
+The architecture an agent needs depends on the region it deploys to — Daily-hosted regions run `arm64`, which is what this command produces. To build for a different architecture, build and push the image yourself rather than through this command.
 
 ## Error Handling
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -24807,7 +24807,7 @@ We recommend using FastAPI to create this route. Please refer to the base image 
   to your own container registry.
 </Note>
 
-Pipecat Cloud requires all images to be built to target Linux on ARM. This is the most common platform for cloud deployments.
+An agent image has to be built for the architecture its region runs. Daily-hosted regions run Linux on ARM, so build for `linux/arm64`:
 
 ```bash
 docker build --platform linux/arm64 -t my-agent:latest .
@@ -26224,7 +26224,9 @@ Check that your image repository is not rate limiting your pull requests. This c
 
 > Image platform is not supported.
 
-Ensure the image you are attempting to pull is supported by Pipecat Cloud. Currently, Pipecat Cloud only supports images for the `linux/arm64` platform.
+The image's architecture has to match what the target region supports. Daily-hosted regions run `linux/arm64`, so an image built for `amd64` is rejected there.
+
+Check what you built with `docker image inspect <image> --format '{{.Architecture}}'`, and rebuild with `--platform linux/arm64` if it doesn't match.
 
 ### PCC_IMAGE_PULL_UNKNOWN_ERROR
 
@@ -26925,8 +26927,8 @@ If you host images in your own container registry (e.g. Docker Hub, AWS ECR, GHC
 
 <Note>
   When deploying a pre-built image, you must provide an `image-credentials`
-  reference if the image is in a private registry. Pipecat Cloud requires images
-  built for `linux/arm64`.
+  reference if the image is in a private registry. Build for the architecture
+  your region runs — `linux/arm64` for Daily-hosted regions.
 </Note>
 
 ## Using v1 with Docker Build
@@ -92236,7 +92238,9 @@ pipecat cloud docker build-push --no-latest
 
 ## Platform Support
 
-All images are built for the `linux/arm64` platform, which is required for Pipecat Cloud deployments. This is automatically configured and cannot be changed.
+`build-push` always builds for `linux/arm64`. This is automatically configured and cannot be changed.
+
+The architecture an agent needs depends on the region it deploys to — Daily-hosted regions run `arm64`, which is what this command produces. To build for a different architecture, build and push the image yourself rather than through this command.
 
 ## Error Handling
 

--- a/pipecat-cloud/fundamentals/agent-images.mdx
+++ b/pipecat-cloud/fundamentals/agent-images.mdx
@@ -218,7 +218,7 @@ We recommend using FastAPI to create this route. Please refer to the base image 
   to your own container registry.
 </Note>
 
-Pipecat Cloud requires all images to be built to target Linux on ARM. This is the most common platform for cloud deployments.
+An agent image has to be built for the architecture its region runs. Daily-hosted regions run Linux on ARM, so build for `linux/arm64`:
 
 ```bash
 docker build --platform linux/arm64 -t my-agent:latest .

--- a/pipecat-cloud/fundamentals/error-codes.mdx
+++ b/pipecat-cloud/fundamentals/error-codes.mdx
@@ -48,7 +48,9 @@ Check that your image repository is not rate limiting your pull requests. This c
 
 > Image platform is not supported.
 
-Ensure the image you are attempting to pull is supported by Pipecat Cloud. Currently, Pipecat Cloud only supports images for the `linux/arm64` platform.
+The image's architecture has to match what the target region supports. Daily-hosted regions run `linux/arm64`, so an image built for `amd64` is rejected there.
+
+Check what you built with `docker image inspect <image> --format '{{.Architecture}}'`, and rebuild with `--platform linux/arm64` if it doesn't match.
 
 ### PCC_IMAGE_PULL_UNKNOWN_ERROR
 

--- a/pipecat-cloud/guides/ci-with-github-actions.mdx
+++ b/pipecat-cloud/guides/ci-with-github-actions.mdx
@@ -157,8 +157,8 @@ If you host images in your own container registry (e.g. Docker Hub, AWS ECR, GHC
 
 <Note>
   When deploying a pre-built image, you must provide an `image-credentials`
-  reference if the image is in a private registry. Pipecat Cloud requires images
-  built for `linux/arm64`.
+  reference if the image is in a private registry. Build for the architecture
+  your region runs — `linux/arm64` for Daily-hosted regions.
 </Note>
 
 ## Using v1 with Docker Build


### PR DESCRIPTION
Four pages assert `linux/arm64` as a platform-wide requirement. `pipecatcloud` 1.2.0 made architecture a property of the **region**, so those absolutes are about to be contradicted by the docs' own content.

| Page | Says |
|---|---|
| `fundamentals/error-codes.mdx` | "Pipecat Cloud **only supports** images for the `linux/arm64` platform" |
| `fundamentals/agent-images.mdx` | "Pipecat Cloud **requires all images** to be built to target Linux on ARM" |
| `api-reference/cli/cloud/docker.mdx` | "`linux/arm64` … **required for** Pipecat Cloud deployments" |
| `guides/ci-with-github-actions.mdx` | "Pipecat Cloud **requires** images built for `linux/arm64`" |

1.2.0 added `deploy --architecture {amd64,arm64}` and an `architecture` key in `pcc-deploy.toml`, validated against what the target region supports.

Nothing above is wrong for a reader deploying today — Daily-hosted regions run arm64. But each states the *consequence* as if it were the *rule*, so each becomes false the moment a region with a different architecture exists. This states the rule and names arm64 as what follows from it.

## Scope

Deliberately narrow, because [#1145](https://github.com/pipecat-ai/docs/pull/1145) is in flight and touches adjacent ground:

- **Not touched:** `deploy.mdx`. #1145 already documents `--architecture`, the `architecture` TOML key, `--resources`, and `[resources]` there. I'd previously recommended splitting the deploy-side flag out and doing it separately — that was wrong, it's covered.
- **Not touched:** the three container-registry guides saying "the correct platform (`linux/arm64`)". Those describe `docker build-push`, which does build arm64 and can't be configured otherwise.
- **No overlap** with #1145's changed files, so this can land in either order.

Phrasing avoids depending on content #1145 introduces — no reader is sent to a `regions list` architecture column that doesn't exist yet.

## One addition

`error-codes.mdx` gains a one-liner for `PCC_INVALID_IMAGE_PLATFORM`:

```
docker image inspect <image> --format '{{.Architecture}}'
```

The first thing someone hitting that error needs is a way to see what they actually built; the page previously only told them what was required.

## Verification

`mint broken-links --check-anchors --check-redirects` clean, `docs-meta-lint.mjs` 0 errors, `llms-full.txt` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)