### PR TITLE
docs: context summarization fires every turn with a large system prompt (T-3682)

### DIFF
--- a/api-reference/server/utilities/context-summarization.mdx
+++ b/api-reference/server/utilities/context-summarization.mdx
@@ -51,7 +51,14 @@ Controls when automatic context summarization triggers.
   Maximum context size in estimated tokens before triggering summarization.
   Tokens are estimated using the heuristic of 1 token per 4 characters. Set to
   `None` to disable token-based triggering. At least one of `max_context_tokens`
-  or `max_unsummarized_messages` must be set.
+  or `max_unsummarized_messages` must be set. The estimate counts every message
+  in the context, including the system message at `messages[0]`, which is
+  preserved and never summarized. Set this value above your system prompt size
+  plus the history you want to keep. If your system prompt alone is close to or
+  above this value, the trigger stays true after every summary, so summarization
+  runs on every turn and never brings the total back under the limit. In that
+  case, raise this value or leave automatic summarization off and trigger it
+  yourself with `LLMSummarizeContextFrame`.
 </ParamField>
 
 <ParamField path="max_unsummarized_messages" type="int | None" default="20">

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4019,6 +4019,16 @@ user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
 )
 ```
 
+<Warning>
+  If you keep your system prompt in the context as `messages[0]`, its tokens
+  count toward the `max_context_tokens` trigger, even though that message is
+  preserved and never summarized. A system prompt that is close to or above
+  `max_context_tokens` (8000 by default) keeps the trigger true, so
+  summarization runs on every turn with no benefit. Raise `max_context_tokens`
+  above your system prompt size plus the history you want to keep, or leave
+  automatic summarization off and trigger it yourself.
+</Warning>
+
 <Card
   title="Context Summarization Guide"
   icon="arrow-right"
@@ -8255,6 +8265,20 @@ Context summarization automatically triggers when **either** condition is met:
 
 You can disable either threshold by setting it to `None`, but at least one must remain active. Summarization always generates a summary and cannot be reduced to pure truncation.
 
+<Warning>
+  **A large system prompt can make summarization run on every turn.** The token
+  count adds up every message in the context, including the system message at
+  `messages[0]`. That system message is never summarized, so its tokens never go
+  away. If your system prompt on its own is close to or above
+  `max_context_tokens`, the token trigger stays true after every summary. The
+  bot then makes an extra summarization LLM call on every turn and never gets
+  back under the limit. To avoid this, set `max_context_tokens` above your
+  system prompt size plus the history you want to keep (for a 24,000 token
+  system prompt and a 6,000 token history budget, use
+  `max_context_tokens=30000`), or leave automatic summarization off and run it
+  yourself with [on-demand summarization](#on-demand-summarization).
+</Warning>
+
 When triggered, the system:
 
 1. Sends a `LLMContextSummaryRequestFrame` to the LLM service
@@ -8321,7 +8345,7 @@ See the [reference page](/api-reference/server/utilities/context-summarization) 
 
 Context summarization intelligently preserves:
 
-- **System messages**: If the first message (`messages[0]`) is a system message, it is preserved as the initial system prompt. Mid-conversation system messages (e.g., idle notifications or context injections) are treated as regular messages and included in the summarization range. When using [`system_instruction`](/pipecat/learn/context-management#using-system_instruction-recommended) in LLM Settings instead, the system prompt is not part of the context messages and is automatically prepended by the service on each request, so there is nothing to preserve in the context.
+- **System messages**: If the first message (`messages[0]`) is a system message, it is preserved as the initial system prompt. Its tokens still count toward the `max_context_tokens` trigger even though it is never summarized. Mid-conversation system messages (e.g., idle notifications or context injections) are treated as regular messages and included in the summarization range. When using [`system_instruction`](/pipecat/learn/context-management#using-system_instruction-recommended) in LLM Settings instead, the system prompt is not part of the context messages and is automatically prepended by the service on each request, so there is nothing to preserve in the context.
 - **Recent messages**: The last N messages stay uncompressed (configured by `min_messages_after_summary`)
 - **Function call sequences**: Incomplete function call/result pairs are not split during summarization
 - **Developer messages are NOT preserved**: Developer messages (`"role": "developer"`) are included in the summarization range like any other message and may be compressed or dropped. If instructions need to survive summarization, use [`system_instruction`](/pipecat/learn/context-management#using-system_instruction-recommended) instead.
@@ -31048,6 +31072,7 @@ Memory services can be used to store and retrieve conversations.
 | Service                                              | Setup                          | Maintainer |
 | ---------------------------------------------------- | ------------------------------ | ---------- |
 | [mem0](/api-reference/server/services/memory/mem0)   | `uv add "pipecat-ai[mem0]"`    | Pipecat    |
+| [MemorySync](/api-reference/server/services/memory/memorysync) | `uv add pipecat-memorysync` | Community |
 | [Synap](/api-reference/server/services/memory/synap) | `uv add maximem-synap-pipecat` | Community  |
 
 ## Realtime LLM
@@ -64153,6 +64178,162 @@ else:
 - **Non-blocking operation**: All Mem0 API calls (storage, retrieval, search) run in background threads to avoid blocking the event loop. Message storage is fire-and-forget, so it doesn't delay downstream processing.
 - **Message role filtering**: Only messages with `user` or `assistant` roles are stored in Mem0. Messages with other roles (such as `system` or `developer`) are automatically filtered out, as the Mem0 API does not accept them.
 
+# undefined
+Source: https://docs.pipecat.ai/api-reference/server/services/memory/memorysync.md
+
+---
+title: "MemorySync Memory"
+sidebarTitle: "MemorySync"
+description: "The pipecat-memorysync integration gives Pipecat voice agents long-term, cross-session memory backed by MemorySync â€” budgeted recall that never stalls a reply."
+---
+
+
+## Overview
+
+The `pipecat-memorysync` integration connects
+[MemorySync](https://memorysync.io), a managed long-term memory layer, to
+Pipecat voice pipelines. It ships one `FrameProcessor`:
+`MemorySyncMemoryService` sits between the user context aggregator and the LLM
+service, enriches every `LLMContextFrame` with relevant memories under a hard
+time budget (default 1.2 s), and mines the same frames for new turns to
+persist in the background â€” so the frame is always pushed on time, enriched or
+not. Capture is delta-only with deterministic idempotency seeds, and the
+injected memory block is excluded from capture, so recalled context never
+re-enters storage.
+
+<CardGroup cols={2}>
+  <Card
+    title="Source Repository"
+    icon="github"
+    href="https://github.com/memorysyncio/memorysync-pipecat"
+  >
+    Source code, foundational example, and issues for the Pipecat integration
+  </Card>
+  <Card
+    title="Documentation"
+    icon="book"
+    href="https://docs.memorysync.io/guides/pipecat"
+  >
+    Full MemorySync guide for Pipecat pipelines
+  </Card>
+  <Card title="Website" icon="globe" href="https://memorysync.io">
+    Learn more about MemorySync
+  </Card>
+  <Card title="Dashboard" icon="key" href="https://app.memorysync.io">
+    Manage your MemorySync account and API keys
+  </Card>
+</CardGroup>
+
+## Installation
+
+This is a community-maintained package distributed separately from `pipecat-ai`:
+
+```bash
+uv add pipecat-memorysync
+```
+
+Requires `pipecat-ai>=1.0.0` and Python 3.10+.
+
+## Prerequisites
+
+### MemorySync Account Setup
+
+Before using the MemorySync integration, you need:
+
+1. **MemorySync API Key**: Get one at
+   [app.memorysync.io](https://app.memorysync.io)
+2. Set it as the `MEMORYSYNC_API_KEY` environment variable, or pass it as the
+   `api_key` constructor argument.
+
+## Configuration
+
+### `MemorySyncMemoryService`
+
+Inserted **after** the user context aggregator and **before** the LLM service.
+On each `LLMContextFrame`, fetches user-scoped memories from MemorySync under
+a hard budget and appends them as a system message to the context, then
+persists any new turns in the background.
+
+<ParamField path="user_id" type="str" required>
+  Required â€” MemorySync memory is user-scoped. Use a stable end-user id.
+</ParamField>
+
+<ParamField path="api_key" type="str" default="None">
+  MemorySync API key. Falls back to the `MEMORYSYNC_API_KEY` environment
+  variable.
+</ParamField>
+
+<ParamField path="session_id" type="str" default="None">
+  Stable id for this call, used to scope the conversation transcript.
+  Auto-generated per service lifetime when absent.
+</ParamField>
+
+<ParamField path="params" type="InputParams" default="InputParams()">
+  Runtime tuning, see below.
+</ParamField>
+
+### `InputParams`
+
+<ParamField path="top_k" type="int" default="5">
+  Memories injected per turn.
+</ParamField>
+
+<ParamField path="recall_timeout" type="float" default="1.2">
+  Hard recall budget in seconds. On timeout the frame proceeds unenriched â€”
+  a slow memory backend can never stall a voice reply.
+</ParamField>
+
+<ParamField path="add_as_system_message" type="bool" default="True">
+  Inject the memory block as a `system` message (else it is appended to the
+  latest user message).
+</ParamField>
+
+<ParamField path="position" type="str" default='"end"'>
+  Where the memory block lands in the message list (`"start"` or `"end"`).
+</ParamField>
+
+<ParamField path="min_prompt_chars" type="int" default="8">
+  Skip recall for user prompts shorter than this.
+</ParamField>
+
+## Usage
+
+```python
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat_memorysync import MemorySyncMemoryService
+
+memory = MemorySyncMemoryService(
+    api_key="ms_...",       # or MEMORYSYNC_API_KEY env var
+    user_id="caller-42",    # stable end-user id
+    session_id="call-123",  # optional: scope to this call
+)
+
+pipeline = Pipeline([
+    transport.input(),
+    stt,
+    context_aggregator.user(),
+    memory,   # enrich with memories + capture new turns, on budget
+    llm,
+    tts,
+    transport.output(),
+    context_aggregator.assistant(),
+])
+```
+
+<Note>
+  Reads and writes both degrade gracefully â€” HTTP errors, quota limits, and
+  timeouts all result in "no memories this turn" and nothing propagates into
+  the pipeline. On `EndFrame`, queued writes get a bounded window to land so
+  the call's final exchange is never lost.
+</Note>
+
+## Compatibility
+
+The integration requires `pipecat-ai>=1.0.0` (tested with Pipecat v1.8.1,
+through `pipecat.tests.utils.run_test` â€” the framework's own harness). Check
+the [source repository](https://github.com/memorysyncio/memorysync-pipecat)
+for the latest tested version and changelog.
+
 # Synap Memory
 Source: https://docs.pipecat.ai/api-reference/server/services/memory/synap.md
 
@@ -69239,7 +69420,14 @@ Controls when automatic context summarization triggers.
   Maximum context size in estimated tokens before triggering summarization.
   Tokens are estimated using the heuristic of 1 token per 4 characters. Set to
   `None` to disable token-based triggering. At least one of `max_context_tokens`
-  or `max_unsummarized_messages` must be set.
+  or `max_unsummarized_messages` must be set. The estimate counts every message
+  in the context, including the system message at `messages[0]`, which is
+  preserved and never summarized. Set this value above your system prompt size
+  plus the history you want to keep. If your system prompt alone is close to or
+  above this value, the trigger stays true after every summary, so summarization
+  runs on every turn and never brings the total back under the limit. In that
+  case, raise this value or leave automatic summarization off and trigger it
+  yourself with `LLMSummarizeContextFrame`.
 </ParamField>
 
 <ParamField path="max_unsummarized_messages" type="int | None" default="20">

--- a/llms.txt
+++ b/llms.txt
@@ -455,6 +455,7 @@ LLM, transports, serializers), pipelines, frames, workers, and utilities.
 ##### Memory
 
 - [Mem0 Long-Term Memory](https://docs.pipecat.ai/api-reference/server/services/memory/mem0.md): Mem0MemoryService adds long-term conversation memory to Pipecat agents, recalling context across sessions with Mem0.
+- [undefined](https://docs.pipecat.ai/api-reference/server/services/memory/memorysync.md)
 - [Synap Memory](https://docs.pipecat.ai/api-reference/server/services/memory/synap.md): The synap-pipecat integration gives Pipecat voice agents persistent, cross-session memory backed by Synap.
 
 ##### Vision

--- a/pipecat/fundamentals/context-summarization.mdx
+++ b/pipecat/fundamentals/context-summarization.mdx
@@ -16,6 +16,20 @@ Context summarization automatically triggers when **either** condition is met:
 
 You can disable either threshold by setting it to `None`, but at least one must remain active. Summarization always generates a summary and cannot be reduced to pure truncation.
 
+<Warning>
+  **A large system prompt can make summarization run on every turn.** The token
+  count adds up every message in the context, including the system message at
+  `messages[0]`. That system message is never summarized, so its tokens never go
+  away. If your system prompt on its own is close to or above
+  `max_context_tokens`, the token trigger stays true after every summary. The
+  bot then makes an extra summarization LLM call on every turn and never gets
+  back under the limit. To avoid this, set `max_context_tokens` above your
+  system prompt size plus the history you want to keep (for a 24,000 token
+  system prompt and a 6,000 token history budget, use
+  `max_context_tokens=30000`), or leave automatic summarization off and run it
+  yourself with [on-demand summarization](#on-demand-summarization).
+</Warning>
+
 When triggered, the system:
 
 1. Sends a `LLMContextSummaryRequestFrame` to the LLM service
@@ -82,7 +96,7 @@ See the [reference page](/api-reference/server/utilities/context-summarization) 
 
 Context summarization intelligently preserves:
 
-- **System messages**: If the first message (`messages[0]`) is a system message, it is preserved as the initial system prompt. Mid-conversation system messages (e.g., idle notifications or context injections) are treated as regular messages and included in the summarization range. When using [`system_instruction`](/pipecat/learn/context-management#using-system_instruction-recommended) in LLM Settings instead, the system prompt is not part of the context messages and is automatically prepended by the service on each request, so there is nothing to preserve in the context.
+- **System messages**: If the first message (`messages[0]`) is a system message, it is preserved as the initial system prompt. Its tokens still count toward the `max_context_tokens` trigger even though it is never summarized. Mid-conversation system messages (e.g., idle notifications or context injections) are treated as regular messages and included in the summarization range. When using [`system_instruction`](/pipecat/learn/context-management#using-system_instruction-recommended) in LLM Settings instead, the system prompt is not part of the context messages and is automatically prepended by the service on each request, so there is nothing to preserve in the context.
 - **Recent messages**: The last N messages stay uncompressed (configured by `min_messages_after_summary`)
 - **Function call sequences**: Incomplete function call/result pairs are not split during summarization
 - **Developer messages are NOT preserved**: Developer messages (`"role": "developer"`) are included in the summarization range like any other message and may be compressed or dropped. If instructions need to survive summarization, use [`system_instruction`](/pipecat/learn/context-management#using-system_instruction-recommended) instead.

--- a/pipecat/learn/context-management.mdx
+++ b/pipecat/learn/context-management.mdx
@@ -296,6 +296,16 @@ user_aggregator, assistant_aggregator = LLMContextAggregatorPair(
 )
 ```
 
+<Warning>
+  If you keep your system prompt in the context as `messages[0]`, its tokens
+  count toward the `max_context_tokens` trigger, even though that message is
+  preserved and never summarized. A system prompt that is close to or above
+  `max_context_tokens` (8000 by default) keeps the trigger true, so
+  summarization runs on every turn with no benefit. Raise `max_context_tokens`
+  above your system prompt size plus the history you want to keep, or leave
+  automatic summarization off and trigger it yourself.
+</Warning>
+
 <Card
   title="Context Summarization Guide"
   icon="arrow-right"


### PR DESCRIPTION
## What

A customer had a 24k token system prompt and the default `max_context_tokens=8000`, so context summarization ran on every single bot turn and never helped.

## The gap

Two behaviors are each documented on their own, but the interaction between them is not:

1. The initial system message at `messages[0]` is preserved and excluded from summarization.
2. The auto-trigger token estimate counts every message in the context, system message included.

So when the system prompt alone is near or above `max_context_tokens`, the trigger condition is permanently true. Every bot turn fires a summarization LLM call, and the total can never drop back under the threshold, because the part that is over the threshold is the exact part summarization will not touch.

Verified against `pipecat` main (`src/pipecat/utils/context/llm_context_summarization.py` and `src/pipecat/processors/aggregators/llm_context_summarizer.py`).

## What changed

A short customer-facing warning on the three pages where a reader would look:

- `pipecat/fundamentals/context-summarization.mdx`: warning in **How It Works**, plus one clause in **What Gets Preserved**.
- `pipecat/learn/context-management.mdx`: warning in the **Context Summarization** section.
- `api-reference/server/utilities/context-summarization.mdx`: added to the `max_context_tokens` param description.

Each says the same two fixes: raise `max_context_tokens` above (system prompt + intended history budget), or leave auto summarization off and drive it on demand.

## Note on llms.txt

`llms.txt` and `llms-full.txt` were regenerated per CLAUDE.md. The regen also picks up a `memorysync` page that was already stale on main before this branch, so part of that diff is not mine.

Draft on purpose. Not for merge without review.