### PR TITLE
docs: link concurrency increase request form

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -25672,8 +25672,10 @@ See [Scaling](./scaling) for more on how the pool grows, and [Capacity Planning]
 
 <Warning>
   The default instance pool capacity is **50 active sessions per deployment**.
-  Please contact us at help@daily.co or via
-  [Discord](https://discord.gg/dailyco) if you require more capacity.
+  If you require more capacity, fill out the [concurrency increase request
+  form](https://docs.google.com/forms/d/e/1FAIpQLSffPYOsJQ_FWun5wh7dHCLbbaSrEjiRCPnfdBe_KefdGWaDqQ/viewform).
+  You can also reach us at help@daily.co or via
+  [Discord](https://discord.gg/dailyco).
 </Warning>
 
 Developers are responsible for handling capacity errors when starting sessions. When your instance pool is at capacity, the start request will fail with a `429` status and code.
@@ -26172,8 +26174,10 @@ pipecat cloud deploy [agent-name] --min-agents 1
 
 <Note>
   Each deployment made to Pipecat Cloud has a maximum allowed pool size of 50.
-  Please contact us at help@daily.co or via
-  [Discord](https://discord.gg/dailyco) if you require more capacity.
+  If you require more capacity, fill out the [concurrency increase request
+  form](https://docs.google.com/forms/d/e/1FAIpQLSffPYOsJQ_FWun5wh7dHCLbbaSrEjiRCPnfdBe_KefdGWaDqQ/viewform).
+  You can also reach us at help@daily.co or via
+  [Discord](https://discord.gg/dailyco).
 </Note>
 
 Deployments can optionally be made with a `max-agents` configuration that limits the number of agent instances that your pool can contain.
@@ -26649,6 +26653,8 @@ Indicates an error in your image that prevent your agent from starting. Typicall
 > Service maximum agent instances reached
 
 This error indicates that the maximum active sessions for your deployment have been reached. You can either increase the maximum active sessions for your deployment (`max-agents`), or place the end-user in a queue until a session becomes available.
+
+If you are already at the default pool ceiling of 50 active sessions, fill out the [concurrency increase request form](https://docs.google.com/forms/d/e/1FAIpQLSffPYOsJQ_FWun5wh7dHCLbbaSrEjiRCPnfdBe_KefdGWaDqQ/viewform) to raise it.
 
 ### Deploy rejected — secret set not ready (HTTP 409)
 

--- a/pipecat-cloud/fundamentals/active-sessions.mdx
+++ b/pipecat-cloud/fundamentals/active-sessions.mdx
@@ -253,8 +253,10 @@ See [Scaling](./scaling) for more on how the pool grows, and [Capacity Planning]
 
 <Warning>
   The default instance pool capacity is **50 active sessions per deployment**.
-  Please contact us at help@daily.co or via
-  [Discord](https://discord.gg/dailyco) if you require more capacity.
+  If you require more capacity, fill out the [concurrency increase request
+  form](https://docs.google.com/forms/d/e/1FAIpQLSffPYOsJQ_FWun5wh7dHCLbbaSrEjiRCPnfdBe_KefdGWaDqQ/viewform).
+  You can also reach us at help@daily.co or via
+  [Discord](https://discord.gg/dailyco).
 </Warning>
 
 Developers are responsible for handling capacity errors when starting sessions. When your instance pool is at capacity, the start request will fail with a `429` status and code.

--- a/pipecat-cloud/fundamentals/error-codes.mdx
+++ b/pipecat-cloud/fundamentals/error-codes.mdx
@@ -70,6 +70,8 @@ Indicates an error in your image that prevent your agent from starting. Typicall
 
 This error indicates that the maximum active sessions for your deployment have been reached. You can either increase the maximum active sessions for your deployment (`max-agents`), or place the end-user in a queue until a session becomes available.
 
+If you are already at the default pool ceiling of 50 active sessions, fill out the [concurrency increase request form](https://docs.google.com/forms/d/e/1FAIpQLSffPYOsJQ_FWun5wh7dHCLbbaSrEjiRCPnfdBe_KefdGWaDqQ/viewform) to raise it.
+
 ### Deploy rejected — secret set not ready (HTTP 409)
 
 > `Secret set 'my-agent-secrets' is not yet ready. Retry once it has been provisioned.`

--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -86,8 +86,10 @@ pipecat cloud deploy [agent-name] --min-agents 1
 
 <Note>
   Each deployment made to Pipecat Cloud has a maximum allowed pool size of 50.
-  Please contact us at help@daily.co or via
-  [Discord](https://discord.gg/dailyco) if you require more capacity.
+  If you require more capacity, fill out the [concurrency increase request
+  form](https://docs.google.com/forms/d/e/1FAIpQLSffPYOsJQ_FWun5wh7dHCLbbaSrEjiRCPnfdBe_KefdGWaDqQ/viewform).
+  You can also reach us at help@daily.co or via
+  [Discord](https://discord.gg/dailyco).
 </Note>
 
 Deployments can optionally be made with a `max-agents` configuration that limits the number of agent instances that your pool can contain.


### PR DESCRIPTION
## Summary

Pipecat Cloud deployments default to a ceiling of **50 active sessions**. The docs mentioned this in three places but only offered email or Discord as the way to ask for more. This adds the concurrency increase request [Google Form](https://docs.google.com/forms/d/e/1FAIpQLSffPYOsJQ_FWun5wh7dHCLbbaSrEjiRCPnfdBe_KefdGWaDqQ/viewform) as the primary path in each.

## Changes

| Page | Location |
| --- | --- |
| `pipecat-cloud/fundamentals/active-sessions.mdx` | "Agent capacity" `<Warning>` |
| `pipecat-cloud/fundamentals/scaling.mdx` | `max-agents` `<Note>` |
| `pipecat-cloud/fundamentals/error-codes.mdx` | New line under `PCC-AGENT-AT-CAPACITY` |

`help@daily.co` and Discord remain as secondary contacts. Wording follows the existing dial-out request form precedent in `pipecat-cloud/guides/telephony/daily-dial-out.mdx`.

`llms-full.txt` is regenerated; `llms.txt` is unchanged since no titles or descriptions moved.

## Testing

- `npm run format` — clean
- `node scripts/gen-llms-txt.mjs` — regenerated, checked in
- `npx mint broken-links --check-anchors --check-redirects` — no broken links
- `node scripts/docs-meta-lint.mjs` — no new findings. Two pre-existing issues unrelated to this PR: the missing `api-reference/server/services/memory/memorysync.mdx` nav entry, and the projected llms.txt size (100,325) sitting just over the 100,000 cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M9trFcQPiuDUoK8GXGRZF