### PR TITLE
docs: fix Rime PRONOUNCE example and add bulk pronunciation lexicon guidance (T-3868)

### DIFF
--- a/api-reference/server/services/tts/rime.mdx
+++ b/api-reference/server/services/tts/rime.mdx
@@ -348,9 +348,7 @@ tts = RimeTTSService(
 
 ### PRONOUNCE(text: str, word: str, phoneme: str) -> str
 
-Convenience method to support Rime's [custom pronunciations feature](https://docs.rime.ai/api-reference/custom-pronunciation). It takes a word and its desired phoneme representation, returning the text with the provided word replaced by the appropriate phoneme tag.
-
-Unlike `SPELL` and `PAUSE_TAG`, call this method **on the service instance**, not on the class. It also takes three arguments, so it does not match the `(text, aggregation_type)` shape a text transform needs. Wrap it in a small function, the same way the examples above do.
+Instance method that implements Rime's [custom pronunciations feature](https://docs.rime.ai/api-reference/custom-pronunciation). It replaces `word` in `text` with the phoneme tag. Unlike `SPELL` and `PAUSE_TAG`, call it on the service instance, not on the class. Its three arguments do not match the `(text, aggregation_type)` transform shape, so wrap it in a function.
 
 ```python
 tts = RimeTTSService(
@@ -370,28 +368,24 @@ async def maybe_say_potato_all_fancylike(text: str, type: str) -> str:
     else:
         return tts.PRONOUNCE(text, "potato", "poteto")
 
-# Register the transform on the instance you just created
 tts.add_text_transformer(maybe_say_potato_all_fancylike, "*")  # Apply to all text
 ```
 
 <Note>
-  Calling `PRONOUNCE` switches on Rime's bracket phonemization for the next
-  message only. If any message in the session can contain a phoneme, set
-  `phonemizeBetweenBrackets=True` in `Settings` as shown above so the option
-  stays on for the whole session.
+  `PRONOUNCE` turns on bracket phonemization for the next message only. If any
+  message may contain a phoneme, set `phonemizeBetweenBrackets=True` in
+  `Settings` (as above) so it stays on for the whole session.
 </Note>
 
 <Tip>
-  `PRONOUNCE` handles one word at a time. If you need hundreds of pronunciation
-  overrides (medication names, product names, place names), use the
-  `replace_text` transform instead. See [Bulk pronunciation
-  overrides](/pipecat/learn/text-to-speech#bulk-pronunciation-overrides) in the
-  Text-to-Speech guide.
+  `PRONOUNCE` handles one word at a time. For hundreds of overrides, use the
+  `replace_text` transform. See [Bulk pronunciation
+  overrides](/pipecat/learn/text-to-speech#bulk-pronunciation-overrides).
 </Tip>
 
 ### INLINE_SPEED(text: str, speed: float) -> str
 
-A convenience method to support Rime's [inline speed adjustment feature](https://docs.rime.ai/api-reference/speed). It will wrap the provided text in the `[]` tags and add the provided speed to the `inlineSpeedAlpha` field in the request metadata. Like `PRONOUNCE`, call this method on the service instance, not on the class.
+Instance method that implements Rime's [inline speed adjustment feature](https://docs.rime.ai/api-reference/speed). It wraps `text` in `[]` and adds `speed` to the `inlineSpeedAlpha` request field. Like `PRONOUNCE`, call it on the service instance, not on the class.
 
 ```python
 tts = RimeTTSService(

--- a/api-reference/server/services/tts/rime.mdx
+++ b/api-reference/server/services/tts/rime.mdx
@@ -346,47 +346,67 @@ tts = RimeTTSService(
 )
 ```
 
-### PRONOUNCE(self, text: str, word: str, phoneme: str) -> str:
+### PRONOUNCE(text: str, word: str, phoneme: str) -> str
 
 Convenience method to support Rime's [custom pronunciations feature](https://docs.rime.ai/api-reference/custom-pronunciation). It takes a word and its desired phoneme representation, returning the text with the provided word replaced by the appropriate phoneme tag.
 
+Unlike `SPELL` and `PAUSE_TAG`, call this method **on the service instance**, not on the class. It also takes three arguments, so it does not match the `(text, aggregation_type)` shape a text transform needs. Wrap it in a small function, the same way the examples above do.
+
 ```python
+tts = RimeTTSService(
+    api_key=os.getenv("RIME_API_KEY"),
+    settings=RimeTTSService.Settings(
+        # Keep bracket phonemization on for the whole session
+        phonemizeBetweenBrackets=True,
+    ),
+)
+
 # Text transformers for TTS
-# This will a phoneme in place of the word "potato" to define how it
+# This puts a phoneme in place of the word "potato" to define how it
 # should be pronounced.
 async def maybe_say_potato_all_fancylike(text: str, type: str) -> str:
     if using_fancy_voice:
-        return RimeTTSService.PRONOUNCE(text, "potato", "potato")
+        return tts.PRONOUNCE(text, "potato", "potato")
     else:
-        return RimeTTSService.PRONOUNCE(text, "potato", "poteto")
+        return tts.PRONOUNCE(text, "potato", "poteto")
 
-tts = RimeTTSService(
-    api_key=os.getenv("RIME_API_KEY"),
-    text_transforms=[
-        ("*", maybe_say_potato_all_fancylike), # Apply to all text
-    ],
-)
+# Register the transform on the instance you just created
+tts.add_text_transformer(maybe_say_potato_all_fancylike, "*")  # Apply to all text
 ```
 
-### INLINE_SPEED(self, text: str, speed: float) -> str:
+<Note>
+  Calling `PRONOUNCE` switches on Rime's bracket phonemization for the next
+  message only. If any message in the session can contain a phoneme, set
+  `phonemizeBetweenBrackets=True` in `Settings` as shown above so the option
+  stays on for the whole session.
+</Note>
 
-A convenience method to support Rime's [inline speed adjustment feature](https://docs.rime.ai/api-reference/speed). It will wrap the provided text in the `[]` tags and add the provided speed to the `inlineSpeedAlpha` field in the request metadata.
+<Tip>
+  `PRONOUNCE` handles one word at a time. If you need hundreds of pronunciation
+  overrides (medication names, product names, place names), use the
+  `replace_text` transform instead. See [Bulk pronunciation
+  overrides](/pipecat/learn/text-to-speech#bulk-pronunciation-overrides) in the
+  Text-to-Speech guide.
+</Tip>
+
+### INLINE_SPEED(text: str, speed: float) -> str
+
+A convenience method to support Rime's [inline speed adjustment feature](https://docs.rime.ai/api-reference/speed). It will wrap the provided text in the `[]` tags and add the provided speed to the `inlineSpeedAlpha` field in the request metadata. Like `PRONOUNCE`, call this method on the service instance, not on the class.
 
 ```python
+tts = RimeTTSService(
+    api_key=os.getenv("RIME_API_KEY"),
+)
+
 # Text transformers for TTS
 # This will make the word slow always be spoken more slowly.
 async def slow_down_slow_words(text: str, type: str) -> str:
     return text.replace(
         "slow",
-        RimeTTSService.INLINE_SPEED("slow", speed=0.5)
+        tts.INLINE_SPEED("slow", speed=0.5)
     )
 
-tts = RimeTTSService(
-    api_key=os.getenv("RIME_API_KEY"),
-    text_transforms=[
-        ("*", slow_down_slow_words), # Apply to all text
-    ],
-)
+tts.add_text_transformer(slow_down_slow_words, "*")  # Apply to all text
 ```
 
 <Tip>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5260,11 +5260,11 @@ tts.add_text_transformer(replace_acronyms, "*")  # Apply to all text
 
 ### Bulk pronunciation overrides
 
-Some bots need a large pronunciation list: medication names, product names, drug brands, place names. Hundreds or even a thousand entries is normal. There are two ways to do this, and they are not equivalent.
+Some bots need hundreds of pronunciation overrides: medication names, product names, place names. There are two ways to do this.
 
 #### Client side with `replace_text`
 
-`replace_text` builds one transform from a list of `(pattern, replacement)` pairs. This is the portable option: it works with every TTS service, because the substitution happens in Pipecat before the text is ever sent.
+`replace_text` builds one transform from a list of `(pattern, replacement)` pairs. It works with every TTS service because the substitution happens in Pipecat before the text is sent.
 
 ```python
 from pipecat.utils.text.transforms import replace_text
@@ -5283,23 +5283,25 @@ tts = CartesiaTTSService(
 )
 ```
 
-The rules are regular expressions and they are compiled once when you build the transform, not on every chunk of text. Each chunk is then run through the list in order. Cost grows in a straight line with the number of rules and stays small: on an Apple silicon laptop, a 300 rule list added roughly 0.4 ms per sentence and a 1000 rule list roughly 1.4 ms. Treat those as an order of magnitude, not a guarantee. Your hardware and your patterns will move the number.
+Rules are regular expressions, compiled once. Each chunk of text runs through the list in order, so cost grows in a straight line with rule count and stays small: on an Apple silicon laptop, 300 rules added about 0.4 ms per sentence and 1000 rules about 1.4 ms. Your hardware and patterns will move those numbers.
 
-Two practical notes. Order matters, since rules are applied in sequence and an earlier replacement can change the text a later rule tries to match. And use word boundaries (`\b`) so that "cat" does not rewrite the middle of "catheter".
+Two tips:
+
+- Order matters. Rules run in sequence, so an earlier replacement can change what a later rule matches.
+- Use word boundaries (`\b`) so "cat" does not rewrite the middle of "catheter".
 
 <Warning>
   **Multi-word replacements need sentence aggregation.** Text transforms run
-  *after* text aggregation, so a transform only ever sees one aggregation at a
-  time. With `TextAggregationMode.TOKEN`, each piece of text is passed straight
-  through with no buffering, so a pattern that spans more than one word can
-  never match: the words arrive in separate calls. If your lexicon contains any
-  multi-word entry (`"beta blocker"`, `"St. John's wort"`), keep the default
-  sentence aggregation.
+  *after* text aggregation and see one aggregation at a time. With
+  `TextAggregationMode.TOKEN`, text passes straight through with no buffering,
+  so a pattern that spans more than one word never matches: the words arrive in
+  separate calls. If your lexicon has any multi-word entry (`"beta blocker"`,
+  `"St. John's wort"`), keep the default sentence aggregation.
 </Warning>
 
 #### Provider side lexicons
 
-Several services can host the lexicon themselves. This keeps the list out of your process, but ties you to that provider.
+Some services host the lexicon for you. This keeps the list out of your process but ties you to that provider.
 
 | Service        | Option                              | What it takes                                                        |
 | -------------- | ----------------------------------- | -------------------------------------------------------------------- |
@@ -5311,22 +5313,18 @@ Several services can host the lexicon themselves. This keeps the list out of you
 
 <Warning>
   **NVIDIA `custom_dictionary` entries cannot contain commas.** The dictionary
-  is sent as a single comma separated string, and the values are not escaped, so
-  one comma inside an entry splits it and corrupts the rest of the dictionary.
-  Strip commas from your entries before passing them in.
+  is sent as one comma separated string with no escaping, so a comma inside an
+  entry splits it and corrupts the rest of the dictionary. Strip commas first.
 </Warning>
 
 <Note>
   **Azure has no pronunciation lexicon path in Pipecat.** `AzureTTSService`
-  escapes your text before wrapping it in SSML, so a `<phoneme>` tag you inject
-  through a text transform is escaped and read out loud as literal characters.
-  There is no flag to turn that off. On Azure, use respellings through
-  `replace_text` instead.
+  escapes your text before wrapping it in SSML, so a `<phoneme>` tag injected by
+  a text transform is read out loud as literal characters. There is no flag to
+  turn this off. On Azure, use respellings through `replace_text`.
 </Note>
 
-#### A note on ElevenLabs
-
-On ElevenLabs, prefer respellings over IPA:
+#### ElevenLabs: prefer respellings over IPA
 
 ```python
 # Works on every ElevenLabs model
@@ -5337,7 +5335,7 @@ On ElevenLabs, prefer respellings over IPA:
 (r"(?i)\bmetformin\b", '<phoneme alphabet="ipa" ph="mɛtˈfɔːrmɪn">metformin</phoneme>')
 ```
 
-Respellings need no extra flags and behave the same across models, which makes them the safer default for a large lexicon.
+Respellings need no flags and work on every model, so they are the safer default for a large lexicon.
 
 ### Text Filters
 
@@ -57628,9 +57626,7 @@ tts = RimeTTSService(
 
 ### PRONOUNCE(text: str, word: str, phoneme: str) -> str
 
-Convenience method to support Rime's [custom pronunciations feature](https://docs.rime.ai/api-reference/custom-pronunciation). It takes a word and its desired phoneme representation, returning the text with the provided word replaced by the appropriate phoneme tag.
-
-Unlike `SPELL` and `PAUSE_TAG`, call this method **on the service instance**, not on the class. It also takes three arguments, so it does not match the `(text, aggregation_type)` shape a text transform needs. Wrap it in a small function, the same way the examples above do.
+Instance method that implements Rime's [custom pronunciations feature](https://docs.rime.ai/api-reference/custom-pronunciation). It replaces `word` in `text` with the phoneme tag. Unlike `SPELL` and `PAUSE_TAG`, call it on the service instance, not on the class. Its three arguments do not match the `(text, aggregation_type)` transform shape, so wrap it in a function.
 
 ```python
 tts = RimeTTSService(
@@ -57650,28 +57646,24 @@ async def maybe_say_potato_all_fancylike(text: str, type: str) -> str:
     else:
         return tts.PRONOUNCE(text, "potato", "poteto")
 
-# Register the transform on the instance you just created
 tts.add_text_transformer(maybe_say_potato_all_fancylike, "*")  # Apply to all text
 ```
 
 <Note>
-  Calling `PRONOUNCE` switches on Rime's bracket phonemization for the next
-  message only. If any message in the session can contain a phoneme, set
-  `phonemizeBetweenBrackets=True` in `Settings` as shown above so the option
-  stays on for the whole session.
+  `PRONOUNCE` turns on bracket phonemization for the next message only. If any
+  message may contain a phoneme, set `phonemizeBetweenBrackets=True` in
+  `Settings` (as above) so it stays on for the whole session.
 </Note>
 
 <Tip>
-  `PRONOUNCE` handles one word at a time. If you need hundreds of pronunciation
-  overrides (medication names, product names, place names), use the
-  `replace_text` transform instead. See [Bulk pronunciation
-  overrides](/pipecat/learn/text-to-speech#bulk-pronunciation-overrides) in the
-  Text-to-Speech guide.
+  `PRONOUNCE` handles one word at a time. For hundreds of overrides, use the
+  `replace_text` transform. See [Bulk pronunciation
+  overrides](/pipecat/learn/text-to-speech#bulk-pronunciation-overrides).
 </Tip>
 
 ### INLINE_SPEED(text: str, speed: float) -> str
 
-A convenience method to support Rime's [inline speed adjustment feature](https://docs.rime.ai/api-reference/speed). It will wrap the provided text in the `[]` tags and add the provided speed to the `inlineSpeedAlpha` field in the request metadata. Like `PRONOUNCE`, call this method on the service instance, not on the class.
+Instance method that implements Rime's [inline speed adjustment feature](https://docs.rime.ai/api-reference/speed). It wraps `text` in `[]` and adds `speed` to the `inlineSpeedAlpha` request field. Like `PRONOUNCE`, call it on the service instance, not on the class.
 
 ```python
 tts = RimeTTSService(

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5258,6 +5258,87 @@ tts.add_text_transformer(replace_acronyms, "*")  # Apply to all text
 #   llm -> llm_text_processor -> tts
 ```
 
+### Bulk pronunciation overrides
+
+Some bots need a large pronunciation list: medication names, product names, drug brands, place names. Hundreds or even a thousand entries is normal. There are two ways to do this, and they are not equivalent.
+
+#### Client side with `replace_text`
+
+`replace_text` builds one transform from a list of `(pattern, replacement)` pairs. This is the portable option: it works with every TTS service, because the substitution happens in Pipecat before the text is ever sent.
+
+```python
+from pipecat.utils.text.transforms import replace_text
+
+# Load your lexicon from wherever it lives: a CSV, a database, a config file
+lexicon = [
+    (r"(?i)\bmetformin\b", "met-FOR-min"),
+    (r"(?i)\blisinopril\b", "ly-SIN-oh-pril"),
+    (r"(?i)\bomeprazole\b", "oh-MEP-ray-zol"),
+    # ... hundreds more
+]
+
+tts = CartesiaTTSService(
+    api_key=os.getenv("CARTESIA_API_KEY"),
+    text_transforms=[("*", replace_text(lexicon))],
+)
+```
+
+The rules are regular expressions and they are compiled once when you build the transform, not on every chunk of text. Each chunk is then run through the list in order. Cost grows in a straight line with the number of rules and stays small: on an Apple silicon laptop, a 300 rule list added roughly 0.4 ms per sentence and a 1000 rule list roughly 1.4 ms. Treat those as an order of magnitude, not a guarantee. Your hardware and your patterns will move the number.
+
+Two practical notes. Order matters, since rules are applied in sequence and an earlier replacement can change the text a later rule tries to match. And use word boundaries (`\b`) so that "cat" does not rewrite the middle of "catheter".
+
+<Warning>
+  **Multi-word replacements need sentence aggregation.** Text transforms run
+  *after* text aggregation, so a transform only ever sees one aggregation at a
+  time. With `TextAggregationMode.TOKEN`, each piece of text is passed straight
+  through with no buffering, so a pattern that spans more than one word can
+  never match: the words arrive in separate calls. If your lexicon contains any
+  multi-word entry (`"beta blocker"`, `"St. John's wort"`), keep the default
+  sentence aggregation.
+</Warning>
+
+#### Provider side lexicons
+
+Several services can host the lexicon themselves. This keeps the list out of your process, but ties you to that provider.
+
+| Service        | Option                              | What it takes                                                        |
+| -------------- | ----------------------------------- | -------------------------------------------------------------------- |
+| **AWS Polly**  | `lexicon_names`                     | A list of PLS lexicon names you have already uploaded to Polly       |
+| **NVIDIA**     | `custom_dictionary`                 | A dict mapping each written word to its IPA pronunciation            |
+| **Cartesia**   | `pronunciation_dict_id`             | The ID of a pronunciation dictionary you created in Cartesia         |
+| **ElevenLabs** | `pronunciation_dictionary_locators` | Deprecated since 1.6.0, removed in 2.0.0. Use `replace_text` instead |
+| **Azure**      | Not available                       | See the note below                                                   |
+
+<Warning>
+  **NVIDIA `custom_dictionary` entries cannot contain commas.** The dictionary
+  is sent as a single comma separated string, and the values are not escaped, so
+  one comma inside an entry splits it and corrupts the rest of the dictionary.
+  Strip commas from your entries before passing them in.
+</Warning>
+
+<Note>
+  **Azure has no pronunciation lexicon path in Pipecat.** `AzureTTSService`
+  escapes your text before wrapping it in SSML, so a `<phoneme>` tag you inject
+  through a text transform is escaped and read out loud as literal characters.
+  There is no flag to turn that off. On Azure, use respellings through
+  `replace_text` instead.
+</Note>
+
+#### A note on ElevenLabs
+
+On ElevenLabs, prefer respellings over IPA:
+
+```python
+# Works on every ElevenLabs model
+(r"(?i)\bmetformin\b", "met-FOR-min")
+
+# IPA phoneme tags need enable_ssml_parsing=True and, per ElevenLabs,
+# only work on their v2 models
+(r"(?i)\bmetformin\b", '<phoneme alphabet="ipa" ph="mɛtˈfɔːrmɪn">metformin</phoneme>')
+```
+
+Respellings need no extra flags and behave the same across models, which makes them the safer default for a large lexicon.
+
 ### Text Filters
 
 <Warning>
@@ -57545,47 +57626,67 @@ tts = RimeTTSService(
 )
 ```
 
-### PRONOUNCE(self, text: str, word: str, phoneme: str) -> str:
+### PRONOUNCE(text: str, word: str, phoneme: str) -> str
 
 Convenience method to support Rime's [custom pronunciations feature](https://docs.rime.ai/api-reference/custom-pronunciation). It takes a word and its desired phoneme representation, returning the text with the provided word replaced by the appropriate phoneme tag.
 
+Unlike `SPELL` and `PAUSE_TAG`, call this method **on the service instance**, not on the class. It also takes three arguments, so it does not match the `(text, aggregation_type)` shape a text transform needs. Wrap it in a small function, the same way the examples above do.
+
 ```python
+tts = RimeTTSService(
+    api_key=os.getenv("RIME_API_KEY"),
+    settings=RimeTTSService.Settings(
+        # Keep bracket phonemization on for the whole session
+        phonemizeBetweenBrackets=True,
+    ),
+)
+
 # Text transformers for TTS
-# This will a phoneme in place of the word "potato" to define how it
+# This puts a phoneme in place of the word "potato" to define how it
 # should be pronounced.
 async def maybe_say_potato_all_fancylike(text: str, type: str) -> str:
     if using_fancy_voice:
-        return RimeTTSService.PRONOUNCE(text, "potato", "potato")
+        return tts.PRONOUNCE(text, "potato", "potato")
     else:
-        return RimeTTSService.PRONOUNCE(text, "potato", "poteto")
+        return tts.PRONOUNCE(text, "potato", "poteto")
 
-tts = RimeTTSService(
-    api_key=os.getenv("RIME_API_KEY"),
-    text_transforms=[
-        ("*", maybe_say_potato_all_fancylike), # Apply to all text
-    ],
-)
+# Register the transform on the instance you just created
+tts.add_text_transformer(maybe_say_potato_all_fancylike, "*")  # Apply to all text
 ```
 
-### INLINE_SPEED(self, text: str, speed: float) -> str:
+<Note>
+  Calling `PRONOUNCE` switches on Rime's bracket phonemization for the next
+  message only. If any message in the session can contain a phoneme, set
+  `phonemizeBetweenBrackets=True` in `Settings` as shown above so the option
+  stays on for the whole session.
+</Note>
 
-A convenience method to support Rime's [inline speed adjustment feature](https://docs.rime.ai/api-reference/speed). It will wrap the provided text in the `[]` tags and add the provided speed to the `inlineSpeedAlpha` field in the request metadata.
+<Tip>
+  `PRONOUNCE` handles one word at a time. If you need hundreds of pronunciation
+  overrides (medication names, product names, place names), use the
+  `replace_text` transform instead. See [Bulk pronunciation
+  overrides](/pipecat/learn/text-to-speech#bulk-pronunciation-overrides) in the
+  Text-to-Speech guide.
+</Tip>
+
+### INLINE_SPEED(text: str, speed: float) -> str
+
+A convenience method to support Rime's [inline speed adjustment feature](https://docs.rime.ai/api-reference/speed). It will wrap the provided text in the `[]` tags and add the provided speed to the `inlineSpeedAlpha` field in the request metadata. Like `PRONOUNCE`, call this method on the service instance, not on the class.
 
 ```python
+tts = RimeTTSService(
+    api_key=os.getenv("RIME_API_KEY"),
+)
+
 # Text transformers for TTS
 # This will make the word slow always be spoken more slowly.
 async def slow_down_slow_words(text: str, type: str) -> str:
     return text.replace(
         "slow",
-        RimeTTSService.INLINE_SPEED("slow", speed=0.5)
+        tts.INLINE_SPEED("slow", speed=0.5)
     )
 
-tts = RimeTTSService(
-    api_key=os.getenv("RIME_API_KEY"),
-    text_transforms=[
-        ("*", slow_down_slow_words), # Apply to all text
-    ],
-)
+tts.add_text_transformer(slow_down_slow_words, "*")  # Apply to all text
 ```
 
 <Tip>

--- a/pipecat/learn/text-to-speech.mdx
+++ b/pipecat/learn/text-to-speech.mdx
@@ -266,6 +266,87 @@ tts.add_text_transformer(replace_acronyms, "*")  # Apply to all text
 #   llm -> llm_text_processor -> tts
 ```
 
+### Bulk pronunciation overrides
+
+Some bots need a large pronunciation list: medication names, product names, drug brands, place names. Hundreds or even a thousand entries is normal. There are two ways to do this, and they are not equivalent.
+
+#### Client side with `replace_text`
+
+`replace_text` builds one transform from a list of `(pattern, replacement)` pairs. This is the portable option: it works with every TTS service, because the substitution happens in Pipecat before the text is ever sent.
+
+```python
+from pipecat.utils.text.transforms import replace_text
+
+# Load your lexicon from wherever it lives: a CSV, a database, a config file
+lexicon = [
+    (r"(?i)\bmetformin\b", "met-FOR-min"),
+    (r"(?i)\blisinopril\b", "ly-SIN-oh-pril"),
+    (r"(?i)\bomeprazole\b", "oh-MEP-ray-zol"),
+    # ... hundreds more
+]
+
+tts = CartesiaTTSService(
+    api_key=os.getenv("CARTESIA_API_KEY"),
+    text_transforms=[("*", replace_text(lexicon))],
+)
+```
+
+The rules are regular expressions and they are compiled once when you build the transform, not on every chunk of text. Each chunk is then run through the list in order. Cost grows in a straight line with the number of rules and stays small: on an Apple silicon laptop, a 300 rule list added roughly 0.4 ms per sentence and a 1000 rule list roughly 1.4 ms. Treat those as an order of magnitude, not a guarantee. Your hardware and your patterns will move the number.
+
+Two practical notes. Order matters, since rules are applied in sequence and an earlier replacement can change the text a later rule tries to match. And use word boundaries (`\b`) so that "cat" does not rewrite the middle of "catheter".
+
+<Warning>
+  **Multi-word replacements need sentence aggregation.** Text transforms run
+  *after* text aggregation, so a transform only ever sees one aggregation at a
+  time. With `TextAggregationMode.TOKEN`, each piece of text is passed straight
+  through with no buffering, so a pattern that spans more than one word can
+  never match: the words arrive in separate calls. If your lexicon contains any
+  multi-word entry (`"beta blocker"`, `"St. John's wort"`), keep the default
+  sentence aggregation.
+</Warning>
+
+#### Provider side lexicons
+
+Several services can host the lexicon themselves. This keeps the list out of your process, but ties you to that provider.
+
+| Service        | Option                              | What it takes                                                        |
+| -------------- | ----------------------------------- | -------------------------------------------------------------------- |
+| **AWS Polly**  | `lexicon_names`                     | A list of PLS lexicon names you have already uploaded to Polly       |
+| **NVIDIA**     | `custom_dictionary`                 | A dict mapping each written word to its IPA pronunciation            |
+| **Cartesia**   | `pronunciation_dict_id`             | The ID of a pronunciation dictionary you created in Cartesia         |
+| **ElevenLabs** | `pronunciation_dictionary_locators` | Deprecated since 1.6.0, removed in 2.0.0. Use `replace_text` instead |
+| **Azure**      | Not available                       | See the note below                                                   |
+
+<Warning>
+  **NVIDIA `custom_dictionary` entries cannot contain commas.** The dictionary
+  is sent as a single comma separated string, and the values are not escaped, so
+  one comma inside an entry splits it and corrupts the rest of the dictionary.
+  Strip commas from your entries before passing them in.
+</Warning>
+
+<Note>
+  **Azure has no pronunciation lexicon path in Pipecat.** `AzureTTSService`
+  escapes your text before wrapping it in SSML, so a `<phoneme>` tag you inject
+  through a text transform is escaped and read out loud as literal characters.
+  There is no flag to turn that off. On Azure, use respellings through
+  `replace_text` instead.
+</Note>
+
+#### A note on ElevenLabs
+
+On ElevenLabs, prefer respellings over IPA:
+
+```python
+# Works on every ElevenLabs model
+(r"(?i)\bmetformin\b", "met-FOR-min")
+
+# IPA phoneme tags need enable_ssml_parsing=True and, per ElevenLabs,
+# only work on their v2 models
+(r"(?i)\bmetformin\b", '<phoneme alphabet="ipa" ph="mɛtˈfɔːrmɪn">metformin</phoneme>')
+```
+
+Respellings need no extra flags and behave the same across models, which makes them the safer default for a large lexicon.
+
 ### Text Filters
 
 <Warning>

--- a/pipecat/learn/text-to-speech.mdx
+++ b/pipecat/learn/text-to-speech.mdx
@@ -268,11 +268,11 @@ tts.add_text_transformer(replace_acronyms, "*")  # Apply to all text
 
 ### Bulk pronunciation overrides
 
-Some bots need a large pronunciation list: medication names, product names, drug brands, place names. Hundreds or even a thousand entries is normal. There are two ways to do this, and they are not equivalent.
+Some bots need hundreds of pronunciation overrides: medication names, product names, place names. There are two ways to do this.
 
 #### Client side with `replace_text`
 
-`replace_text` builds one transform from a list of `(pattern, replacement)` pairs. This is the portable option: it works with every TTS service, because the substitution happens in Pipecat before the text is ever sent.
+`replace_text` builds one transform from a list of `(pattern, replacement)` pairs. It works with every TTS service because the substitution happens in Pipecat before the text is sent.
 
 ```python
 from pipecat.utils.text.transforms import replace_text
@@ -291,23 +291,25 @@ tts = CartesiaTTSService(
 )
 ```
 
-The rules are regular expressions and they are compiled once when you build the transform, not on every chunk of text. Each chunk is then run through the list in order. Cost grows in a straight line with the number of rules and stays small: on an Apple silicon laptop, a 300 rule list added roughly 0.4 ms per sentence and a 1000 rule list roughly 1.4 ms. Treat those as an order of magnitude, not a guarantee. Your hardware and your patterns will move the number.
+Rules are regular expressions, compiled once. Each chunk of text runs through the list in order, so cost grows in a straight line with rule count and stays small: on an Apple silicon laptop, 300 rules added about 0.4 ms per sentence and 1000 rules about 1.4 ms. Your hardware and patterns will move those numbers.
 
-Two practical notes. Order matters, since rules are applied in sequence and an earlier replacement can change the text a later rule tries to match. And use word boundaries (`\b`) so that "cat" does not rewrite the middle of "catheter".
+Two tips:
+
+- Order matters. Rules run in sequence, so an earlier replacement can change what a later rule matches.
+- Use word boundaries (`\b`) so "cat" does not rewrite the middle of "catheter".
 
 <Warning>
   **Multi-word replacements need sentence aggregation.** Text transforms run
-  *after* text aggregation, so a transform only ever sees one aggregation at a
-  time. With `TextAggregationMode.TOKEN`, each piece of text is passed straight
-  through with no buffering, so a pattern that spans more than one word can
-  never match: the words arrive in separate calls. If your lexicon contains any
-  multi-word entry (`"beta blocker"`, `"St. John's wort"`), keep the default
-  sentence aggregation.
+  *after* text aggregation and see one aggregation at a time. With
+  `TextAggregationMode.TOKEN`, text passes straight through with no buffering,
+  so a pattern that spans more than one word never matches: the words arrive in
+  separate calls. If your lexicon has any multi-word entry (`"beta blocker"`,
+  `"St. John's wort"`), keep the default sentence aggregation.
 </Warning>
 
 #### Provider side lexicons
 
-Several services can host the lexicon themselves. This keeps the list out of your process, but ties you to that provider.
+Some services host the lexicon for you. This keeps the list out of your process but ties you to that provider.
 
 | Service        | Option                              | What it takes                                                        |
 | -------------- | ----------------------------------- | -------------------------------------------------------------------- |
@@ -319,22 +321,18 @@ Several services can host the lexicon themselves. This keeps the list out of you
 
 <Warning>
   **NVIDIA `custom_dictionary` entries cannot contain commas.** The dictionary
-  is sent as a single comma separated string, and the values are not escaped, so
-  one comma inside an entry splits it and corrupts the rest of the dictionary.
-  Strip commas from your entries before passing them in.
+  is sent as one comma separated string with no escaping, so a comma inside an
+  entry splits it and corrupts the rest of the dictionary. Strip commas first.
 </Warning>
 
 <Note>
   **Azure has no pronunciation lexicon path in Pipecat.** `AzureTTSService`
-  escapes your text before wrapping it in SSML, so a `<phoneme>` tag you inject
-  through a text transform is escaped and read out loud as literal characters.
-  There is no flag to turn that off. On Azure, use respellings through
-  `replace_text` instead.
+  escapes your text before wrapping it in SSML, so a `<phoneme>` tag injected by
+  a text transform is read out loud as literal characters. There is no flag to
+  turn this off. On Azure, use respellings through `replace_text`.
 </Note>
 
-#### A note on ElevenLabs
-
-On ElevenLabs, prefer respellings over IPA:
+#### ElevenLabs: prefer respellings over IPA
 
 ```python
 # Works on every ElevenLabs model
@@ -345,7 +343,7 @@ On ElevenLabs, prefer respellings over IPA:
 (r"(?i)\bmetformin\b", '<phoneme alphabet="ipa" ph="mɛtˈfɔːrmɪn">metformin</phoneme>')
 ```
 
-Respellings need no extra flags and behave the same across models, which makes them the safer default for a large lexicon.
+Respellings need no flags and work on every model, so they are the safer default for a large lexicon.
 
 ### Text Filters
 


### PR DESCRIPTION
Two documentation gaps found while working support ticket 

All claims below were verified against `pipecat` main at `0417f251`.

## Gap A: the Rime `PRONOUNCE` example cannot run

The page showed `RimeTTSService.PRONOUNCE(text, "potato", "potato")`, called on the class with 3 arguments. `PRONOUNCE` is an **instance** method taking `(self, text, word, phoneme)`. The `@staticmethod` decorator above it binds `PAUSE_TAG`, not `PRONOUNCE`. As documented, the call binds `self=text` and leaves `phoneme` missing, so it raises `TypeError`.

`INLINE_SPEED` is an instance method too, and its example on the same page had the identical problem. Fixed both.

Also added:
- A note that `PRONOUNCE` takes three arguments, so it needs a small wrapper function to satisfy the `(text, aggregation_type)` text transform contract.
- A note that `PRONOUNCE` enables bracket phonemization for the next message only, with a pointer to the `Settings` field that keeps it on for the whole session. That is the better choice for anything beyond a one-off.

## Gap B: no guidance on bulk pronunciation lexicons

Nothing in the docs told you how to do a lexicon of hundreds of words, or which providers can host one. New "Bulk pronunciation overrides" section in the Text-to-Speech guide covering:

1. **`replace_text` as the portable client side path.** Rules are regexes compiled once at construction and applied as a loop per chunk, so cost grows linearly and stays small. Measured roughly 0.4 ms per sentence at 300 rules and 1.4 ms at 1000 on an Apple silicon Mac. Presented as an order of magnitude, with hardware variance called out.

2. **The footgun: transforms run after aggregation.** In `TextAggregationMode.TOKEN`, `SimpleTextAggregator` yields each text immediately with no buffering, so a pattern spanning multiple words can never match. Multi-word lexicon entries require sentence aggregation. This is the single most useful thing on the page. Related: pipecat-ai/pipecat#5574.

3. **Provider hosted lexicon table**, checked by grepping every `src/pipecat/services/*/tts.py`:
   - AWS Polly: `lexicon_names`
   - NVIDIA: `custom_dictionary`, with a warning that entries are joined into one comma separated string with no escaping, so a comma in an entry corrupts the dictionary
   - Cartesia: `pronunciation_dict_id`
   - ElevenLabs: `pronunciation_dictionary_locators`, deprecated in 1.6.0 and removed in 2.0.0
   - Azure: not possible. `_construct_ssml` escapes the input text before assembling SSML, so an injected `<phoneme>` tag is escaped and spoken literally, and there is no opt-out. Worth stating, since the page lists "SSML support: Fine-grained pronunciation control" as an advanced feature and people try it on Azure.

4. **ElevenLabs specifics:** prefer respellings over IPA, since respellings work on every model while IPA `<phoneme>` tags need `enable_ssml_parsing=True` and only work on v2 models.

## Checks run

- `npx mint broken-links --check-anchors --check-redirects`: no broken links
- `node scripts/check-imports.mjs --pipecat ../pipecat`: all imports resolve
- `node scripts/docs-meta-lint.mjs`: the one error and the llms.txt budget warning both reproduce on `main` unchanged, so neither comes from this branch
- `llms.txt` and `llms-full.txt` regenerated

Note: `npm run format` is not a no-op on `main` right now, it reformats about 30 unrelated files. I reverted those so this diff stays scoped.

Opened as a draft for review.
