### PR TITLE
Add Maya Research TTS community integration

### DIFF
--- a/api-reference/server/services/memory/memorysync.mdx
+++ b/api-reference/server/services/memory/memorysync.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "MemorySync Memory"
 sidebarTitle: "MemorySync"
 description: "The pipecat-memorysync integration gives Pipecat voice agents long-term, cross-session memory backed by MemorySync â€” budgeted recall that never stalls a reply."

--- a/api-reference/server/services/supported-services.mdx
+++ b/api-reference/server/services/supported-services.mdx
@@ -199,61 +199,62 @@ Speech-to-Text services receive and audio input and output transcriptions.
 
 Text-to-Speech services receive text input and output audio streams or chunks.
 
-| Service                                                           | Setup                                                                         | Maintainer |
-| ----------------------------------------------------------------- | ----------------------------------------------------------------------------- | ---------- |
-| [Async](/api-reference/server/services/tts/asyncai)               | `uv add "pipecat-ai[asyncai]"`                                                | Pipecat    |
-| [AWS Polly](/api-reference/server/services/tts/aws)               | `uv add "pipecat-ai[aws]"`                                                    | Pipecat    |
-| [Azure](/api-reference/server/services/tts/azure)                 | `uv add "pipecat-ai[azure]"`                                                  | Pipecat    |
-| [Bland](/api-reference/server/services/tts/bland)                 | `uv add "pipecat-ai[bland]"`                                                  | Pipecat    |
-| [Camb AI](/api-reference/server/services/tts/camb)                | `uv add "pipecat-ai[camb]"`                                                   | Pipecat    |
-| [Cartesia](/api-reference/server/services/tts/cartesia)           | `uv add "pipecat-ai[cartesia]"`                                               | Pipecat    |
-| [Deepdub](/api-reference/server/services/tts/deepdub)             | `uv add pipecat-deepdub-tts`                                                  | Community  |
-| [Deepgram](/api-reference/server/services/tts/deepgram)           | `uv add "pipecat-ai[deepgram]"`                                               | Pipecat    |
-| [ElevenLabs](/api-reference/server/services/tts/elevenlabs)       | `uv add "pipecat-ai[elevenlabs]"`                                             | Pipecat    |
-| [Fish](/api-reference/server/services/tts/fish)                   | `uv add "pipecat-ai[fish]"`                                                   | Pipecat    |
-| [Floe](/api-reference/server/services/tts/floe)                   | `uv add pipecat-floe`                                                         | Community  |
-| [Gandr](/api-reference/server/services/tts/gandr)                 | `uv add pipecat-gandr`                                                        | Community  |
-| [Gnani](/api-reference/server/services/tts/gnani)                 | `uv add pipecat-gnani`                                                        | Community  |
-| [Google](/api-reference/server/services/tts/google)               | `uv add "pipecat-ai[google]"`                                                 | Pipecat    |
-| [Gradium](/api-reference/server/services/tts/gradium)             | `uv add "pipecat-ai[gradium]"`                                                | Pipecat    |
-| [Groq](/api-reference/server/services/tts/groq)                   | `uv add "pipecat-ai[groq]"`                                                   | Pipecat    |
-| [Hakim](/api-reference/server/services/tts/hakim)                 | `uv pip install git+https://github.com/tryHakimAI/hakim-pipecat.git`          | Community  |
-| [Hume](/api-reference/server/services/tts/hume)                   | `uv add "pipecat-ai[hume]"`                                                   | Pipecat    |
-| [Inworld](/api-reference/server/services/tts/inworld)             | `uv add "pipecat-ai[inworld]"`                                                | Pipecat    |
-| [Kokoro](/api-reference/server/services/tts/kokoro)               | `uv add "pipecat-ai[kokoro]"`                                                 | Pipecat    |
-| [LMNT](/api-reference/server/services/tts/lmnt)                   | `uv add "pipecat-ai[lmnt]"`                                                   | Pipecat    |
-| [Lokutor](/api-reference/server/services/tts/lokutor)             | `uv add pipecat-lokutor`                                                      | Community  |
-| [MiniMax](/api-reference/server/services/tts/minimax)             | `uv add "pipecat-ai[minimax]"`                                                | Pipecat    |
-| [Mistral](/api-reference/server/services/tts/mistral)             | `uv add "pipecat-ai[mistral]"`                                                | Pipecat    |
-| [Murf AI](/api-reference/server/services/tts/murf)                | `uv add pipecat-murf-tts`                                                     | Community  |
-| [Neuphonic](/api-reference/server/services/tts/neuphonic)         | `uv add "pipecat-ai[neuphonic]"`                                              | Pipecat    |
-| [NVIDIA](/api-reference/server/services/tts/nvidia)               | `uv add "pipecat-ai[nvidia]"`                                                 | Pipecat    |
-| [OpenAI](/api-reference/server/services/tts/openai)               | `uv add "pipecat-ai[openai]"`                                                 | Pipecat    |
-| [Pipecat TTS Cache](/api-reference/server/services/tts/tts-cache) | `uv add pipecat-tts-cache`                                                    | Community  |
-| [Piper](/api-reference/server/services/tts/piper)                 | `uv add "pipecat-ai[piper]"`                                                  | Pipecat    |
-| [Pocket TTS](/api-reference/server/services/tts/pocket-tts)       | `uv add "pipecat-ai[pocket-tts]"`                                             | Pipecat    |
-| [ResembleAI](/api-reference/server/services/tts/resembleai)       | `uv add "pipecat-ai[resemble]"`                                               | Pipecat    |
-| [Respeecher](/api-reference/server/services/tts/respeecher)       | `uv add pipecat-respeecher`                                                   | Community  |
-| [Quickdial](/api-reference/server/services/tts/quickdial)         | `uv add pipecat-quickdial`                                                    | Community  |
-| [Rime](/api-reference/server/services/tts/rime)                   | `uv add "pipecat-ai[rime]"`                                                   | Pipecat    |
-| [Rumik AI](/api-reference/server/services/tts/rumik)              | `uv add pipecat-rumik`                                                        | Community  |
-| [Sarvam](/api-reference/server/services/tts/sarvam)               | `uv add "pipecat-ai[sarvam]"`                                                 | Pipecat    |
-| [Simplismart](/api-reference/server/services/tts/simplismart)     | `uv add pipecat-simplismart`                                                  | Community  |
-| [SLNG](/api-reference/server/services/tts/slng)                   | `uv add pipecat-slng`                                                         | Community  |
-| [Smallest AI](/api-reference/server/services/tts/smallest)        | `uv add "pipecat-ai[smallest]"`                                               | Pipecat    |
-| [SonexLabs](/api-reference/server/services/tts/sonex)             | `uv add pipecat-sonex`                                                        | Community  |
-| [Soniox](/api-reference/server/services/tts/soniox)               | `uv add "pipecat-ai[soniox]"`                                                 | Pipecat    |
-| [Speechify](/api-reference/server/services/tts/speechify)         | `uv add "pipecat-ai[speechify]"`                                              | Pipecat    |
-| [Speechmatics](/api-reference/server/services/tts/speechmatics)   | `uv add "pipecat-ai[speechmatics]"`                                           | Pipecat    |
-| [Supertonic](/api-reference/server/services/tts/supertonic)       | `uv add pipecat-supertonic`                                                   | Community  |
-| [Together AI](/api-reference/server/services/tts/together)        | `uv add "pipecat-ai[together]"`                                               | Pipecat    |
-| [Typecast](/api-reference/server/services/tts/typecast)           | `uv add pipecat-ai-typecast`                                                  | Community  |
-| [Uplift AI](/api-reference/server/services/tts/upliftai)          | `uv pip install git+https://github.com/havkerboi123/pipecat-upliftai-tts.git` | Community  |
-| [Vakyam AI](/api-reference/server/services/tts/vakyam)            | `uv add pipecat-vakyam`                                                       | Community  |
-| [Voice.ai](/api-reference/server/services/tts/voiceai)            | `uv pip install git+https://github.com/voice-ai/voice-ai-pipecat-tts.git`     | Community  |
-| [xAI](/api-reference/server/services/tts/xai)                     | `uv add "pipecat-ai[xai]"`                                                    | Pipecat    |
-| [XTTS](/api-reference/server/services/tts/xtts) (deprecated)      | `uv add "pipecat-ai[xtts]"`                                                   | Pipecat    |
-| [XTTS-vLLM](/api-reference/server/services/tts/xtts-vllm)         | `uv add pipecat-xtts-vllm`                                                    | Community  |
+| Service                                                           | Setup                                                                                 | Maintainer |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------- |
+| [Async](/api-reference/server/services/tts/asyncai)               | `uv add "pipecat-ai[asyncai]"`                                                        | Pipecat    |
+| [AWS Polly](/api-reference/server/services/tts/aws)               | `uv add "pipecat-ai[aws]"`                                                            | Pipecat    |
+| [Azure](/api-reference/server/services/tts/azure)                 | `uv add "pipecat-ai[azure]"`                                                          | Pipecat    |
+| [Bland](/api-reference/server/services/tts/bland)                 | `uv add "pipecat-ai[bland]"`                                                          | Pipecat    |
+| [Camb AI](/api-reference/server/services/tts/camb)                | `uv add "pipecat-ai[camb]"`                                                           | Pipecat    |
+| [Cartesia](/api-reference/server/services/tts/cartesia)           | `uv add "pipecat-ai[cartesia]"`                                                       | Pipecat    |
+| [Deepdub](/api-reference/server/services/tts/deepdub)             | `uv add pipecat-deepdub-tts`                                                          | Community  |
+| [Deepgram](/api-reference/server/services/tts/deepgram)           | `uv add "pipecat-ai[deepgram]"`                                                       | Pipecat    |
+| [ElevenLabs](/api-reference/server/services/tts/elevenlabs)       | `uv add "pipecat-ai[elevenlabs]"`                                                     | Pipecat    |
+| [Fish](/api-reference/server/services/tts/fish)                   | `uv add "pipecat-ai[fish]"`                                                           | Pipecat    |
+| [Floe](/api-reference/server/services/tts/floe)                   | `uv add pipecat-floe`                                                                 | Community  |
+| [Gandr](/api-reference/server/services/tts/gandr)                 | `uv add pipecat-gandr`                                                                | Community  |
+| [Gnani](/api-reference/server/services/tts/gnani)                 | `uv add pipecat-gnani`                                                                | Community  |
+| [Google](/api-reference/server/services/tts/google)               | `uv add "pipecat-ai[google]"`                                                         | Pipecat    |
+| [Gradium](/api-reference/server/services/tts/gradium)             | `uv add "pipecat-ai[gradium]"`                                                        | Pipecat    |
+| [Groq](/api-reference/server/services/tts/groq)                   | `uv add "pipecat-ai[groq]"`                                                           | Pipecat    |
+| [Hakim](/api-reference/server/services/tts/hakim)                 | `uv pip install git+https://github.com/tryHakimAI/hakim-pipecat.git`                  | Community  |
+| [Hume](/api-reference/server/services/tts/hume)                   | `uv add "pipecat-ai[hume]"`                                                           | Pipecat    |
+| [Inworld](/api-reference/server/services/tts/inworld)             | `uv add "pipecat-ai[inworld]"`                                                        | Pipecat    |
+| [Kokoro](/api-reference/server/services/tts/kokoro)               | `uv add "pipecat-ai[kokoro]"`                                                         | Pipecat    |
+| [LMNT](/api-reference/server/services/tts/lmnt)                   | `uv add "pipecat-ai[lmnt]"`                                                           | Pipecat    |
+| [Lokutor](/api-reference/server/services/tts/lokutor)             | `uv add pipecat-lokutor`                                                              | Community  |
+| [Maya](/api-reference/server/services/tts/maya)                   | `uv add "pipecat-maya @ git+https://github.com/MayaResearch/pipecat-maya.git@v0.1.0"` | Community  |
+| [MiniMax](/api-reference/server/services/tts/minimax)             | `uv add "pipecat-ai[minimax]"`                                                        | Pipecat    |
+| [Mistral](/api-reference/server/services/tts/mistral)             | `uv add "pipecat-ai[mistral]"`                                                        | Pipecat    |
+| [Murf AI](/api-reference/server/services/tts/murf)                | `uv add pipecat-murf-tts`                                                             | Community  |
+| [Neuphonic](/api-reference/server/services/tts/neuphonic)         | `uv add "pipecat-ai[neuphonic]"`                                                      | Pipecat    |
+| [NVIDIA](/api-reference/server/services/tts/nvidia)               | `uv add "pipecat-ai[nvidia]"`                                                         | Pipecat    |
+| [OpenAI](/api-reference/server/services/tts/openai)               | `uv add "pipecat-ai[openai]"`                                                         | Pipecat    |
+| [Pipecat TTS Cache](/api-reference/server/services/tts/tts-cache) | `uv add pipecat-tts-cache`                                                            | Community  |
+| [Piper](/api-reference/server/services/tts/piper)                 | `uv add "pipecat-ai[piper]"`                                                          | Pipecat    |
+| [Pocket TTS](/api-reference/server/services/tts/pocket-tts)       | `uv add "pipecat-ai[pocket-tts]"`                                                     | Pipecat    |
+| [ResembleAI](/api-reference/server/services/tts/resembleai)       | `uv add "pipecat-ai[resemble]"`                                                       | Pipecat    |
+| [Respeecher](/api-reference/server/services/tts/respeecher)       | `uv add pipecat-respeecher`                                                           | Community  |
+| [Quickdial](/api-reference/server/services/tts/quickdial)         | `uv add pipecat-quickdial`                                                            | Community  |
+| [Rime](/api-reference/server/services/tts/rime)                   | `uv add "pipecat-ai[rime]"`                                                           | Pipecat    |
+| [Rumik AI](/api-reference/server/services/tts/rumik)              | `uv add pipecat-rumik`                                                                | Community  |
+| [Sarvam](/api-reference/server/services/tts/sarvam)               | `uv add "pipecat-ai[sarvam]"`                                                         | Pipecat    |
+| [Simplismart](/api-reference/server/services/tts/simplismart)     | `uv add pipecat-simplismart`                                                          | Community  |
+| [SLNG](/api-reference/server/services/tts/slng)                   | `uv add pipecat-slng`                                                                 | Community  |
+| [Smallest AI](/api-reference/server/services/tts/smallest)        | `uv add "pipecat-ai[smallest]"`                                                       | Pipecat    |
+| [SonexLabs](/api-reference/server/services/tts/sonex)             | `uv add pipecat-sonex`                                                                | Community  |
+| [Soniox](/api-reference/server/services/tts/soniox)               | `uv add "pipecat-ai[soniox]"`                                                         | Pipecat    |
+| [Speechify](/api-reference/server/services/tts/speechify)         | `uv add "pipecat-ai[speechify]"`                                                      | Pipecat    |
+| [Speechmatics](/api-reference/server/services/tts/speechmatics)   | `uv add "pipecat-ai[speechmatics]"`                                                   | Pipecat    |
+| [Supertonic](/api-reference/server/services/tts/supertonic)       | `uv add pipecat-supertonic`                                                           | Community  |
+| [Together AI](/api-reference/server/services/tts/together)        | `uv add "pipecat-ai[together]"`                                                       | Pipecat    |
+| [Typecast](/api-reference/server/services/tts/typecast)           | `uv add pipecat-ai-typecast`                                                          | Community  |
+| [Uplift AI](/api-reference/server/services/tts/upliftai)          | `uv pip install git+https://github.com/havkerboi123/pipecat-upliftai-tts.git`         | Community  |
+| [Vakyam AI](/api-reference/server/services/tts/vakyam)            | `uv add pipecat-vakyam`                                                               | Community  |
+| [Voice.ai](/api-reference/server/services/tts/voiceai)            | `uv pip install git+https://github.com/voice-ai/voice-ai-pipecat-tts.git`             | Community  |
+| [xAI](/api-reference/server/services/tts/xai)                     | `uv add "pipecat-ai[xai]"`                                                            | Pipecat    |
+| [XTTS](/api-reference/server/services/tts/xtts) (deprecated)      | `uv add "pipecat-ai[xtts]"`                                                           | Pipecat    |
+| [XTTS-vLLM](/api-reference/server/services/tts/xtts-vllm)         | `uv add pipecat-xtts-vllm`                                                            | Community  |
 
 ## Translation
 

--- a/api-reference/server/services/tts/maya.mdx
+++ b/api-reference/server/services/tts/maya.mdx
@@ -1,0 +1,188 @@
+---
+title: "Maya Text-to-Speech"
+sidebarTitle: "Maya"
+description: "Stream Indian-language TTS with MayaTTSService, or use MayaHttpTTSService for HTTP synthesis, in a Pipecat pipeline."
+---
+
+import { CommunityMaintained } from "/snippets/community-maintained.mdx";
+
+<CommunityMaintained
+  maintainer="Maya Research"
+  maintainerUrl="https://github.com/MayaResearch"
+  repo="https://github.com/MayaResearch/pipecat-maya"
+/>
+
+## Overview
+
+[Maya Research](https://www.mayaresearch.ai/) maintains this integration for its
+text-to-speech API. Use `MayaTTSService` for conversational agents: it keeps a
+WebSocket open across turns, streams audio as it arrives, and cancels the active
+turn when the user interrupts. `MayaHttpTTSService` uses the HTTP streaming API.
+
+Both services support Maya 2 Native and Maya Calyx. The package handles the wire
+protocol, text chunks, and conversion to Pipecat audio frames. You can use it
+with an existing STT, LLM, and transport.
+
+<CardGroup cols={2}>
+  <Card
+    title="Source Repository"
+    icon="github"
+    href="https://github.com/MayaResearch/pipecat-maya"
+  >
+    Installation, runnable examples, tests, and issue tracker
+  </Card>
+  <Card
+    title="Maya API Reference"
+    icon="book"
+    href="https://www.mayaresearch.ai/llm.txt"
+  >
+    Current models, voices, languages, formats, and API behavior
+  </Card>
+</CardGroup>
+
+## Installation
+
+Install the community package from its versioned Git release:
+
+```bash
+uv add "pipecat-maya @ git+https://github.com/MayaResearch/pipecat-maya.git@v0.1.0"
+```
+
+Or install into an existing Python environment:
+
+```bash
+python -m pip install "pipecat-maya @ git+https://github.com/MayaResearch/pipecat-maya.git@v0.1.0"
+```
+
+## Prerequisites
+
+Request an API key from [Maya Research](mailto:charan@mayaresearch.ai), then set
+`MAYA_API_KEY` in the server environment. Keep the key out of browser code.
+
+```bash
+export MAYA_API_KEY="your-api-key"
+```
+
+## Configuration
+
+Pass an API key and optional runtime settings to either service:
+
+```python
+import os
+
+from pipecat_maya import MayaTTSService
+
+tts = MayaTTSService(
+    api_key=os.environ["MAYA_API_KEY"],
+    settings=MayaTTSService.Settings(
+        model="Maya 2 Native",
+        voice="Ananya",
+    ),
+)
+```
+
+### Settings
+
+Pass these through `MayaTTSService.Settings(...)` or
+`MayaHttpTTSService.Settings(...)`. Use a
+[`TTSUpdateSettingsFrame`](/pipecat/fundamentals/service-settings) to change them
+during a conversation.
+
+| Parameter  | Type                      | Default           | Description                                                                                       |
+| ---------- | ------------------------- | ----------------- | ------------------------------------------------------------------------------------------------- |
+| `model`    | `str`                     | `"Maya 2 Native"` | `"Maya 2 Native"` or `"Maya Calyx"`. Names are case-sensitive.                                    |
+| `voice`    | `str`                     | `"Ananya"`        | A case-sensitive voice name belonging to the selected model.                                      |
+| `language` | `Language \| str \| None` | `None`            | Auto-detect when omitted. Set a supported language only when it matches the text.                 |
+| `speed`    | `float \| None`           | `None`            | Maya 2 Native only, from `0.5` to `1.25`. `None` resets Native to `1.0` and omits speed on Calyx. |
+
+Maya 2 Native offers `Ananya` and `Arjun`. Maya Calyx has a separate voice roster,
+including `Aarav` and `Tarini`. When changing models, change the voice in the
+same settings update. See the [Maya API reference](https://www.mayaresearch.ai/llm.txt)
+for the complete voice catalog. Clear a Native-only speed setting with
+`speed=None` when switching to Calyx. On Native, `speed=None` or `speed=1.0`
+restores normal speed.
+
+Supported language codes are `hi`, `bn`, `gu`, `kn`, `ml`, `mr`, `or`, `pa`, `ta`,
+`te`, and `en`. `en` is Indian English. Leave `language=None` for mixed-language
+text. An explicit language that does not match the text can produce the wrong
+pronunciation even when the API accepts the request.
+
+### HTTP synthesis
+
+Use the HTTP service in the same pipeline position:
+
+```python
+import os
+
+from pipecat_maya import MayaHttpTTSService
+
+tts = MayaHttpTTSService(
+    api_key=os.environ["MAYA_API_KEY"],
+    settings=MayaHttpTTSService.Settings(
+        model="Maya Calyx",
+        voice="Aarav",
+    ),
+)
+```
+
+Maya Calyx supports HTTP audio at 8, 16, and 24 kHz, with PCM or G.711 mu-law
+encoding. Maya 2 Native produces 24 kHz PCM. The integration converts provider
+audio to the PCM frames expected by Pipecat. See the
+[package documentation](https://github.com/MayaResearch/pipecat-maya) for
+transport and audio-format options.
+
+## Usage
+
+Place the service after your LLM and before your transport output. Keep the
+assistant context aggregator after the output transport:
+
+```python
+from pipecat.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline(
+    [
+        transport.input(),
+        stt,
+        context_aggregator.user(),
+        llm,
+        tts,
+        transport.output(),
+        context_aggregator.assistant(),
+    ]
+)
+```
+
+The surrounding `transport`, `stt`, `llm`, and `context_aggregator` are your
+existing pipeline components. For a complete runnable example, follow the
+[package README](https://github.com/MayaResearch/pipecat-maya#readme).
+
+### Text chunks and interruptions
+
+Use the default sentence aggregation for streamed LLM output. The WebSocket
+service associates chunks with their Pipecat context and closes the turn when
+text generation finishes. Callers do not need to manage Maya context IDs,
+continuation flags, or cancellation messages.
+
+Use Pipecat's [interruption handling](/pipecat/fundamentals/interruptions) so
+playback stops as soon as the user interrupts. The service cancels generation
+and discards late audio for the interrupted context. Stopping generation alone
+cannot remove audio that a custom client has already buffered.
+
+Send plain text. Maya reads SSML and markup literally; use Pipecat's
+[text processing](/pipecat/learn/text-to-speech#text-processing-and-filtering)
+when your LLM produces markup. Maya does not provide word timestamps, so the
+integration cannot report exact word-level playback timing.
+
+<Warning>
+  Validation found incomplete sentences in some Calyx/Amit HTTP responses. The
+  package documents the provider-level reproduction and the tested Native
+  default in its [validation
+  report](https://github.com/MayaResearch/pipecat-maya/blob/main/docs/validation.md).
+  API acceptance is not a guarantee of voice or language quality.
+</Warning>
+
+## Compatibility
+
+Tested with Pipecat v1.8.1. See the
+[package repository](https://github.com/MayaResearch/pipecat-maya) for the tested
+Python versions, release changelog, and validation results.

--- a/api-reference/server/services/tts/maya.mdx
+++ b/api-reference/server/services/tts/maya.mdx
@@ -183,6 +183,7 @@ integration cannot report exact word-level playback timing.
 
 ## Compatibility
 
-Tested with Pipecat v1.8.1. See the
+This release requires and pins Pipecat v1.8.1. Check compatibility before adding
+it to an environment that requires another Pipecat version. See the
 [package repository](https://github.com/MayaResearch/pipecat-maya) for the tested
 Python versions, release changelog, and validation results.

--- a/docs.json
+++ b/docs.json
@@ -461,6 +461,7 @@
                       "api-reference/server/services/tts/kokoro",
                       "api-reference/server/services/tts/lmnt",
                       "api-reference/server/services/tts/lokutor",
+                      "api-reference/server/services/tts/maya",
                       "api-reference/server/services/tts/minimax",
                       "api-reference/server/services/tts/mistral",
                       "api-reference/server/services/tts/murf",
@@ -1737,6 +1738,10 @@
     {
       "source": "/server/services/tts/murf",
       "destination": "/api-reference/server/services/tts/murf"
+    },
+    {
+      "source": "/server/services/tts/maya",
+      "destination": "/api-reference/server/services/tts/maya"
     },
     {
       "source": "/server/services/tts/tts-cache",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -31848,61 +31848,62 @@ Speech-to-Text services receive and audio input and output transcriptions.
 
 Text-to-Speech services receive text input and output audio streams or chunks.
 
-| Service                                                           | Setup                                                                         | Maintainer |
-| ----------------------------------------------------------------- | ----------------------------------------------------------------------------- | ---------- |
-| [Async](/api-reference/server/services/tts/asyncai)               | `uv add "pipecat-ai[asyncai]"`                                                | Pipecat    |
-| [AWS Polly](/api-reference/server/services/tts/aws)               | `uv add "pipecat-ai[aws]"`                                                    | Pipecat    |
-| [Azure](/api-reference/server/services/tts/azure)                 | `uv add "pipecat-ai[azure]"`                                                  | Pipecat    |
-| [Bland](/api-reference/server/services/tts/bland)                 | `uv add "pipecat-ai[bland]"`                                                  | Pipecat    |
-| [Camb AI](/api-reference/server/services/tts/camb)                | `uv add "pipecat-ai[camb]"`                                                   | Pipecat    |
-| [Cartesia](/api-reference/server/services/tts/cartesia)           | `uv add "pipecat-ai[cartesia]"`                                               | Pipecat    |
-| [Deepdub](/api-reference/server/services/tts/deepdub)             | `uv add pipecat-deepdub-tts`                                                  | Community  |
-| [Deepgram](/api-reference/server/services/tts/deepgram)           | `uv add "pipecat-ai[deepgram]"`                                               | Pipecat    |
-| [ElevenLabs](/api-reference/server/services/tts/elevenlabs)       | `uv add "pipecat-ai[elevenlabs]"`                                             | Pipecat    |
-| [Fish](/api-reference/server/services/tts/fish)                   | `uv add "pipecat-ai[fish]"`                                                   | Pipecat    |
-| [Floe](/api-reference/server/services/tts/floe)                   | `uv add pipecat-floe`                                                         | Community  |
-| [Gandr](/api-reference/server/services/tts/gandr)                 | `uv add pipecat-gandr`                                                        | Community  |
-| [Gnani](/api-reference/server/services/tts/gnani)                 | `uv add pipecat-gnani`                                                        | Community  |
-| [Google](/api-reference/server/services/tts/google)               | `uv add "pipecat-ai[google]"`                                                 | Pipecat    |
-| [Gradium](/api-reference/server/services/tts/gradium)             | `uv add "pipecat-ai[gradium]"`                                                | Pipecat    |
-| [Groq](/api-reference/server/services/tts/groq)                   | `uv add "pipecat-ai[groq]"`                                                   | Pipecat    |
-| [Hakim](/api-reference/server/services/tts/hakim)                 | `uv pip install git+https://github.com/tryHakimAI/hakim-pipecat.git`          | Community  |
-| [Hume](/api-reference/server/services/tts/hume)                   | `uv add "pipecat-ai[hume]"`                                                   | Pipecat    |
-| [Inworld](/api-reference/server/services/tts/inworld)             | `uv add "pipecat-ai[inworld]"`                                                | Pipecat    |
-| [Kokoro](/api-reference/server/services/tts/kokoro)               | `uv add "pipecat-ai[kokoro]"`                                                 | Pipecat    |
-| [LMNT](/api-reference/server/services/tts/lmnt)                   | `uv add "pipecat-ai[lmnt]"`                                                   | Pipecat    |
-| [Lokutor](/api-reference/server/services/tts/lokutor)             | `uv add pipecat-lokutor`                                                      | Community  |
-| [MiniMax](/api-reference/server/services/tts/minimax)             | `uv add "pipecat-ai[minimax]"`                                                | Pipecat    |
-| [Mistral](/api-reference/server/services/tts/mistral)             | `uv add "pipecat-ai[mistral]"`                                                | Pipecat    |
-| [Murf AI](/api-reference/server/services/tts/murf)                | `uv add pipecat-murf-tts`                                                     | Community  |
-| [Neuphonic](/api-reference/server/services/tts/neuphonic)         | `uv add "pipecat-ai[neuphonic]"`                                              | Pipecat    |
-| [NVIDIA](/api-reference/server/services/tts/nvidia)               | `uv add "pipecat-ai[nvidia]"`                                                 | Pipecat    |
-| [OpenAI](/api-reference/server/services/tts/openai)               | `uv add "pipecat-ai[openai]"`                                                 | Pipecat    |
-| [Pipecat TTS Cache](/api-reference/server/services/tts/tts-cache) | `uv add pipecat-tts-cache`                                                    | Community  |
-| [Piper](/api-reference/server/services/tts/piper)                 | `uv add "pipecat-ai[piper]"`                                                  | Pipecat    |
-| [Pocket TTS](/api-reference/server/services/tts/pocket-tts)       | `uv add "pipecat-ai[pocket-tts]"`                                             | Pipecat    |
-| [ResembleAI](/api-reference/server/services/tts/resembleai)       | `uv add "pipecat-ai[resemble]"`                                               | Pipecat    |
-| [Respeecher](/api-reference/server/services/tts/respeecher)       | `uv add pipecat-respeecher`                                                   | Community  |
-| [Quickdial](/api-reference/server/services/tts/quickdial)         | `uv add pipecat-quickdial`                                                    | Community  |
-| [Rime](/api-reference/server/services/tts/rime)                   | `uv add "pipecat-ai[rime]"`                                                   | Pipecat    |
-| [Rumik AI](/api-reference/server/services/tts/rumik)              | `uv add pipecat-rumik`                                                        | Community  |
-| [Sarvam](/api-reference/server/services/tts/sarvam)               | `uv add "pipecat-ai[sarvam]"`                                                 | Pipecat    |
-| [Simplismart](/api-reference/server/services/tts/simplismart)     | `uv add pipecat-simplismart`                                                  | Community  |
-| [SLNG](/api-reference/server/services/tts/slng)                   | `uv add pipecat-slng`                                                         | Community  |
-| [Smallest AI](/api-reference/server/services/tts/smallest)        | `uv add "pipecat-ai[smallest]"`                                               | Pipecat    |
-| [SonexLabs](/api-reference/server/services/tts/sonex)             | `uv add pipecat-sonex`                                                        | Community  |
-| [Soniox](/api-reference/server/services/tts/soniox)               | `uv add "pipecat-ai[soniox]"`                                                 | Pipecat    |
-| [Speechify](/api-reference/server/services/tts/speechify)         | `uv add "pipecat-ai[speechify]"`                                              | Pipecat    |
-| [Speechmatics](/api-reference/server/services/tts/speechmatics)   | `uv add "pipecat-ai[speechmatics]"`                                           | Pipecat    |
-| [Supertonic](/api-reference/server/services/tts/supertonic)       | `uv add pipecat-supertonic`                                                   | Community  |
-| [Together AI](/api-reference/server/services/tts/together)        | `uv add "pipecat-ai[together]"`                                               | Pipecat    |
-| [Typecast](/api-reference/server/services/tts/typecast)           | `uv add pipecat-ai-typecast`                                                  | Community  |
-| [Uplift AI](/api-reference/server/services/tts/upliftai)          | `uv pip install git+https://github.com/havkerboi123/pipecat-upliftai-tts.git` | Community  |
-| [Vakyam AI](/api-reference/server/services/tts/vakyam)            | `uv add pipecat-vakyam`                                                       | Community  |
-| [Voice.ai](/api-reference/server/services/tts/voiceai)            | `uv pip install git+https://github.com/voice-ai/voice-ai-pipecat-tts.git`     | Community  |
-| [xAI](/api-reference/server/services/tts/xai)                     | `uv add "pipecat-ai[xai]"`                                                    | Pipecat    |
-| [XTTS](/api-reference/server/services/tts/xtts) (deprecated)      | `uv add "pipecat-ai[xtts]"`                                                   | Pipecat    |
-| [XTTS-vLLM](/api-reference/server/services/tts/xtts-vllm)         | `uv add pipecat-xtts-vllm`                                                    | Community  |
+| Service                                                           | Setup                                                                                 | Maintainer |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ---------- |
+| [Async](/api-reference/server/services/tts/asyncai)               | `uv add "pipecat-ai[asyncai]"`                                                        | Pipecat    |
+| [AWS Polly](/api-reference/server/services/tts/aws)               | `uv add "pipecat-ai[aws]"`                                                            | Pipecat    |
+| [Azure](/api-reference/server/services/tts/azure)                 | `uv add "pipecat-ai[azure]"`                                                          | Pipecat    |
+| [Bland](/api-reference/server/services/tts/bland)                 | `uv add "pipecat-ai[bland]"`                                                          | Pipecat    |
+| [Camb AI](/api-reference/server/services/tts/camb)                | `uv add "pipecat-ai[camb]"`                                                           | Pipecat    |
+| [Cartesia](/api-reference/server/services/tts/cartesia)           | `uv add "pipecat-ai[cartesia]"`                                                       | Pipecat    |
+| [Deepdub](/api-reference/server/services/tts/deepdub)             | `uv add pipecat-deepdub-tts`                                                          | Community  |
+| [Deepgram](/api-reference/server/services/tts/deepgram)           | `uv add "pipecat-ai[deepgram]"`                                                       | Pipecat    |
+| [ElevenLabs](/api-reference/server/services/tts/elevenlabs)       | `uv add "pipecat-ai[elevenlabs]"`                                                     | Pipecat    |
+| [Fish](/api-reference/server/services/tts/fish)                   | `uv add "pipecat-ai[fish]"`                                                           | Pipecat    |
+| [Floe](/api-reference/server/services/tts/floe)                   | `uv add pipecat-floe`                                                                 | Community  |
+| [Gandr](/api-reference/server/services/tts/gandr)                 | `uv add pipecat-gandr`                                                                | Community  |
+| [Gnani](/api-reference/server/services/tts/gnani)                 | `uv add pipecat-gnani`                                                                | Community  |
+| [Google](/api-reference/server/services/tts/google)               | `uv add "pipecat-ai[google]"`                                                         | Pipecat    |
+| [Gradium](/api-reference/server/services/tts/gradium)             | `uv add "pipecat-ai[gradium]"`                                                        | Pipecat    |
+| [Groq](/api-reference/server/services/tts/groq)                   | `uv add "pipecat-ai[groq]"`                                                           | Pipecat    |
+| [Hakim](/api-reference/server/services/tts/hakim)                 | `uv pip install git+https://github.com/tryHakimAI/hakim-pipecat.git`                  | Community  |
+| [Hume](/api-reference/server/services/tts/hume)                   | `uv add "pipecat-ai[hume]"`                                                           | Pipecat    |
+| [Inworld](/api-reference/server/services/tts/inworld)             | `uv add "pipecat-ai[inworld]"`                                                        | Pipecat    |
+| [Kokoro](/api-reference/server/services/tts/kokoro)               | `uv add "pipecat-ai[kokoro]"`                                                         | Pipecat    |
+| [LMNT](/api-reference/server/services/tts/lmnt)                   | `uv add "pipecat-ai[lmnt]"`                                                           | Pipecat    |
+| [Lokutor](/api-reference/server/services/tts/lokutor)             | `uv add pipecat-lokutor`                                                              | Community  |
+| [Maya](/api-reference/server/services/tts/maya)                   | `uv add "pipecat-maya @ git+https://github.com/MayaResearch/pipecat-maya.git@v0.1.0"` | Community  |
+| [MiniMax](/api-reference/server/services/tts/minimax)             | `uv add "pipecat-ai[minimax]"`                                                        | Pipecat    |
+| [Mistral](/api-reference/server/services/tts/mistral)             | `uv add "pipecat-ai[mistral]"`                                                        | Pipecat    |
+| [Murf AI](/api-reference/server/services/tts/murf)                | `uv add pipecat-murf-tts`                                                             | Community  |
+| [Neuphonic](/api-reference/server/services/tts/neuphonic)         | `uv add "pipecat-ai[neuphonic]"`                                                      | Pipecat    |
+| [NVIDIA](/api-reference/server/services/tts/nvidia)               | `uv add "pipecat-ai[nvidia]"`                                                         | Pipecat    |
+| [OpenAI](/api-reference/server/services/tts/openai)               | `uv add "pipecat-ai[openai]"`                                                         | Pipecat    |
+| [Pipecat TTS Cache](/api-reference/server/services/tts/tts-cache) | `uv add pipecat-tts-cache`                                                            | Community  |
+| [Piper](/api-reference/server/services/tts/piper)                 | `uv add "pipecat-ai[piper]"`                                                          | Pipecat    |
+| [Pocket TTS](/api-reference/server/services/tts/pocket-tts)       | `uv add "pipecat-ai[pocket-tts]"`                                                     | Pipecat    |
+| [ResembleAI](/api-reference/server/services/tts/resembleai)       | `uv add "pipecat-ai[resemble]"`                                                       | Pipecat    |
+| [Respeecher](/api-reference/server/services/tts/respeecher)       | `uv add pipecat-respeecher`                                                           | Community  |
+| [Quickdial](/api-reference/server/services/tts/quickdial)         | `uv add pipecat-quickdial`                                                            | Community  |
+| [Rime](/api-reference/server/services/tts/rime)                   | `uv add "pipecat-ai[rime]"`                                                           | Pipecat    |
+| [Rumik AI](/api-reference/server/services/tts/rumik)              | `uv add pipecat-rumik`                                                                | Community  |
+| [Sarvam](/api-reference/server/services/tts/sarvam)               | `uv add "pipecat-ai[sarvam]"`                                                         | Pipecat    |
+| [Simplismart](/api-reference/server/services/tts/simplismart)     | `uv add pipecat-simplismart`                                                          | Community  |
+| [SLNG](/api-reference/server/services/tts/slng)                   | `uv add pipecat-slng`                                                                 | Community  |
+| [Smallest AI](/api-reference/server/services/tts/smallest)        | `uv add "pipecat-ai[smallest]"`                                                       | Pipecat    |
+| [SonexLabs](/api-reference/server/services/tts/sonex)             | `uv add pipecat-sonex`                                                                | Community  |
+| [Soniox](/api-reference/server/services/tts/soniox)               | `uv add "pipecat-ai[soniox]"`                                                         | Pipecat    |
+| [Speechify](/api-reference/server/services/tts/speechify)         | `uv add "pipecat-ai[speechify]"`                                                      | Pipecat    |
+| [Speechmatics](/api-reference/server/services/tts/speechmatics)   | `uv add "pipecat-ai[speechmatics]"`                                                   | Pipecat    |
+| [Supertonic](/api-reference/server/services/tts/supertonic)       | `uv add pipecat-supertonic`                                                           | Community  |
+| [Together AI](/api-reference/server/services/tts/together)        | `uv add "pipecat-ai[together]"`                                                       | Pipecat    |
+| [Typecast](/api-reference/server/services/tts/typecast)           | `uv add pipecat-ai-typecast`                                                          | Community  |
+| [Uplift AI](/api-reference/server/services/tts/upliftai)          | `uv pip install git+https://github.com/havkerboi123/pipecat-upliftai-tts.git`         | Community  |
+| [Vakyam AI](/api-reference/server/services/tts/vakyam)            | `uv add pipecat-vakyam`                                                               | Community  |
+| [Voice.ai](/api-reference/server/services/tts/voiceai)            | `uv pip install git+https://github.com/voice-ai/voice-ai-pipecat-tts.git`             | Community  |
+| [xAI](/api-reference/server/services/tts/xai)                     | `uv add "pipecat-ai[xai]"`                                                            | Pipecat    |
+| [XTTS](/api-reference/server/services/tts/xtts) (deprecated)      | `uv add "pipecat-ai[xtts]"`                                                           | Pipecat    |
+| [XTTS-vLLM](/api-reference/server/services/tts/xtts-vllm)         | `uv add pipecat-xtts-vllm`                                                            | Community  |
 
 ## Translation
 
@@ -55172,6 +55173,186 @@ Tested with Pipecat v0.0.86+. Check the [source
 repository](https://github.com/lokutor-ai/pipecat-lokutor) for the latest tested
 version and changelog.
 
+# Maya Text-to-Speech
+Source: https://docs.pipecat.ai/api-reference/server/services/tts/maya.md
+
+Stream Indian-language TTS with MayaTTSService, or use MayaHttpTTSService for HTTP synthesis, in a Pipecat pipeline.
+
+## Overview
+
+[Maya Research](https://www.mayaresearch.ai/) maintains this integration for its
+text-to-speech API. Use `MayaTTSService` for conversational agents: it keeps a
+WebSocket open across turns, streams audio as it arrives, and cancels the active
+turn when the user interrupts. `MayaHttpTTSService` uses the HTTP streaming API.
+
+Both services support Maya 2 Native and Maya Calyx. The package handles the wire
+protocol, text chunks, and conversion to Pipecat audio frames. You can use it
+with an existing STT, LLM, and transport.
+
+<CardGroup cols={2}>
+  <Card
+    title="Source Repository"
+    icon="github"
+    href="https://github.com/MayaResearch/pipecat-maya"
+  >
+    Installation, runnable examples, tests, and issue tracker
+  </Card>
+  <Card
+    title="Maya API Reference"
+    icon="book"
+    href="https://www.mayaresearch.ai/llm.txt"
+  >
+    Current models, voices, languages, formats, and API behavior
+  </Card>
+</CardGroup>
+
+## Installation
+
+Install the community package from its versioned Git release:
+
+```bash
+uv add "pipecat-maya @ git+https://github.com/MayaResearch/pipecat-maya.git@v0.1.0"
+```
+
+Or install into an existing Python environment:
+
+```bash
+python -m pip install "pipecat-maya @ git+https://github.com/MayaResearch/pipecat-maya.git@v0.1.0"
+```
+
+## Prerequisites
+
+Request an API key from [Maya Research](mailto:charan@mayaresearch.ai), then set
+`MAYA_API_KEY` in the server environment. Keep the key out of browser code.
+
+```bash
+export MAYA_API_KEY="your-api-key"
+```
+
+## Configuration
+
+Pass an API key and optional runtime settings to either service:
+
+```python
+import os
+
+from pipecat_maya import MayaTTSService
+
+tts = MayaTTSService(
+    api_key=os.environ["MAYA_API_KEY"],
+    settings=MayaTTSService.Settings(
+        model="Maya 2 Native",
+        voice="Ananya",
+    ),
+)
+```
+
+### Settings
+
+Pass these through `MayaTTSService.Settings(...)` or
+`MayaHttpTTSService.Settings(...)`. Use a
+[`TTSUpdateSettingsFrame`](/pipecat/fundamentals/service-settings) to change them
+during a conversation.
+
+| Parameter  | Type                      | Default           | Description                                                                                       |
+| ---------- | ------------------------- | ----------------- | ------------------------------------------------------------------------------------------------- |
+| `model`    | `str`                     | `"Maya 2 Native"` | `"Maya 2 Native"` or `"Maya Calyx"`. Names are case-sensitive.                                    |
+| `voice`    | `str`                     | `"Ananya"`        | A case-sensitive voice name belonging to the selected model.                                      |
+| `language` | `Language \| str \| None` | `None`            | Auto-detect when omitted. Set a supported language only when it matches the text.                 |
+| `speed`    | `float \| None`           | `None`            | Maya 2 Native only, from `0.5` to `1.25`. `None` resets Native to `1.0` and omits speed on Calyx. |
+
+Maya 2 Native offers `Ananya` and `Arjun`. Maya Calyx has a separate voice roster,
+including `Aarav` and `Tarini`. When changing models, change the voice in the
+same settings update. See the [Maya API reference](https://www.mayaresearch.ai/llm.txt)
+for the complete voice catalog. Clear a Native-only speed setting with
+`speed=None` when switching to Calyx. On Native, `speed=None` or `speed=1.0`
+restores normal speed.
+
+Supported language codes are `hi`, `bn`, `gu`, `kn`, `ml`, `mr`, `or`, `pa`, `ta`,
+`te`, and `en`. `en` is Indian English. Leave `language=None` for mixed-language
+text. An explicit language that does not match the text can produce the wrong
+pronunciation even when the API accepts the request.
+
+### HTTP synthesis
+
+Use the HTTP service in the same pipeline position:
+
+```python
+import os
+
+from pipecat_maya import MayaHttpTTSService
+
+tts = MayaHttpTTSService(
+    api_key=os.environ["MAYA_API_KEY"],
+    settings=MayaHttpTTSService.Settings(
+        model="Maya Calyx",
+        voice="Aarav",
+    ),
+)
+```
+
+Maya Calyx supports HTTP audio at 8, 16, and 24 kHz, with PCM or G.711 mu-law
+encoding. Maya 2 Native produces 24 kHz PCM. The integration converts provider
+audio to the PCM frames expected by Pipecat. See the
+[package documentation](https://github.com/MayaResearch/pipecat-maya) for
+transport and audio-format options.
+
+## Usage
+
+Place the service after your LLM and before your transport output. Keep the
+assistant context aggregator after the output transport:
+
+```python
+from pipecat.pipeline.pipeline import Pipeline
+
+pipeline = Pipeline(
+    [
+        transport.input(),
+        stt,
+        context_aggregator.user(),
+        llm,
+        tts,
+        transport.output(),
+        context_aggregator.assistant(),
+    ]
+)
+```
+
+The surrounding `transport`, `stt`, `llm`, and `context_aggregator` are your
+existing pipeline components. For a complete runnable example, follow the
+[package README](https://github.com/MayaResearch/pipecat-maya#readme).
+
+### Text chunks and interruptions
+
+Use the default sentence aggregation for streamed LLM output. The WebSocket
+service associates chunks with their Pipecat context and closes the turn when
+text generation finishes. Callers do not need to manage Maya context IDs,
+continuation flags, or cancellation messages.
+
+Use Pipecat's [interruption handling](/pipecat/fundamentals/interruptions) so
+playback stops as soon as the user interrupts. The service cancels generation
+and discards late audio for the interrupted context. Stopping generation alone
+cannot remove audio that a custom client has already buffered.
+
+Send plain text. Maya reads SSML and markup literally; use Pipecat's
+[text processing](/pipecat/learn/text-to-speech#text-processing-and-filtering)
+when your LLM produces markup. Maya does not provide word timestamps, so the
+integration cannot report exact word-level playback timing.
+
+<Warning>
+  Validation found incomplete sentences in some Calyx/Amit HTTP responses. The
+  package documents the provider-level reproduction and the tested Native
+  default in its [validation
+  report](https://github.com/MayaResearch/pipecat-maya/blob/main/docs/validation.md).
+  API acceptance is not a guarantee of voice or language quality.
+</Warning>
+
+## Compatibility
+
+Tested with Pipecat v1.8.1. See the
+[package repository](https://github.com/MayaResearch/pipecat-maya) for the tested
+Python versions, release changelog, and validation results.
+
 # MiniMax Text-to-Speech
 Source: https://docs.pipecat.ai/api-reference/server/services/tts/minimax.md
 
@@ -65169,15 +65350,10 @@ else:
 - **Non-blocking operation**: All Mem0 API calls (storage, retrieval, search) run in background threads to avoid blocking the event loop. Message storage is fire-and-forget, so it doesn't delay downstream processing.
 - **Message role filtering**: Only messages with `user` or `assistant` roles are stored in Mem0. Messages with other roles (such as `system` or `developer`) are automatically filtered out, as the Mem0 API does not accept them.
 
-# undefined
+# MemorySync Memory
 Source: https://docs.pipecat.ai/api-reference/server/services/memory/memorysync.md
 
----
-title: "MemorySync Memory"
-sidebarTitle: "MemorySync"
-description: "The pipecat-memorysync integration gives Pipecat voice agents long-term, cross-session memory backed by MemorySync â€” budgeted recall that never stalls a reply."
----
-
+The pipecat-memorysync integration gives Pipecat voice agents long-term, cross-session memory backed by MemorySync â€” budgeted recall that never stalls a reply.
 
 ## Overview
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -55349,7 +55349,8 @@ integration cannot report exact word-level playback timing.
 
 ## Compatibility
 
-Tested with Pipecat v1.8.1. See the
+This release requires and pins Pipecat v1.8.1. Check compatibility before adding
+it to an environment that requires another Pipecat version. See the
 [package repository](https://github.com/MayaResearch/pipecat-maya) for the tested
 Python versions, release changelog, and validation results.
 

--- a/llms.txt
+++ b/llms.txt
@@ -398,6 +398,7 @@ LLM, transports, serializers), pipelines, frames, workers, and utilities.
 - [Kokoro Text-to-Speech](https://docs.pipecat.ai/api-reference/server/services/tts/kokoro.md): Local offline TTS with KokoroTTSService and the kokoro-onnx engine: on-device synthesis with no external API calls.
 - [LMNT Text-to-Speech](https://docs.pipecat.ai/api-reference/server/services/tts/lmnt.md): LMNTTTSService streams TTS through LMNT's WebSocket API, optimized for ultra-low-latency conversational voice agents.
 - [Lokutor Text-to-Speech](https://docs.pipecat.ai/api-reference/server/services/tts/lokutor.md): LokutorTTSService generates TTS over a persistent WebSocket connection to Lokutor's CPU-only speech synthesis API.
+- [Maya Text-to-Speech](https://docs.pipecat.ai/api-reference/server/services/tts/maya.md): Stream Indian-language TTS with MayaTTSService, or use MayaHttpTTSService for HTTP synthesis, in a Pipecat pipeline.
 - [MiniMax Text-to-Speech](https://docs.pipecat.ai/api-reference/server/services/tts/minimax.md): TTS with MiniMaxTTSService and MiniMaxHttpTTSService on MiniMax's T2A API: streaming, emotional voice control, and voice options.
 - [Mistral Text-to-Speech](https://docs.pipecat.ai/api-reference/server/services/tts/mistral.md): MistralTTSService synthesizes speech with Mistral's Voxtral TTS API, streaming PCM audio over HTTP Server-Sent Events.
 - [Murf AI Text-to-Speech](https://docs.pipecat.ai/api-reference/server/services/tts/murf.md): MurfTTSService streams real-time TTS from Murf AI's WebSocket API with voice customization and styling options.
@@ -460,7 +461,7 @@ LLM, transports, serializers), pipelines, frames, workers, and utilities.
 ##### Memory
 
 - [Mem0 Long-Term Memory](https://docs.pipecat.ai/api-reference/server/services/memory/mem0.md): Mem0MemoryService adds long-term conversation memory to Pipecat agents, recalling context across sessions with Mem0.
-- [undefined](https://docs.pipecat.ai/api-reference/server/services/memory/memorysync.md)
+- [MemorySync Memory](https://docs.pipecat.ai/api-reference/server/services/memory/memorysync.md): The pipecat-memorysync integration gives Pipecat voice agents long-term, cross-session memory backed by MemorySync â€” budgeted recall that never stalls a reply.
 - [Synap Memory](https://docs.pipecat.ai/api-reference/server/services/memory/synap.md): The synap-pipecat integration gives Pipecat voice agents persistent, cross-session memory backed by Synap.
 
 ##### Vision


### PR DESCRIPTION
Adds Maya Research's community-maintained TTS integration to Supported Services and documents how to install it and use it in an existing Pipecat pipeline.

This follows the [community integration guide](https://github.com/pipecat-ai/pipecat/blob/main/COMMUNITY_INTEGRATIONS.md) and the [maintainer's direction on the earlier Maya core PR](https://github.com/pipecat-ai/pipecat/pull/5222#issuecomment-5186553125). Maya Research maintains the implementation in its own repository.

## Integration

- [Source, installation, and runnable examples](https://github.com/MayaResearch/pipecat-maya)
- [Versioned v0.1.0 release](https://github.com/MayaResearch/pipecat-maya/releases/tag/v0.1.0), including a wheel and source distribution. The documented Git-tag install was verified from the public repository; this package is not yet on PyPI.
- [31-second demo](https://github.com/MayaResearch/pipecat-maya/releases/download/v0.1.0/maya-pipecat-demo.mp4): recorded production synthesis and paced Pipecat playback, token chunking, interruption, a replacement response, and runtime settings changes. The video renders the actual recorded PCM and event trace. The interruption is synthetic; this is not a microphone or carrier-call demonstration.
- [Maya API coverage and implementation rationale](https://github.com/MayaResearch/pipecat-maya/blob/v0.1.0/docs/api-coverage.md), mapped to the provider's complete [llm.txt](https://www.mayaresearch.ai/llm.txt).
- [Validation report](https://github.com/MayaResearch/pipecat-maya/blob/main/docs/validation.md) and [reproducible evidence](https://github.com/MayaResearch/pipecat-maya/releases/download/v0.1.0/validation-evidence.zip).

`MayaTTSService` uses `WebsocketTTSService` with sentence aggregation, context-aware continuation and cancellation, explicit completion, stale-audio isolation, and local PCM resampling. `MayaHttpTTSService` provides the HTTP alternative. The default is Maya 2 Native; Maya Calyx is available with its separate voice catalog and format options. This release requires and pins Pipecat 1.8.1.

## Documentation changes

- Add the community service page, badge, Supported Services row, navigation entry, and legacy-path redirect.
- Cover installation, credentials, runtime settings, pipeline placement, chunking, interruption, audio formats, and known limitations; link to the maintained repository for the full API and examples.
- Regenerate `llms.txt` and `llms-full.txt` using this repository's generator.
- Remove only the leading UTF-8 BOM from the existing MemorySync page. It prevented the metadata linter from recognizing its frontmatter and caused a pre-existing navigation error; the page's content is otherwise unchanged.

## Validation

- Integration: **110 automated tests pass**, including cancellation/reconnect races, text flushing across settings and shutdown, retries, PCM conversion, and Pipecat pipeline behavior. [CI passes on Python 3.11, 3.12, and 3.13](https://github.com/MayaResearch/pipecat-maya/actions/runs/34110781697); Ruff and wheel/source builds pass.
- Production: WebSocket and HTTP examples run against Maya; complete playback at 8 and 16 kHz, token chunking, settings changes, and interruption are verified through Pipecat's output transport. Six completed playback clips were independently transcribed. The interrupted context produced no stale transport writes after the interruption.
- Catalog: 41 request cases cover both models, all 21 advertised voices, and all 11 advertised languages with valid nonempty audio. This establishes API acceptance, not exhaustive pronunciation or language quality.
- Docs: metadata lint has zero errors; Pipecat import validation, formatting, and Mintlify broken-link/anchor/redirect checks pass. Existing metadata warnings remain.

## Known provider limitation

Some Calyx/Amit HTTP responses omitted the second sentence. A same-request byte comparison proved the missing speech was already absent from the provider response and that the adapter emitted every returned byte. The service page and package explicitly disclose this provider P1, with its request ID and transcript in the validation report. The tested Native default is preserved; there is no silent model substitution or claim of universal voice quality.
