### PR TITLE
docs: refresh examples and recipes pages

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -864,6 +864,13 @@ The worker handles pipeline execution, collects metrics, and manages RTVI events
 Event handlers manage the bot's lifecycle and user interactions:
 
 ```python
+# Create a WorkerRunner to run the worker
+runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+# Add the worker and run it
+# This will start the pipeline and begin processing frames
+await runner.add_workers(worker)
+
 # Kick off the conversation when the client signals it's ready
 @worker.rtvi.event_handler("on_client_ready")
 async def on_client_ready(rtvi):
@@ -888,16 +895,9 @@ When the client signals it's ready over the RTVI protocol, the bot adds a greeti
 
 ### Running the Pipeline
 
-Finally, the pipeline is executed by a WorkerRunner. Note that the runner must be created **before** registering event handlers so that handlers can call `runner.cancel()`:
+Finally, the pipeline is executed by a WorkerRunner.
 
 ```python
-# Create a WorkerRunner to run the worker
-# In scaffolded bots, use runner_args.handle_sigint
-runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-# Finally, add the worker and run it
-# This will start the pipeline and begin processing frames
-await runner.add_workers(worker)
 await runner.run()
 ```
 
@@ -5604,6 +5604,13 @@ async def on_client_connected(transport, client):
 Connect termination to transport events for automatic cleanup:
 
 ```python
+# Create a WorkerRunner to run the worker
+runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
+
+# Add the worker and run it
+# This will start the pipeline and begin processing frames
+await runner.add_workers(worker)
+
 @transport.event_handler("on_client_connected")
 async def on_client_connected(transport, client):
     logger.info("Client connected - starting conversation")
@@ -5615,8 +5622,6 @@ async def on_client_disconnected(transport, client):
     await runner.cancel()
 
 # Run the pipeline
-runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-await runner.add_workers(worker)
 await runner.run()
 ```
 
@@ -5644,7 +5649,6 @@ Ensure pipelines can terminate properly even when exceptions occur:
 try:
     runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
     await runner.add_workers(worker)
-    await runner.run()
 except Exception as e:
     logger.error(f"Pipeline error: {e}")
     # Ensure cleanup happens even on errors
@@ -18610,6 +18614,70 @@ Stream real-time audio from an active Vonage Video API session into a Pipecat pi
 
 </Update>
 
+<Update label={<><Icon icon="bolt" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Instant Voice</span></>} tags={["Web & Mobile"]}>
+
+Have the bot talking the moment the user presses connect, using a warm pool of rooms on the server and client-side connection optimizations.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/instant-voice)
+
+</Update>
+
+<Update label={<><Icon icon="gauge-high" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Speculative Inference</span></>} tags={["Web & Mobile"]}>
+
+A `SpeculativeUserAggregator` that starts the LLM response before the user's turn is confirmed complete, cutting roughly half a second of latency.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/speculative-user-aggregator)
+
+</Update>
+
+<Update label={<><Icon icon="comment-sms" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>SMS Verification</span></>} tags={["Telephony"]}>
+
+Send a 6-digit code by SMS and confirm it back, spoken or entered on the keypad as DTMF.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/sms-verification)
+
+</Update>
+
+<Update label={<><Icon icon="microchip" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>PhoneLLM</span></>} tags={["Telephony"]}>
+
+Run Pipecat PhoneLLM, an open-weights 30B model fine-tuned for phone agents, on Modal with Deepgram Flux for STT and TTS.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/phonellm)
+
+</Update>
+
+<Update label={<><Icon icon="robot" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>AWS Strands Agents</span></>} tags={["Agents"]}>
+
+Delegate multi-step, tool-using tasks to an AWS Strands agent from inside a voice pipeline.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/aws-strands)
+
+</Update>
+
+<Update label={<><Icon icon="aws" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Bedrock AgentCore</span></>} tags={["Agents"]}>
+
+Put an AgentCore-hosted agent in the LLM's place in the pipeline, streaming its responses back as speech.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/aws-agentcore)
+
+</Update>
+
+<Update label={<><Icon icon="earth-americas" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Multi-Language Translation</span></>} tags={["Multilingual"]}>
+
+Translate one incoming English stream into Spanish, French, and German simultaneously, each on its own Daily custom track.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/daily-multi-translation)
+
+</Update>
+
+<Update label={<><Icon icon="cloud-arrow-up" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Record Audio to S3</span></>} tags={["Logging & Analytics"]}>
+
+Upload recordings to S3 with `AudioBufferProcessor` and multipart uploads, so long calls don't grow the buffer until the process runs out of memory.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/audio-recording-s3-multipart-upload)
+
+</Update>
+
 ## Multi-agent examples
 
 These build coordinated multi-agent systems. All of them live in the [pipecat repository](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker).
@@ -18646,6 +18714,22 @@ A voice agent backed by a code agent that uses Claude Agent SDK with tools (Read
 
 </Update>
 
+<Update label={<><Icon icon="satellite-dish" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Sensor Controller</span></>} tags={["Local"]}>
+
+A voice agent forwards questions to a sidecar `PipelineWorker` that owns a simulated sensor, keeping hardware state out of the conversation.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/sensor-controller)
+
+</Update>
+
+<Update label={<><Icon icon="robot" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>OpenClaw Agent</span></>} tags={["Local"]}>
+
+The voice loop stays responsive while an OpenClaw agent works in the background, so the user can steer or stop it mid-task.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/openclaw-agent)
+
+</Update>
+
 <Update label={<><Icon icon="server" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Redis Handoff</span></>} tags={["Distributed"]}>
 
 The two-agent handoff split across separate processes using `RedisBus`. The main transport agent runs independently from the LLM agents.
@@ -18667,6 +18751,58 @@ The same distributed handoff on a `PgmqBus` (Postgres / Supabase), for ops-frien
 A main agent connects to a remote LLM server over WebSocket using proxy agents. Demonstrates point-to-point distributed deployment.
 
 [View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/remote-proxy-assistant)
+
+</Update>
+
+### UI workers
+
+A [`UIWorker`](/pipecat/learn/ui-worker) bridges the bus to a web client: page snapshots, state updates, job progress, and user actions all flow through it.
+
+<Update label={<><Icon icon="window" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Hello Snapshot</span></>} tags={["UI"]}>
+
+The smallest UIWorker example: a voice agent grounded in whatever is currently on the page.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/ui-worker/hello-snapshot)
+
+</Update>
+
+<Update label={<><Icon icon="list-check" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Shopping List</span></>} tags={["UI"]}>
+
+Every voice turn drives the UI. Speech is the input modality and the screen is the source of truth.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/ui-worker/shopping-list)
+
+</Update>
+
+<Update label={<><Icon icon="pen-to-square" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Form Fill</span></>} tags={["UI"]}>
+
+An accessibility-first, voice-guided walkthrough of a web form.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/ui-worker/form-fill)
+
+</Update>
+
+<Update label={<><Icon icon="hand-pointer" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Deixis</span></>} tags={["UI"]}>
+
+The worker reads the user's current selection out of the snapshot, so "explain this" resolves to what they have highlighted.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/ui-worker/deixis)
+
+</Update>
+
+<Update label={<><Icon icon="spinner" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Async Tasks</span></>} tags={["UI"]}>
+
+A `BaseUIWorker` dispatcher fans out long-running work and streams progress and cancellation to the UI — no second LLM involved.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/ui-worker/async-tasks)
+
+</Update>
+
+<Update label={<><Icon icon="file-lines" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Document Review</span></>} tags={["UI"]}>
+
+A synthesis demo: snapshots, deixis, form-fill actions, and async job groups in one application.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/ui-worker/document-review)
 
 </Update>
 
@@ -18699,6 +18835,8 @@ Source: https://docs.pipecat.ai/pipecat/examples/recipes.md
 
 Pipecat code recipes: focused snippets and techniques for common voice agent tasks and pipeline patterns.
 
+## LLM and tools
+
 <Update label={<><Icon icon="code" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Function Calling</span></>} tags={["LLM"]}>
 
 Add function calling to your Pipecat bot. Examples exist for each LLM provider supported in Pipecat.
@@ -18707,99 +18845,35 @@ Add function calling to your Pipecat bot. Examples exist for each LLM provider s
 
 </Update>
 
-<Update label={<><Icon icon="microphone" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Record Audio</span></>} tags={["Recording & Logging"]}>
+<Update label={<><Icon icon="bolt" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Direct Functions</span></>} tags={["LLM"]}>
 
-Collect audio frames from the user and bot for later processing or storage.
+Skip the schema boilerplate: pass Python functions straight into the context and let Pipecat derive the tool schema from the signature and docstring.
 
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/audio/audio-recording.py)
-
-</Update>
-
-<Update label={<><Icon icon="file-lines" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Capture Transcripts</span></>} tags={["Recording & Logging"]}>
-
-Capture user and bot transcripts for later processing or storage.
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-user-assistant-turns.py)
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/function-calling/function-calling-direct.py)
 
 </Update>
 
-<Update label={<><Icon icon="volume-high" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Play Background Sound</span></>} tags={["Audio"]}>
+<Update label={<><Icon icon="clock" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Async Function Calls</span></>} tags={["LLM"]}>
 
-Play a background sound in your Pipecat bot. The audio is mixed with the transport audio to create a single integrated audio stream.
+Run long tool calls in the background so the bot keeps talking while the work finishes. Covers `@tool_options`, `on_function_calls_started`, and cancellation on interruption.
 
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/audio/audio-bot-background-sound.py)
-
-</Update>
-
-<Update label={<><Icon icon="microphone-slash" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Mute User Input</span></>} tags={["User Interaction"]}>
-
-Specify a strategy for mute to mute user input, allowing the bot to continue without interruption.
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-user-mute-strategy.py)
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/function-calling/function-calling-openai-async.py)
 
 </Update>
 
-<Update label={<><Icon icon="bell" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Wake Phrase</span></>} tags={["User Interaction"]}>
+<Update label={<><Icon icon="lightbulb" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Reasoning Models</span></>} tags={["LLM"]}>
 
-Use a wake phrase to wake up your Pipecat bot.
+Use a model's thinking/reasoning mode in a voice pipeline, including reasoning alongside function calls. Examples exist for Anthropic, Google, and OpenAI Responses.
 
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-wake-phrase.py)
-
-</Update>
-
-<Update label={<><Icon icon="music" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Play Sound Effects</span></>} tags={["Audio"]}>
-
-Play sound effects in your Pipecat bot.
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/audio/audio-sound-effects.py)
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/thinking/thinking-anthropic.py)
 
 </Update>
 
-<Update label={<><Icon icon="language" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Switch Languages</span></>} tags={["Multilingual"]}>
+<Update label={<><Icon icon="magnifying-glass" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Web Search</span></>} tags={["LLM"]}>
 
-A ParallelPipeline example showing how to dynamically switch languages.
+Give the agent live web search with `KeenableWebSearch`, so it can answer questions about current events beyond the model's training data.
 
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-switch-languages.py)
-
-</Update>
-
-<Update label={<><Icon icon="hourglass" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Detect an Idle User</span></>} tags={["User Interaction"]}>
-
-Detect when a user is idle and automatically respond.
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-detect-user-idle.py)
-
-</Update>
-
-<Update label={<><Icon icon="bug" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Debug with an Observer</span></>} tags={["Debugging"]}>
-
-Learn how to debug your Pipecat bot with an Observer by observing frames flowing through the pipeline.
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/observability/observability-observer.py)
-
-</Update>
-
-<Update label={<><Icon icon="monitor-waveform" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Live Debugger (Whisker)</span></>} tags={["Debugging"]}>
-
-A live graphical debugger for the Pipecat voice and multimodal conversational AI framework. It lets you visualize pipelines and debug frames in real time — so you can see exactly what your bot is thinking and doing.
-
-[View Recipe →](https://github.com/pipecat-ai/whisker)
-
-</Update>
-
-<Update label={<><Icon icon="envelope" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Collect Emails</span></>} tags={["Recording & Logging"]}>
-
-Parse user email from the LLM response.
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-user-email-gathering.py)
-
-</Update>
-
-<Update label={<><Icon icon="brain" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Smart Turn Detection</span></>} tags={["User Interaction"]}>
-
-Detect when a user has finished speaking and automatically respond. Learn more about [smart-turn model](https://github.com/pipecat-ai/smart-turn).
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-smart-turn-local.py)
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-keenable-web-search.py)
 
 </Update>
 
@@ -18827,6 +18901,132 @@ Combine tools from multiple MCP servers (stdio and HTTP) in a single bot.
 
 </Update>
 
+## Context and memory
+
+<Update label={<><Icon icon="compress" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Summarize Context</span></>} tags={["Context"]}>
+
+Automatically compress conversation history as it approaches the token limit, preserving in-flight function calls. See [context summarization](/pipecat/fundamentals/context-summarization) for configuration, including using a cheaper dedicated LLM for the summary.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/context-summarization/context-summarization-openai.py)
+
+</Update>
+
+<Update label={<><Icon icon="floppy-disk" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Persist Context Across Sessions</span></>} tags={["Context"]}>
+
+Save and restore conversation context so a returning user picks up where they left off. Examples exist for standard LLMs and speech-to-speech models.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/persistent-context/persistent-context-openai.py)
+
+</Update>
+
+<Update label={<><Icon icon="book-open" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>RAG with Gemini</span></>} tags={["Context"]}>
+
+Answer questions from a document the model was never trained on, by routing them through a second, cheaper model holding the source in its context window.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/rag/rag-gemini.py)
+
+</Update>
+
+<Update label={<><Icon icon="database" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Long-Term Memory (Mem0)</span></>} tags={["Context"]}>
+
+Store and recall memories across conversations with Mem0, so the bot personalizes its greeting and responses based on past interactions.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/rag/rag-mem0.py)
+
+</Update>
+
+## Speech and audio
+
+<Update label={<><Icon icon="microphone" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Record Audio</span></>} tags={["Recording & Logging"]}>
+
+Collect audio frames from the user and bot for later processing or storage.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/audio/audio-recording.py)
+
+</Update>
+
+<Update label={<><Icon icon="volume-high" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Play Background Sound</span></>} tags={["Audio"]}>
+
+Play a background sound in your Pipecat bot. The audio is mixed with the transport audio to create a single integrated audio stream.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/audio/audio-bot-background-sound.py)
+
+</Update>
+
+<Update label={<><Icon icon="music" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Play Sound Effects</span></>} tags={["Audio"]}>
+
+Play sound effects in your Pipecat bot.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/audio/audio-sound-effects.py)
+
+</Update>
+
+<Update label={<><Icon icon="spell-check" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Speak Text Naturally</span></>} tags={["TTS"]}>
+
+Use `VoiceFormatter` so currency, phone numbers, dates, and acronyms are spoken the way a person would say them — "$42.50" becomes "forty-two dollars and fifty cents" rather than "dollar sign four two point five zero".
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-voice-formatter.py)
+
+</Update>
+
+<Update label={<><Icon icon="wand-magic-sparkles" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Custom Text Transforms</span></>} tags={["TTS"]}>
+
+Compose individual text transforms instead of the `VoiceFormatter` bundle, for fine-grained control over which run and in what order.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-text-transforms.py)
+
+</Update>
+
+<Update label={<><Icon icon="masks-theater" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Switch Voices Mid-Response</span></>} tags={["TTS"]}>
+
+Use `PatternPairAggregator` to switch TTS voices inside a single streamed response — a narrator and two characters in one story.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-pattern-pair-voice-switching.py)
+
+</Update>
+
+<Update label={<><Icon icon="sliders" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Update Settings at Runtime</span></>} tags={["STT/TTS/LLM"]}>
+
+Change STT, TTS, and LLM settings mid-session — voice, model, language, temperature. See [service settings](/pipecat/fundamentals/service-settings) for the API.
+
+[View Recipes →](https://github.com/pipecat-ai/pipecat/tree/main/examples/update-settings)
+
+</Update>
+
+## Turn management
+
+<Update label={<><Icon icon="microphone-slash" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Mute User Input</span></>} tags={["User Interaction"]}>
+
+Specify a strategy for mute to mute user input, allowing the bot to continue without interruption.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-user-mute-strategy.py)
+
+</Update>
+
+<Update label={<><Icon icon="bell" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Wake Phrase</span></>} tags={["User Interaction"]}>
+
+Use a wake phrase to wake up your Pipecat bot.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-wake-phrase.py)
+
+</Update>
+
+<Update label={<><Icon icon="hourglass" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Detect an Idle User</span></>} tags={["User Interaction"]}>
+
+Detect when a user is idle and automatically respond.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-detect-user-idle.py)
+
+</Update>
+
+<Update label={<><Icon icon="brain" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Smart Turn Detection</span></>} tags={["User Interaction"]}>
+
+Detect when a user has finished speaking and automatically respond. Learn more about [smart-turn model](https://github.com/pipecat-ai/smart-turn).
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-smart-turn-local.py)
+
+</Update>
+
 <Update label={<><Icon icon="hand" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Interruption Strategies</span></>} tags={["User Interaction"]}>
 
 Learn how to configure interruption strategies for your Pipecat bot.
@@ -18834,6 +19034,60 @@ Learn how to configure interruption strategies for your Pipecat bot.
 [View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-interruption-config.py)
 
 </Update>
+
+<Update label={<><Icon icon="filter" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Filter Incomplete Turns</span></>} tags={["User Interaction"]}>
+
+Use the LLM to detect when the user was cut off mid-thought, suppress the response, and re-engage after a timeout instead of answering half a sentence.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-filter-incomplete-turns.py)
+
+</Update>
+
+<Update label={<><Icon icon="stopwatch" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Custom Turn-Stop Strategy</span></>} tags={["User Interaction"]}>
+
+Extend a turn-detecting STT's timing with your own stop strategy — hold the turn open for a beat after Deepgram Flux proposes the end, so afterthoughts land in the same user message.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-custom-external-turn-strategy.py)
+
+</Update>
+
+<Update label={<><Icon icon="users" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>User and Bot Turn Events</span></>} tags={["Events"]}>
+
+Handle user and bot end of turn events to add custom logic after a turn.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-turn-tracking-observer.py)
+
+</Update>
+
+## Multilingual
+
+<Update label={<><Icon icon="language" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Switch Languages</span></>} tags={["Multilingual"]}>
+
+A ParallelPipeline example showing how to dynamically switch languages.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-switch-languages.py)
+
+</Update>
+
+<Update label={<><Icon icon="earth-americas" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Live Translation</span></>} tags={["Multilingual"]}>
+
+Translate the user's speech into another language and speak it back in real time.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-live-translation.py)
+
+</Update>
+
+## Telephony
+
+<Update label={<><Icon icon="hashtag" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>DTMF Keypad Menu</span></>} tags={["Telephony"]}>
+
+Build a keypad-driven phone menu with no STT in the pipeline: `DTMFAggregator` turns each key sequence into a transcription the LLM reacts to. See [IVR navigation](/pipecat/fundamentals/ivr) for the other direction.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-dtmf-menu.py)
+
+</Update>
+
+## Vision and video
 
 <Update label={<><Icon icon="video" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Describe Video</span></>} tags={["Vision"]}>
 
@@ -18843,11 +19097,87 @@ Pass a video frame from a live video stream to a model and get a description.
 
 </Update>
 
-<Update label={<><Icon icon="users" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>User and Bot Turn Events</span></>} tags={["Events"]}>
+<Update label={<><Icon icon="film" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Custom Video Tracks</span></>} tags={["Video"]}>
 
-Handle user and bot end of turn events to add custom logic after a turn.
+Output more than one video track at once — the default camera track plus a second processed track sent to a custom destination.
 
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-turn-tracking-observer.py)
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/video-processing/video-processing-custom-video-track.py)
+
+</Update>
+
+## Pipeline and reliability
+
+<Update label={<><Icon icon="cubes" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Custom Frame Processor</span></>} tags={["Pipeline"]}>
+
+Write your own `FrameProcessor` to inspect or transform frames as they move through the pipeline. See [custom frame processors](/pipecat/fundamentals/custom-frame-processor) for the walkthrough.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-custom-frame-processor.py)
+
+</Update>
+
+<Update label={<><Icon icon="shuffle" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Switch Services at Runtime</span></>} tags={["Pipeline"]}>
+
+Put two providers behind a `ServiceSwitcher` and move work between them mid-session, manually or on failure.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-service-switcher.py)
+
+</Update>
+
+<Update label={<><Icon icon="heart-pulse" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Handle Service Failures</span></>} tags={["Pipeline"]}>
+
+React to processor health with `is_usable` and `on_usable_changed`: fall back to a second TTS provider when the first stops working, and end the bot only when the last one is gone.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-processor-usable.py)
+
+</Update>
+
+<Update label={<><Icon icon="box" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Share App Resources</span></>} tags={["Pipeline"]}>
+
+Pass database handles, HTTP clients, or per-user state through `PipelineWorker(app_resources=...)` and read them from tool handlers and custom processors.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-app-resources.py)
+
+</Update>
+
+## Debugging and observability
+
+<Update label={<><Icon icon="file-lines" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Capture Transcripts</span></>} tags={["Recording & Logging"]}>
+
+Capture user and bot transcripts for later processing or storage.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-user-assistant-turns.py)
+
+</Update>
+
+<Update label={<><Icon icon="envelope" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Collect Emails</span></>} tags={["Recording & Logging"]}>
+
+Parse user email from the LLM response.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-user-email-gathering.py)
+
+</Update>
+
+<Update label={<><Icon icon="bug" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Debug with an Observer</span></>} tags={["Debugging"]}>
+
+Learn how to debug your Pipecat bot with an Observer by observing frames flowing through the pipeline.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/observability/observability-observer.py)
+
+</Update>
+
+<Update label={<><Icon icon="wave-square" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Pipeline Heartbeats</span></>} tags={["Debugging"]}>
+
+Enable heartbeat frames to detect a stalled or blocked pipeline in production.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/observability/observability-heartbeats.py)
+
+</Update>
+
+<Update label={<><Icon icon="monitor-waveform" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Live Debugger (Whisker)</span></>} tags={["Debugging"]}>
+
+A live graphical debugger for the Pipecat voice and multimodal conversational AI framework. It lets you visualize pipelines and debug frames in real time — so you can see exactly what your bot is thinking and doing.
+
+[View Recipe →](https://github.com/pipecat-ai/whisker)
 
 </Update>
 
@@ -71284,38 +71614,6 @@ Notice how we use lazy imports (`from pipecat.transports.daily.transport import 
   common interface for the runner to pass transport-specific information to your
   bot.
 </Info>
-
-## Runner Lifecycle Management
-
-### Ending Sessions Early
-
-The `WorkerRunner` provides a `cancel()` method to end a session before it completes naturally. This is commonly used in event handlers to clean up when clients disconnect:
-
-```python
-async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
-    # Create the runner before registering event handlers
-    # so handlers can call runner.cancel()
-    runner = WorkerRunner(handle_sigint=runner_args.handle_sigint)
-
-    # Your bot setup: services, pipeline, worker...
-    worker = PipelineWorker(pipeline)
-
-    @transport.event_handler("on_client_disconnected")
-    async def on_client_disconnected(transport, client):
-        logger.info("Client disconnected")
-        await runner.cancel()
-
-    await runner.add_workers(worker)
-    await runner.run()
-```
-
-The runner must be created **before** registering event handlers that need to call `runner.cancel()`. Bots scaffolded by `pipecat init` follow this pattern automatically.
-
-<Tip>
-  Use `runner.cancel()` rather than `worker.cancel()` in event handlers. The
-  runner-level cancel is the recommended approach for ending sessions, as it
-  properly coordinates shutdown across all workers and the runner itself.
-</Tip>
 
 ## Environment Detection
 

--- a/pipecat/examples/overview.mdx
+++ b/pipecat/examples/overview.mdx
@@ -166,6 +166,70 @@ Stream real-time audio from an active Vonage Video API session into a Pipecat pi
 
 </Update>
 
+<Update label={<><Icon icon="bolt" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Instant Voice</span></>} tags={["Web & Mobile"]}>
+
+Have the bot talking the moment the user presses connect, using a warm pool of rooms on the server and client-side connection optimizations.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/instant-voice)
+
+</Update>
+
+<Update label={<><Icon icon="gauge-high" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Speculative Inference</span></>} tags={["Web & Mobile"]}>
+
+A `SpeculativeUserAggregator` that starts the LLM response before the user's turn is confirmed complete, cutting roughly half a second of latency.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/speculative-user-aggregator)
+
+</Update>
+
+<Update label={<><Icon icon="comment-sms" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>SMS Verification</span></>} tags={["Telephony"]}>
+
+Send a 6-digit code by SMS and confirm it back, spoken or entered on the keypad as DTMF.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/sms-verification)
+
+</Update>
+
+<Update label={<><Icon icon="microchip" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>PhoneLLM</span></>} tags={["Telephony"]}>
+
+Run Pipecat PhoneLLM, an open-weights 30B model fine-tuned for phone agents, on Modal with Deepgram Flux for STT and TTS.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/phonellm)
+
+</Update>
+
+<Update label={<><Icon icon="robot" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>AWS Strands Agents</span></>} tags={["Agents"]}>
+
+Delegate multi-step, tool-using tasks to an AWS Strands agent from inside a voice pipeline.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/aws-strands)
+
+</Update>
+
+<Update label={<><Icon icon="aws" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Bedrock AgentCore</span></>} tags={["Agents"]}>
+
+Put an AgentCore-hosted agent in the LLM's place in the pipeline, streaming its responses back as speech.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/aws-agentcore)
+
+</Update>
+
+<Update label={<><Icon icon="earth-americas" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Multi-Language Translation</span></>} tags={["Multilingual"]}>
+
+Translate one incoming English stream into Spanish, French, and German simultaneously, each on its own Daily custom track.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/daily-multi-translation)
+
+</Update>
+
+<Update label={<><Icon icon="cloud-arrow-up" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Record Audio to S3</span></>} tags={["Logging & Analytics"]}>
+
+Upload recordings to S3 with `AudioBufferProcessor` and multipart uploads, so long calls don't grow the buffer until the process runs out of memory.
+
+[View Example →](https://github.com/pipecat-ai/pipecat-examples/tree/main/audio-recording-s3-multipart-upload)
+
+</Update>
+
 ## Multi-agent examples
 
 These build coordinated multi-agent systems. All of them live in the [pipecat repository](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker).
@@ -202,6 +266,22 @@ A voice agent backed by a code agent that uses Claude Agent SDK with tools (Read
 
 </Update>
 
+<Update label={<><Icon icon="satellite-dish" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Sensor Controller</span></>} tags={["Local"]}>
+
+A voice agent forwards questions to a sidecar `PipelineWorker` that owns a simulated sensor, keeping hardware state out of the conversation.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/sensor-controller)
+
+</Update>
+
+<Update label={<><Icon icon="robot" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>OpenClaw Agent</span></>} tags={["Local"]}>
+
+The voice loop stays responsive while an OpenClaw agent works in the background, so the user can steer or stop it mid-task.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/openclaw-agent)
+
+</Update>
+
 <Update label={<><Icon icon="server" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Redis Handoff</span></>} tags={["Distributed"]}>
 
 The two-agent handoff split across separate processes using `RedisBus`. The main transport agent runs independently from the LLM agents.
@@ -223,6 +303,58 @@ The same distributed handoff on a `PgmqBus` (Postgres / Supabase), for ops-frien
 A main agent connects to a remote LLM server over WebSocket using proxy agents. Demonstrates point-to-point distributed deployment.
 
 [View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/remote-proxy-assistant)
+
+</Update>
+
+### UI workers
+
+A [`UIWorker`](/pipecat/learn/ui-worker) bridges the bus to a web client: page snapshots, state updates, job progress, and user actions all flow through it.
+
+<Update label={<><Icon icon="window" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Hello Snapshot</span></>} tags={["UI"]}>
+
+The smallest UIWorker example: a voice agent grounded in whatever is currently on the page.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/ui-worker/hello-snapshot)
+
+</Update>
+
+<Update label={<><Icon icon="list-check" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Shopping List</span></>} tags={["UI"]}>
+
+Every voice turn drives the UI. Speech is the input modality and the screen is the source of truth.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/ui-worker/shopping-list)
+
+</Update>
+
+<Update label={<><Icon icon="pen-to-square" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Form Fill</span></>} tags={["UI"]}>
+
+An accessibility-first, voice-guided walkthrough of a web form.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/ui-worker/form-fill)
+
+</Update>
+
+<Update label={<><Icon icon="hand-pointer" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Deixis</span></>} tags={["UI"]}>
+
+The worker reads the user's current selection out of the snapshot, so "explain this" resolves to what they have highlighted.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/ui-worker/deixis)
+
+</Update>
+
+<Update label={<><Icon icon="spinner" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Async Tasks</span></>} tags={["UI"]}>
+
+A `BaseUIWorker` dispatcher fans out long-running work and streams progress and cancellation to the UI — no second LLM involved.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/ui-worker/async-tasks)
+
+</Update>
+
+<Update label={<><Icon icon="file-lines" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Document Review</span></>} tags={["UI"]}>
+
+A synthesis demo: snapshots, deixis, form-fill actions, and async job groups in one application.
+
+[View Example →](https://github.com/pipecat-ai/pipecat/tree/main/examples/multi-worker/ui-worker/document-review)
 
 </Update>
 

--- a/pipecat/examples/recipes.mdx
+++ b/pipecat/examples/recipes.mdx
@@ -3,6 +3,8 @@ title: "Recipes"
 description: "Pipecat code recipes: focused snippets and techniques for common voice agent tasks and pipeline patterns."
 ---
 
+## LLM and tools
+
 <Update label={<><Icon icon="code" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Function Calling</span></>} tags={["LLM"]}>
 
 Add function calling to your Pipecat bot. Examples exist for each LLM provider supported in Pipecat.
@@ -11,99 +13,35 @@ Add function calling to your Pipecat bot. Examples exist for each LLM provider s
 
 </Update>
 
-<Update label={<><Icon icon="microphone" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Record Audio</span></>} tags={["Recording & Logging"]}>
+<Update label={<><Icon icon="bolt" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Direct Functions</span></>} tags={["LLM"]}>
 
-Collect audio frames from the user and bot for later processing or storage.
+Skip the schema boilerplate: pass Python functions straight into the context and let Pipecat derive the tool schema from the signature and docstring.
 
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/audio/audio-recording.py)
-
-</Update>
-
-<Update label={<><Icon icon="file-lines" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Capture Transcripts</span></>} tags={["Recording & Logging"]}>
-
-Capture user and bot transcripts for later processing or storage.
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-user-assistant-turns.py)
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/function-calling/function-calling-direct.py)
 
 </Update>
 
-<Update label={<><Icon icon="volume-high" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Play Background Sound</span></>} tags={["Audio"]}>
+<Update label={<><Icon icon="clock" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Async Function Calls</span></>} tags={["LLM"]}>
 
-Play a background sound in your Pipecat bot. The audio is mixed with the transport audio to create a single integrated audio stream.
+Run long tool calls in the background so the bot keeps talking while the work finishes. Covers `@tool_options`, `on_function_calls_started`, and cancellation on interruption.
 
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/audio/audio-bot-background-sound.py)
-
-</Update>
-
-<Update label={<><Icon icon="microphone-slash" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Mute User Input</span></>} tags={["User Interaction"]}>
-
-Specify a strategy for mute to mute user input, allowing the bot to continue without interruption.
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-user-mute-strategy.py)
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/function-calling/function-calling-openai-async.py)
 
 </Update>
 
-<Update label={<><Icon icon="bell" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Wake Phrase</span></>} tags={["User Interaction"]}>
+<Update label={<><Icon icon="lightbulb" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Reasoning Models</span></>} tags={["LLM"]}>
 
-Use a wake phrase to wake up your Pipecat bot.
+Use a model's thinking/reasoning mode in a voice pipeline, including reasoning alongside function calls. Examples exist for Anthropic, Google, and OpenAI Responses.
 
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-wake-phrase.py)
-
-</Update>
-
-<Update label={<><Icon icon="music" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Play Sound Effects</span></>} tags={["Audio"]}>
-
-Play sound effects in your Pipecat bot.
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/audio/audio-sound-effects.py)
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/thinking/thinking-anthropic.py)
 
 </Update>
 
-<Update label={<><Icon icon="language" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Switch Languages</span></>} tags={["Multilingual"]}>
+<Update label={<><Icon icon="magnifying-glass" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Web Search</span></>} tags={["LLM"]}>
 
-A ParallelPipeline example showing how to dynamically switch languages.
+Give the agent live web search with `KeenableWebSearch`, so it can answer questions about current events beyond the model's training data.
 
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-switch-languages.py)
-
-</Update>
-
-<Update label={<><Icon icon="hourglass" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Detect an Idle User</span></>} tags={["User Interaction"]}>
-
-Detect when a user is idle and automatically respond.
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-detect-user-idle.py)
-
-</Update>
-
-<Update label={<><Icon icon="bug" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Debug with an Observer</span></>} tags={["Debugging"]}>
-
-Learn how to debug your Pipecat bot with an Observer by observing frames flowing through the pipeline.
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/observability/observability-observer.py)
-
-</Update>
-
-<Update label={<><Icon icon="monitor-waveform" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Live Debugger (Whisker)</span></>} tags={["Debugging"]}>
-
-A live graphical debugger for the Pipecat voice and multimodal conversational AI framework. It lets you visualize pipelines and debug frames in real time — so you can see exactly what your bot is thinking and doing.
-
-[View Recipe →](https://github.com/pipecat-ai/whisker)
-
-</Update>
-
-<Update label={<><Icon icon="envelope" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Collect Emails</span></>} tags={["Recording & Logging"]}>
-
-Parse user email from the LLM response.
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-user-email-gathering.py)
-
-</Update>
-
-<Update label={<><Icon icon="brain" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Smart Turn Detection</span></>} tags={["User Interaction"]}>
-
-Detect when a user has finished speaking and automatically respond. Learn more about [smart-turn model](https://github.com/pipecat-ai/smart-turn).
-
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-smart-turn-local.py)
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-keenable-web-search.py)
 
 </Update>
 
@@ -131,6 +69,132 @@ Combine tools from multiple MCP servers (stdio and HTTP) in a single bot.
 
 </Update>
 
+## Context and memory
+
+<Update label={<><Icon icon="compress" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Summarize Context</span></>} tags={["Context"]}>
+
+Automatically compress conversation history as it approaches the token limit, preserving in-flight function calls. See [context summarization](/pipecat/fundamentals/context-summarization) for configuration, including using a cheaper dedicated LLM for the summary.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/context-summarization/context-summarization-openai.py)
+
+</Update>
+
+<Update label={<><Icon icon="floppy-disk" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Persist Context Across Sessions</span></>} tags={["Context"]}>
+
+Save and restore conversation context so a returning user picks up where they left off. Examples exist for standard LLMs and speech-to-speech models.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/persistent-context/persistent-context-openai.py)
+
+</Update>
+
+<Update label={<><Icon icon="book-open" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>RAG with Gemini</span></>} tags={["Context"]}>
+
+Answer questions from a document the model was never trained on, by routing them through a second, cheaper model holding the source in its context window.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/rag/rag-gemini.py)
+
+</Update>
+
+<Update label={<><Icon icon="database" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Long-Term Memory (Mem0)</span></>} tags={["Context"]}>
+
+Store and recall memories across conversations with Mem0, so the bot personalizes its greeting and responses based on past interactions.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/rag/rag-mem0.py)
+
+</Update>
+
+## Speech and audio
+
+<Update label={<><Icon icon="microphone" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Record Audio</span></>} tags={["Recording & Logging"]}>
+
+Collect audio frames from the user and bot for later processing or storage.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/audio/audio-recording.py)
+
+</Update>
+
+<Update label={<><Icon icon="volume-high" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Play Background Sound</span></>} tags={["Audio"]}>
+
+Play a background sound in your Pipecat bot. The audio is mixed with the transport audio to create a single integrated audio stream.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/audio/audio-bot-background-sound.py)
+
+</Update>
+
+<Update label={<><Icon icon="music" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Play Sound Effects</span></>} tags={["Audio"]}>
+
+Play sound effects in your Pipecat bot.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/audio/audio-sound-effects.py)
+
+</Update>
+
+<Update label={<><Icon icon="spell-check" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Speak Text Naturally</span></>} tags={["TTS"]}>
+
+Use `VoiceFormatter` so currency, phone numbers, dates, and acronyms are spoken the way a person would say them — "$42.50" becomes "forty-two dollars and fifty cents" rather than "dollar sign four two point five zero".
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-voice-formatter.py)
+
+</Update>
+
+<Update label={<><Icon icon="wand-magic-sparkles" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Custom Text Transforms</span></>} tags={["TTS"]}>
+
+Compose individual text transforms instead of the `VoiceFormatter` bundle, for fine-grained control over which run and in what order.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-text-transforms.py)
+
+</Update>
+
+<Update label={<><Icon icon="masks-theater" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Switch Voices Mid-Response</span></>} tags={["TTS"]}>
+
+Use `PatternPairAggregator` to switch TTS voices inside a single streamed response — a narrator and two characters in one story.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-pattern-pair-voice-switching.py)
+
+</Update>
+
+<Update label={<><Icon icon="sliders" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Update Settings at Runtime</span></>} tags={["STT/TTS/LLM"]}>
+
+Change STT, TTS, and LLM settings mid-session — voice, model, language, temperature. See [service settings](/pipecat/fundamentals/service-settings) for the API.
+
+[View Recipes →](https://github.com/pipecat-ai/pipecat/tree/main/examples/update-settings)
+
+</Update>
+
+## Turn management
+
+<Update label={<><Icon icon="microphone-slash" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Mute User Input</span></>} tags={["User Interaction"]}>
+
+Specify a strategy for mute to mute user input, allowing the bot to continue without interruption.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-user-mute-strategy.py)
+
+</Update>
+
+<Update label={<><Icon icon="bell" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Wake Phrase</span></>} tags={["User Interaction"]}>
+
+Use a wake phrase to wake up your Pipecat bot.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-wake-phrase.py)
+
+</Update>
+
+<Update label={<><Icon icon="hourglass" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Detect an Idle User</span></>} tags={["User Interaction"]}>
+
+Detect when a user is idle and automatically respond.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-detect-user-idle.py)
+
+</Update>
+
+<Update label={<><Icon icon="brain" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Smart Turn Detection</span></>} tags={["User Interaction"]}>
+
+Detect when a user has finished speaking and automatically respond. Learn more about [smart-turn model](https://github.com/pipecat-ai/smart-turn).
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-smart-turn-local.py)
+
+</Update>
+
 <Update label={<><Icon icon="hand" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Interruption Strategies</span></>} tags={["User Interaction"]}>
 
 Learn how to configure interruption strategies for your Pipecat bot.
@@ -138,6 +202,60 @@ Learn how to configure interruption strategies for your Pipecat bot.
 [View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-interruption-config.py)
 
 </Update>
+
+<Update label={<><Icon icon="filter" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Filter Incomplete Turns</span></>} tags={["User Interaction"]}>
+
+Use the LLM to detect when the user was cut off mid-thought, suppress the response, and re-engage after a timeout instead of answering half a sentence.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-filter-incomplete-turns.py)
+
+</Update>
+
+<Update label={<><Icon icon="stopwatch" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Custom Turn-Stop Strategy</span></>} tags={["User Interaction"]}>
+
+Extend a turn-detecting STT's timing with your own stop strategy — hold the turn open for a beat after Deepgram Flux proposes the end, so afterthoughts land in the same user message.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-custom-external-turn-strategy.py)
+
+</Update>
+
+<Update label={<><Icon icon="users" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>User and Bot Turn Events</span></>} tags={["Events"]}>
+
+Handle user and bot end of turn events to add custom logic after a turn.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-turn-tracking-observer.py)
+
+</Update>
+
+## Multilingual
+
+<Update label={<><Icon icon="language" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Switch Languages</span></>} tags={["Multilingual"]}>
+
+A ParallelPipeline example showing how to dynamically switch languages.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-switch-languages.py)
+
+</Update>
+
+<Update label={<><Icon icon="earth-americas" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Live Translation</span></>} tags={["Multilingual"]}>
+
+Translate the user's speech into another language and speak it back in real time.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-live-translation.py)
+
+</Update>
+
+## Telephony
+
+<Update label={<><Icon icon="hashtag" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>DTMF Keypad Menu</span></>} tags={["Telephony"]}>
+
+Build a keypad-driven phone menu with no STT in the pipeline: `DTMFAggregator` turns each key sequence into a transcription the LLM reacts to. See [IVR navigation](/pipecat/fundamentals/ivr) for the other direction.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-dtmf-menu.py)
+
+</Update>
+
+## Vision and video
 
 <Update label={<><Icon icon="video" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Describe Video</span></>} tags={["Vision"]}>
 
@@ -147,11 +265,87 @@ Pass a video frame from a live video stream to a model and get a description.
 
 </Update>
 
-<Update label={<><Icon icon="users" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>User and Bot Turn Events</span></>} tags={["Events"]}>
+<Update label={<><Icon icon="film" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Custom Video Tracks</span></>} tags={["Video"]}>
 
-Handle user and bot end of turn events to add custom logic after a turn.
+Output more than one video track at once — the default camera track plus a second processed track sent to a custom destination.
 
-[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-turn-tracking-observer.py)
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/video-processing/video-processing-custom-video-track.py)
+
+</Update>
+
+## Pipeline and reliability
+
+<Update label={<><Icon icon="cubes" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Custom Frame Processor</span></>} tags={["Pipeline"]}>
+
+Write your own `FrameProcessor` to inspect or transform frames as they move through the pipeline. See [custom frame processors](/pipecat/fundamentals/custom-frame-processor) for the walkthrough.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-custom-frame-processor.py)
+
+</Update>
+
+<Update label={<><Icon icon="shuffle" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Switch Services at Runtime</span></>} tags={["Pipeline"]}>
+
+Put two providers behind a `ServiceSwitcher` and move work between them mid-session, manually or on failure.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-service-switcher.py)
+
+</Update>
+
+<Update label={<><Icon icon="heart-pulse" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Handle Service Failures</span></>} tags={["Pipeline"]}>
+
+React to processor health with `is_usable` and `on_usable_changed`: fall back to a second TTS provider when the first stops working, and end the bot only when the last one is gone.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-processor-usable.py)
+
+</Update>
+
+<Update label={<><Icon icon="box" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Share App Resources</span></>} tags={["Pipeline"]}>
+
+Pass database handles, HTTP clients, or per-user state through `PipelineWorker(app_resources=...)` and read them from tool handlers and custom processors.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-app-resources.py)
+
+</Update>
+
+## Debugging and observability
+
+<Update label={<><Icon icon="file-lines" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Capture Transcripts</span></>} tags={["Recording & Logging"]}>
+
+Capture user and bot transcripts for later processing or storage.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/turn-management/turn-management-user-assistant-turns.py)
+
+</Update>
+
+<Update label={<><Icon icon="envelope" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Collect Emails</span></>} tags={["Recording & Logging"]}>
+
+Parse user email from the LLM response.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/features/features-user-email-gathering.py)
+
+</Update>
+
+<Update label={<><Icon icon="bug" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Debug with an Observer</span></>} tags={["Debugging"]}>
+
+Learn how to debug your Pipecat bot with an Observer by observing frames flowing through the pipeline.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/observability/observability-observer.py)
+
+</Update>
+
+<Update label={<><Icon icon="wave-square" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Pipeline Heartbeats</span></>} tags={["Debugging"]}>
+
+Enable heartbeat frames to detect a stalled or blocked pipeline in production.
+
+[View Recipe →](https://github.com/pipecat-ai/pipecat/blob/main/examples/observability/observability-heartbeats.py)
+
+</Update>
+
+<Update label={<><Icon icon="monitor-waveform" size={16} color="currentColor" /><span style={{marginLeft: '8px'}}>Live Debugger (Whisker)</span></>} tags={["Debugging"]}>
+
+A live graphical debugger for the Pipecat voice and multimodal conversational AI framework. It lets you visualize pipelines and debug frames in real time — so you can see exactly what your bot is thinking and doing.
+
+[View Recipe →](https://github.com/pipecat-ai/whisker)
 
 </Update>
 


### PR DESCRIPTION
## Summary

The recipes page hadn't had a content change since April 2026 (the August commit was a site-wide metadata pass), while `pipecat/examples/` gained ~100 new files in that window. Every link already on both pages still resolves — I checked all 47 against GitHub — so the drift was omission, not rot.

## Changes

**`recipes.mdx`: 19 → 41 recipes**, now grouped under headings since a flat list of 41 is hard to scan. Whole categories were missing:

- Context and memory — summarization, persistent context, RAG, Mem0
- Reasoning models, direct functions, async function calls, web search
- Voice formatting, custom text transforms, mid-response voice switching, runtime service settings
- Filtering incomplete turns, custom turn-stop strategies
- DTMF keypad menus, live translation, custom video tracks
- Pipeline reliability — `ServiceSwitcher`, `is_usable`, `app_resources`, heartbeats

Existing entries keep their text and links verbatim.

**`overview.mdx`: +8 single-agent, +8 multi-agent.** The multi-agent gap was the biggest — the whole `ui-worker/` suite (6 examples) plus `sensor-controller` and `openclaw-agent` landed after that section was written. New single-agent entries: Instant Voice, Speculative Inference, SMS Verification, PhoneLLM, AWS Strands, Bedrock AgentCore, Multi-Language Translation, S3 audio recording.

Descriptions are drawn from the examples' own docstrings and READMEs, not guessed from filenames.

## Verification

- `mint broken-links --check-anchors --check-redirects` — passes
- `docs-meta-lint.mjs` — 0 errors (188 warnings, unchanged from baseline)
- `llms.txt` / `llms-full.txt` regenerated
- Prettier clean

## Notes for review

- **Curated, not exhaustive.** `function-calling/` alone has 40+ provider variants and `voice/` has 60+; listing them individually would bury the techniques, so those directories stay behind the "More Recipes" card. Also skipped `features-add-tool-change-messages.py`, which describes itself as a manual validation harness rather than a recipe.
- **Unrelated Prettier drift left alone.** `npm run format` also reformats a table in `pipecat-cloud/guides/telephony/daily-dial-out.mdx`. I reverted that to keep this diff focused, so it's still un-clean on `main` — contrary to CLAUDE.md, `npm run format` is not currently a no-op on a clean tree.
- **`llms.txt` is over its cap** at 100,086 / 100,000 (warning, not error). Verified via `git stash` that this is identical before and after — the projection is driven by nav page titles and descriptions, which this PR doesn't touch. Needs attention on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrQCYMWzMeLo6y4BpeuFEN