### PR TITLE
Add acefone serializer

### DIFF
--- a/api-reference/server/services/serializers/acefone.mdx
+++ b/api-reference/server/services/serializers/acefone.mdx
@@ -15,7 +15,8 @@ import { CommunityMaintained } from "/snippets/community-maintained.mdx";
 ## Overview
 
 `AcefoneFrameSerializer` converts between Pipecat frames and the
-[Acefone](https://acefone.in/) bi-directional audio streaming protocol, enabling
+[Acefone](https://acefone.com?utm_source=pipecat-docs&utm_medium=referral&utm_campaign=acefone-frame-serializer)
+bi-directional audio streaming protocol, enabling
 real-time voice agents over a websocket. It is designed to be wired into a
 `FastAPIWebsocketTransport` so you can host a Pipecat agent on the Acefone
 telephony stack and reach it over an Indian phone number.
@@ -39,13 +40,17 @@ termination over the same websocket.
   >
     The `pipecat-acefone` package on PyPI
   </Card>
-  <Card title="Acefone" icon="phone" href="https://acefone.in/">
+  <Card
+    title="Acefone"
+    icon="phone"
+    href="https://acefone.com?utm_source=pipecat-docs&utm_medium=referral&utm_campaign=acefone-frame-serializer"
+  >
     Learn about Acefone telephony and get a phone number
   </Card>
   <Card
     title="Protocol Docs"
     icon="book"
-    href="https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document"
+    href="https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document?utm_source=pipecat-docs&utm_medium=referral&utm_campaign=acefone-frame-serializer"
   >
     Acefone bi-directional audio streaming message formats
   </Card>
@@ -71,7 +76,7 @@ To host an agent on the Acefone telephony stack you need:
 The serializer itself does not require any API keys — automatic hang-up is
 performed over the same websocket via an `end` event. The message formats are
 documented in the
-[Acefone bi-directional audio streaming](https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document)
+[Acefone bi-directional audio streaming](https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document?utm_source=pipecat-docs&utm_medium=referral&utm_campaign=acefone-frame-serializer)
 docs.
 
 ## Configuration

--- a/api-reference/server/services/serializers/acefone.mdx
+++ b/api-reference/server/services/serializers/acefone.mdx
@@ -15,10 +15,9 @@ import { CommunityMaintained } from "/snippets/community-maintained.mdx";
 ## Overview
 
 `AcefoneFrameSerializer` converts between Pipecat frames and the
-[Acefone](https://acefone.in/) / [Smartflo](https://smartflo.tatatelebusiness.com/)
-(Tata Tele Business) bi-directional audio streaming protocol, enabling real-time
-voice agents over a websocket. It is designed to be wired into a
-`FastAPIWebsocketTransport` so you can host a Pipecat agent on the Acefone/Smartflo
+[Acefone](https://acefone.in/) bi-directional audio streaming protocol, enabling
+real-time voice agents over a websocket. It is designed to be wired into a
+`FastAPIWebsocketTransport` so you can host a Pipecat agent on the Acefone
 telephony stack and reach it over an Indian phone number.
 
 It supports both `ULAW` (8kHz G.711 μ-law, the default) and `PCM` (16-bit linear
@@ -31,7 +30,7 @@ termination over the same websocket.
     icon="github"
     href="https://github.com/monster-anshu/pipecat-acefone"
   >
-    Source code, examples, and issues for the Acefone/Smartflo integration
+    Source code, examples, and issues for the Acefone integration
   </Card>
   <Card
     title="PyPI Package"
@@ -41,14 +40,14 @@ termination over the same websocket.
     The `pipecat-acefone` package on PyPI
   </Card>
   <Card title="Acefone" icon="phone" href="https://acefone.in/">
-    Learn about Acefone / Smartflo telephony and get a phone number
+    Learn about Acefone telephony and get a phone number
   </Card>
   <Card
     title="Protocol Docs"
     icon="book"
     href="https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document"
   >
-    Acefone/Smartflo bi-directional audio streaming message formats
+    Acefone bi-directional audio streaming message formats
   </Card>
 </CardGroup>
 
@@ -62,19 +61,17 @@ uv add pipecat-acefone
 
 ## Prerequisites
 
-To host an agent on the Acefone/Smartflo telephony stack you need:
+To host an agent on the Acefone telephony stack you need:
 
-1. **An Acefone or Smartflo phone number**: with bi-directional audio streaming
-   enabled and pointed at your bot's websocket endpoint.
-2. **A public websocket endpoint**: expose your bot's websocket so Acefone/Smartflo
-   can connect to it (for example, by tunneling with `ngrok` during development).
+1. **An Acefone phone number**: with bi-directional audio streaming enabled and
+   pointed at your bot's websocket endpoint.
+2. **A public websocket endpoint**: expose your bot's websocket so Acefone can
+   connect to it (for example, by tunneling with `ngrok` during development).
 
 The serializer itself does not require any API keys — automatic hang-up is
-performed over the same websocket via an `end` event. The provider's message
-formats are documented in the
-[Acefone](https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document)
-and
-[Smartflo](https://docs.smartflo.tatatelebusiness.com/docs/bi-directional-audio-streaming-integration-document)
+performed over the same websocket via an `end` event. The message formats are
+documented in the
+[Acefone bi-directional audio streaming](https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document)
 docs.
 
 ## Configuration
@@ -98,7 +95,7 @@ Passed via the `params` constructor argument using
 | Parameter             | Type                 | Default | Description                                                                                                                    |
 | --------------------- | -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `media_format`        | `AcefoneMediaFormat` | `ULAW`  | Wire audio format. `ULAW` = 8kHz G.711 μ-law; `PCM` = 16-bit linear PCM (`slin16`).                                            |
-| `acefone_sample_rate` | `int`                | `8000`  | Sample rate of the Acefone/Smartflo media stream (Hz).                                                                         |
+| `acefone_sample_rate` | `int`                | `8000`  | Sample rate of the Acefone media stream (Hz).                                                                                  |
 | `sample_rate`         | `int`                | `0`     | Pipeline input sample rate override. When `0`, the rate comes from the pipeline configuration during setup.                    |
 | `stream_sid`          | `str`                | `None`  | The Media Stream SID for the call. Typically parsed from the initial `start` message; captured automatically from it if unset. |
 | `call_sid`            | `str`                | `None`  | The associated Call SID. Required when `auto_hang_up` is enabled.                                                              |
@@ -113,7 +110,7 @@ Passed via the `params` constructor argument using
 
 Wire the serializer into a `FastAPIWebsocketTransport`. The `stream_sid` (and
 `call_sid`, if you enable auto hang-up) is read from the initial websocket `start`
-message Acefone/Smartflo sends when a call connects.
+message Acefone sends when a call connects.
 
 ```python
 from pipecat_acefone import AcefoneFrameSerializer, AcefoneMediaFormat

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -36143,10 +36143,9 @@ AcefoneFrameSerializer converts between Pipecat frames and Acefone's telephony W
 ## Overview
 
 `AcefoneFrameSerializer` converts between Pipecat frames and the
-[Acefone](https://acefone.in/) / [Smartflo](https://smartflo.tatatelebusiness.com/)
-(Tata Tele Business) bi-directional audio streaming protocol, enabling real-time
-voice agents over a websocket. It is designed to be wired into a
-`FastAPIWebsocketTransport` so you can host a Pipecat agent on the Acefone/Smartflo
+[Acefone](https://acefone.in/) bi-directional audio streaming protocol, enabling
+real-time voice agents over a websocket. It is designed to be wired into a
+`FastAPIWebsocketTransport` so you can host a Pipecat agent on the Acefone
 telephony stack and reach it over an Indian phone number.
 
 It supports both `ULAW` (8kHz G.711 μ-law, the default) and `PCM` (16-bit linear
@@ -36159,7 +36158,7 @@ termination over the same websocket.
     icon="github"
     href="https://github.com/monster-anshu/pipecat-acefone"
   >
-    Source code, examples, and issues for the Acefone/Smartflo integration
+    Source code, examples, and issues for the Acefone integration
   </Card>
   <Card
     title="PyPI Package"
@@ -36169,14 +36168,14 @@ termination over the same websocket.
     The `pipecat-acefone` package on PyPI
   </Card>
   <Card title="Acefone" icon="phone" href="https://acefone.in/">
-    Learn about Acefone / Smartflo telephony and get a phone number
+    Learn about Acefone telephony and get a phone number
   </Card>
   <Card
     title="Protocol Docs"
     icon="book"
     href="https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document"
   >
-    Acefone/Smartflo bi-directional audio streaming message formats
+    Acefone bi-directional audio streaming message formats
   </Card>
 </CardGroup>
 
@@ -36190,19 +36189,17 @@ uv add pipecat-acefone
 
 ## Prerequisites
 
-To host an agent on the Acefone/Smartflo telephony stack you need:
+To host an agent on the Acefone telephony stack you need:
 
-1. **An Acefone or Smartflo phone number**: with bi-directional audio streaming
-   enabled and pointed at your bot's websocket endpoint.
-2. **A public websocket endpoint**: expose your bot's websocket so Acefone/Smartflo
-   can connect to it (for example, by tunneling with `ngrok` during development).
+1. **An Acefone phone number**: with bi-directional audio streaming enabled and
+   pointed at your bot's websocket endpoint.
+2. **A public websocket endpoint**: expose your bot's websocket so Acefone can
+   connect to it (for example, by tunneling with `ngrok` during development).
 
 The serializer itself does not require any API keys — automatic hang-up is
-performed over the same websocket via an `end` event. The provider's message
-formats are documented in the
-[Acefone](https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document)
-and
-[Smartflo](https://docs.smartflo.tatatelebusiness.com/docs/bi-directional-audio-streaming-integration-document)
+performed over the same websocket via an `end` event. The message formats are
+documented in the
+[Acefone bi-directional audio streaming](https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document)
 docs.
 
 ## Configuration
@@ -36226,7 +36223,7 @@ Passed via the `params` constructor argument using
 | Parameter             | Type                 | Default | Description                                                                                                                    |
 | --------------------- | -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `media_format`        | `AcefoneMediaFormat` | `ULAW`  | Wire audio format. `ULAW` = 8kHz G.711 μ-law; `PCM` = 16-bit linear PCM (`slin16`).                                            |
-| `acefone_sample_rate` | `int`                | `8000`  | Sample rate of the Acefone/Smartflo media stream (Hz).                                                                         |
+| `acefone_sample_rate` | `int`                | `8000`  | Sample rate of the Acefone media stream (Hz).                                                                                  |
 | `sample_rate`         | `int`                | `0`     | Pipeline input sample rate override. When `0`, the rate comes from the pipeline configuration during setup.                    |
 | `stream_sid`          | `str`                | `None`  | The Media Stream SID for the call. Typically parsed from the initial `start` message; captured automatically from it if unset. |
 | `call_sid`            | `str`                | `None`  | The associated Call SID. Required when `auto_hang_up` is enabled.                                                              |
@@ -36241,7 +36238,7 @@ Passed via the `params` constructor argument using
 
 Wire the serializer into a `FastAPIWebsocketTransport`. The `stream_sid` (and
 `call_sid`, if you enable auto hang-up) is read from the initial websocket `start`
-message Acefone/Smartflo sends when a call connects.
+message Acefone sends when a call connects.
 
 ```python
 from pipecat_acefone import AcefoneFrameSerializer, AcefoneMediaFormat

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -36143,7 +36143,8 @@ AcefoneFrameSerializer converts between Pipecat frames and Acefone's telephony W
 ## Overview
 
 `AcefoneFrameSerializer` converts between Pipecat frames and the
-[Acefone](https://acefone.in/) bi-directional audio streaming protocol, enabling
+[Acefone](https://acefone.com?utm_source=pipecat-docs&utm_medium=referral&utm_campaign=acefone-frame-serializer)
+bi-directional audio streaming protocol, enabling
 real-time voice agents over a websocket. It is designed to be wired into a
 `FastAPIWebsocketTransport` so you can host a Pipecat agent on the Acefone
 telephony stack and reach it over an Indian phone number.
@@ -36167,13 +36168,17 @@ termination over the same websocket.
   >
     The `pipecat-acefone` package on PyPI
   </Card>
-  <Card title="Acefone" icon="phone" href="https://acefone.in/">
+  <Card
+    title="Acefone"
+    icon="phone"
+    href="https://acefone.com?utm_source=pipecat-docs&utm_medium=referral&utm_campaign=acefone-frame-serializer"
+  >
     Learn about Acefone telephony and get a phone number
   </Card>
   <Card
     title="Protocol Docs"
     icon="book"
-    href="https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document"
+    href="https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document?utm_source=pipecat-docs&utm_medium=referral&utm_campaign=acefone-frame-serializer"
   >
     Acefone bi-directional audio streaming message formats
   </Card>
@@ -36199,7 +36204,7 @@ To host an agent on the Acefone telephony stack you need:
 The serializer itself does not require any API keys — automatic hang-up is
 performed over the same websocket via an `end` event. The message formats are
 documented in the
-[Acefone bi-directional audio streaming](https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document)
+[Acefone bi-directional audio streaming](https://docs.acefone.in/docs/bi-directional-audio-streaming-integration-document?utm_source=pipecat-docs&utm_medium=referral&utm_campaign=acefone-frame-serializer)
 docs.
 
 ## Configuration


### PR DESCRIPTION
The serializer page documented both Acefone and Smartflo (Tata Tele Business). The integration targets Acefone, so drop the Smartflo references and protocol doc link. Regenerate llms-full.txt.