### PR TITLE
Document 30 day default log retention for Pipecat Cloud

### DIFF
--- a/pipecat-cloud/fundamentals/logging.mdx
+++ b/pipecat-cloud/fundamentals/logging.mdx
@@ -37,6 +37,10 @@ This command accept various filters to help you narrow down the logs you are loo
 pipecat cloud agent logs my-agent -l ERROR
 ```
 
+### Log retention
+
+Agent logs are kept for 30 days by default. Logs older than 30 days are deleted and cannot be recovered. To keep logs longer, forward them to your own logging service. See [Using Datadog](../guides/using-datadog) for an example.
+
 ### Session logging
 
 We recommend using the `loguru` library for logging within your agent. This will ensure any logging within your agent associated to the session it is running in.


### PR DESCRIPTION
Adds a short Log retention section to the Pipecat Cloud logging page.

Agent logs are kept for 30 days by default. This matches the OpenSearch ISM policy (`pcc-prod`) in the tf repo: indices move to read-only at 2 days and are deleted at 30 days. Nothing in the API or dashboard applies a shorter per-plan window.

Context: support ticket T-3892, a customer asked why logs from a month ago were missing.