### PR TITLE
Add MemorySync memory service (community integration)

### DIFF
--- a/api-reference/server/services/memory/memorysync.mdx
+++ b/api-reference/server/services/memory/memorysync.mdx
@@ -1,0 +1,159 @@
+﻿---
+title: "MemorySync Memory"
+sidebarTitle: "MemorySync"
+description: "The pipecat-memorysync integration gives Pipecat voice agents long-term, cross-session memory backed by MemorySync â€” budgeted recall that never stalls a reply."
+---
+
+import { CommunityMaintained } from "/snippets/community-maintained.mdx";
+
+<CommunityMaintained
+  maintainer="MemorySync"
+  maintainerUrl="https://github.com/memorysyncio"
+  repo="https://github.com/memorysyncio/memorysync-pipecat"
+/>
+
+## Overview
+
+The `pipecat-memorysync` integration connects
+[MemorySync](https://memorysync.io), a managed long-term memory layer, to
+Pipecat voice pipelines. It ships one `FrameProcessor`:
+`MemorySyncMemoryService` sits between the user context aggregator and the LLM
+service, enriches every `LLMContextFrame` with relevant memories under a hard
+time budget (default 1.2 s), and mines the same frames for new turns to
+persist in the background â€” so the frame is always pushed on time, enriched or
+not. Capture is delta-only with deterministic idempotency seeds, and the
+injected memory block is excluded from capture, so recalled context never
+re-enters storage.
+
+<CardGroup cols={2}>
+  <Card
+    title="Source Repository"
+    icon="github"
+    href="https://github.com/memorysyncio/memorysync-pipecat"
+  >
+    Source code, foundational example, and issues for the Pipecat integration
+  </Card>
+  <Card
+    title="Documentation"
+    icon="book"
+    href="https://docs.memorysync.io/guides/pipecat"
+  >
+    Full MemorySync guide for Pipecat pipelines
+  </Card>
+  <Card title="Website" icon="globe" href="https://memorysync.io">
+    Learn more about MemorySync
+  </Card>
+  <Card title="Dashboard" icon="key" href="https://app.memorysync.io">
+    Manage your MemorySync account and API keys
+  </Card>
+</CardGroup>
+
+## Installation
+
+This is a community-maintained package distributed separately from `pipecat-ai`:
+
+```bash
+uv add pipecat-memorysync
+```
+
+Requires `pipecat-ai>=1.0.0` and Python 3.10+.
+
+## Prerequisites
+
+### MemorySync Account Setup
+
+Before using the MemorySync integration, you need:
+
+1. **MemorySync API Key**: Get one at
+   [app.memorysync.io](https://app.memorysync.io)
+2. Set it as the `MEMORYSYNC_API_KEY` environment variable, or pass it as the
+   `api_key` constructor argument.
+
+## Configuration
+
+### `MemorySyncMemoryService`
+
+Inserted **after** the user context aggregator and **before** the LLM service.
+On each `LLMContextFrame`, fetches user-scoped memories from MemorySync under
+a hard budget and appends them as a system message to the context, then
+persists any new turns in the background.
+
+<ParamField path="user_id" type="str" required>
+  Required â€” MemorySync memory is user-scoped. Use a stable end-user id.
+</ParamField>
+
+<ParamField path="api_key" type="str" default="None">
+  MemorySync API key. Falls back to the `MEMORYSYNC_API_KEY` environment
+  variable.
+</ParamField>
+
+<ParamField path="session_id" type="str" default="None">
+  Stable id for this call, used to scope the conversation transcript.
+  Auto-generated per service lifetime when absent.
+</ParamField>
+
+<ParamField path="params" type="InputParams" default="InputParams()">
+  Runtime tuning, see below.
+</ParamField>
+
+### `InputParams`
+
+<ParamField path="top_k" type="int" default="5">
+  Memories injected per turn.
+</ParamField>
+
+<ParamField path="recall_timeout" type="float" default="1.2">
+  Hard recall budget in seconds. On timeout the frame proceeds unenriched â€”
+  a slow memory backend can never stall a voice reply.
+</ParamField>
+
+<ParamField path="add_as_system_message" type="bool" default="True">
+  Inject the memory block as a `system` message (else it is appended to the
+  latest user message).
+</ParamField>
+
+<ParamField path="position" type="str" default='"end"'>
+  Where the memory block lands in the message list (`"start"` or `"end"`).
+</ParamField>
+
+<ParamField path="min_prompt_chars" type="int" default="8">
+  Skip recall for user prompts shorter than this.
+</ParamField>
+
+## Usage
+
+```python
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat_memorysync import MemorySyncMemoryService
+
+memory = MemorySyncMemoryService(
+    api_key="ms_...",       # or MEMORYSYNC_API_KEY env var
+    user_id="caller-42",    # stable end-user id
+    session_id="call-123",  # optional: scope to this call
+)
+
+pipeline = Pipeline([
+    transport.input(),
+    stt,
+    context_aggregator.user(),
+    memory,   # enrich with memories + capture new turns, on budget
+    llm,
+    tts,
+    transport.output(),
+    context_aggregator.assistant(),
+])
+```
+
+<Note>
+  Reads and writes both degrade gracefully â€” HTTP errors, quota limits, and
+  timeouts all result in "no memories this turn" and nothing propagates into
+  the pipeline. On `EndFrame`, queued writes get a bounded window to land so
+  the call's final exchange is never lost.
+</Note>
+
+## Compatibility
+
+The integration requires `pipecat-ai>=1.0.0` (tested with Pipecat v1.8.1,
+through `pipecat.tests.utils.run_test` â€” the framework's own harness). Check
+the [source repository](https://github.com/memorysyncio/memorysync-pipecat)
+for the latest tested version and changelog.

--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -121,6 +121,7 @@ Memory services can be used to store and retrieve conversations.
 | Service                                              | Setup                          | Maintainer |
 | ---------------------------------------------------- | ------------------------------ | ---------- |
 | [mem0](/api-reference/server/services/memory/mem0)   | `uv add "pipecat-ai[mem0]"`    | Pipecat    |
+| [MemorySync](/api-reference/server/services/memory/memorysync) | `uv add pipecat-memorysync` | Community |
 | [Synap](/api-reference/server/services/memory/synap) | `uv add maximem-synap-pipecat` | Community  |
 
 ## Realtime LLM

--- a/docs.json
+++ b/docs.json
@@ -524,6 +524,7 @@
                     "group": "Memory",
                     "pages": [
                       "api-reference/server/services/memory/mem0",
+                      "api-reference/server/services/memory/memorysync",
                       "api-reference/server/services/memory/synap"
                     ]
                   },
@@ -1699,6 +1700,10 @@
     {
       "source": "/server/services/llm/simplismart",
       "destination": "/api-reference/server/services/llm/simplismart"
+    },
+    {
+      "source": "/server/services/memory/memorysync",
+      "destination": "/api-reference/server/services/memory/memorysync"
     },
     {
       "source": "/server/services/memory/synap",


### PR DESCRIPTION
## What

Adds **MemorySync** as a community-maintained memory service, following the [Community Integrations Guide](https://github.com/pipecat-ai/pipecat/blob/main/COMMUNITY_INTEGRATIONS.md):

- **Supported Services row** — `Memory` table: `MemorySync` · `uv add pipecat-memorysync` · `Community`
- **Service page** — `api-reference/server/services/memory/memorysync.mdx` (community-maintained badge via the shared snippet, overview, installation, prerequisites, configuration, usage, compatibility)
- **Navigation + redirect** — `docs.json` entry under the `Memory` group and a `/server/services/memory/memorysync` redirect, following the existing pattern

## About the integration

[`memorysync-pipecat`](https://github.com/memorysyncio/memorysync-pipecat) (PyPI package [`pipecat-memorysync`](https://pypi.org/project/pipecat-memorysync/)) ships one `FrameProcessor`, `MemorySyncMemoryService`, for the position between the user context aggregator and the LLM service:

- Budgeted recall (default 1.2 s hard timeout) injected as a guarded system message — a slow or unreachable memory backend degrades to an unenriched frame, never a stalled voice reply
- Delta-only capture with deterministic idempotency seeds (no re-storing the whole context each turn)
- Injection exclusion (recalled context is never captured back), graceful `EndFrame` flush, `CancelFrame` salvage
- Tested with Pipecat v1.8.1 through `pipecat.tests.utils.run_test` — the framework's own harness (14-test suite in the repo)

The source repository includes the foundational single-file example, README (install, usage, example run, version compatibility, company attribution), MIT LICENSE, and CHANGELOG per the guide's repository requirements. Built and maintained by the MemorySync team.

## Demo video

Core functionality + interruption handling: connect → share facts → interrupt the bot mid-reply → disconnect → reconnect in a fresh session → the bot recalls the stored facts.

https://github.com/user-attachments/assets/ea187075-c46d-4ead-bb34-affaa58f1635
