### PR TITLE
Fix how deploys affect running agent instances (T-3890)

### DIFF
--- a/pipecat-cloud/fundamentals/deploy.mdx
+++ b/pipecat-cloud/fundamentals/deploy.mdx
@@ -147,13 +147,14 @@ pipecat cloud deploy --min-agents 2
 
 This command will update the deployment to set the minimum number of instances to 2.
 
-To avoid interruption of any active sessions, any running agent instances will continue on the old image until the session concludes. Once those sessions end, the instances running the old image are discarded and will not be returned to the pool.
+To avoid interruption of any active sessions, any running agent instances will continue on the old image until the new deployment has finished rolling out and is healthy. Until that point, those instances stay in the pool: when a session on one of them ends, it can pick up another new session.
 
 <Note>
-  When there is no new deployment, instances are returned to the pool after a
-  session ends and remain available to serve new sessions during a cooldown
-  period. A new deployment changes this behavior: instances running the prior
-  image are terminated once their sessions conclude, rather than being recycled.
+  A new deployment does not take old instances out of the pool right away. They
+  keep serving, including new sessions, until the new version has rolled out and
+  passed its health checks. If you deploy again before the previous deployment
+  finishes rolling out, instances from an even older version can keep serving for
+  longer.
 </Note>
 
 Idle agent instances in your agent pool will be replaced with the new configuration according to the Pipecat Cloud auto-scaling strategy.
@@ -163,6 +164,12 @@ remains consistent and avoids potential cold starts.
 ### When a deploy does not replace running agents
 
 A deploy only replaces your running agent instances when it creates a new version of your agent, so a routine deploy can't cut off a session that is already in progress. Some changes look like no change and keep the current version: a scaling-only change (`min-agents` or `max-agents`), an image tag you already deployed (Pipecat Cloud stores the tag, not the image behind it, so re-pushing to a tag like `:latest` looks identical), and a new value for a secret in a set you already use. If you keep warm instances (`min-agents` set to 1 or higher), they can keep serving your old code while the deploy reports success. Run [`pipecat cloud deploy --force`](/api-reference/cli/cloud/deploy) to force a new version.
+
+### Taking an old instance out of rotation
+
+There is no way to ask the API which image a single instance is running, or to move one instance to a new image. If you need an instance to stop taking new sessions, have your [`readyz()`](/pipecat-cloud/fundamentals/health-checks) function return not ready. Pipecat Cloud stops routing new sessions to that instance, and any session already running on it finishes normally.
+
+Lowering [`--max-session-duration`](/api-reference/cli/cloud/deploy#param-max-session-duration) also shortens how long an old instance can stick around, because an instance is only kept alive long enough to finish the longest session it could be running. The trade-off is that a real session that runs past the limit gets cut off, so do not set it below the length of your longest expected call.
 
 ### Failed deployments
 

--- a/pipecat-cloud/fundamentals/scaling.mdx
+++ b/pipecat-cloud/fundamentals/scaling.mdx
@@ -121,7 +121,7 @@ pipecat cloud deploy [agent-name] --max-agents 25
 <Step title="Auto-scaling">
 
 - The Pipecat Cloud auto-scaler determines if additional warm agent instances should be created to support further requests.
-- Once a session concludes, the instance is returned to the pool and can immediately serve another session. However, if a new deployment has been pushed since the instance was created, the instance is discarded instead and will not be reused.
+- Once a session concludes, the instance is returned to the pool and can immediately serve another session. This is also true after you push a new deployment: an instance created by an earlier deployment keeps taking new sessions until the new version has rolled out and passed its health checks. See [modifying a deployment](/pipecat-cloud/fundamentals/deploy#modifying-a-deployment).
 
 </Step>
 </Steps>


### PR DESCRIPTION
Found while working support ticket T-3890.

## The problem

Two pages tell customers that once you push a new deployment, agent instances on the old image finish their current session and are then thrown away:

- `pipecat-cloud/fundamentals/deploy.mdx`: "the instances running the old image are discarded and will not be returned to the pool" and "instances running the prior image are terminated once their sessions conclude, rather than being recycled."
- `pipecat-cloud/fundamentals/scaling.mdx`: "if a new deployment has been pushed since the instance was created, the instance is discarded instead and will not be reused."

That is not what the platform does. Instances from an older version are only removed after the new version has finished rolling out and is healthy. Until then they stay in the pool and keep picking up new sessions. If you deploy again before the previous deployment finishes, instances from an even older version can stay live longer.

On T-3890 a customer saw one instance from an older deployment serve four sessions over a two hour window while three newer deployments were live.

## What changed

- Reworded both pages to describe what actually happens.
- Added a short section to the deploy page on taking an instance out of rotation with `readyz()`, and on what max session duration does to how long an old instance can stick around, with the trade-off called out.

Draft on purpose. Please check the wording before this goes out.